### PR TITLE
Verify tag matches pyproject version before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,22 @@ jobs:
         with:
           enable-cache: false
 
+      - name: Check tag matches pyproject version
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${REF_NAME#v}"
+          PROJECT_VERSION=$(python -c '
+            import tomllib
+            with open("pyproject.toml", "rb") as f:
+                print(tomllib.load(f)["project"]["version"])
+            ')
+          if [ "$TAG_VERSION" != "$PROJECT_VERSION" ]; then
+            echo "Tag $REF_NAME (version $TAG_VERSION) does not match pyproject version $PROJECT_VERSION" >&2
+            exit 1
+          fi
+
       - name: Build sdist and wheel
         run: uv build
 


### PR DESCRIPTION
Avoids accidentally pushing a tag whose number disagrees with the package metadata. Reads project.version with stdlib tomllib (the build job is pinned to Python 3.14 so this is always available).