### PR TITLE
docs: drop internal jargon from user-facing docs

### DIFF
--- a/docs/comments.md
+++ b/docs/comments.md
@@ -37,7 +37,7 @@ server.leading_comments["port"] = (
 
 ## Section header comments
 
-`Table.header_comment` is the EOL comment on the `[section]` line itself; `Table.header_leading_comments` is the run of `# …` lines immediately above it:
+`Table.header_comment` is the end-of-line comment on the `[section]` line itself; `Table.header_leading_comments` is the run of `# …` lines immediately above it:
 
 ```python
 server.header_comment = "HTTP listener"

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -16,7 +16,7 @@ doc["tags"] = Array(["a", "b"], multiline=True)  # multi-line array
 
 ## Live vs snapshot
 
-Assigning a fresh `Table.section(...)`, `Table.inline(...)`, `Array(...)`, or `AoT(...)` _attaches it live_: the user's reference becomes the live view at the destination, and later mutations through that reference show up in the document.
+Assigning a fresh `Table.section(...)`, `Table.inline(...)`, `Array(...)`, or `AoT(...)` _attaches it live_: your reference becomes the live view at the destination, and later mutations through that reference show up in the document.
 
 ```python
 xs = Array([1, 2])
@@ -33,8 +33,8 @@ assert doc["a"] is t
 Plain `dict` / `list` values are _snapshot_ on assignment — mutating the original after assignment does _not_ affect the document.
 Reach for `Table.section`, `Table.inline`, or `Array` when you want live semantics.
 
-A container that is already attached somewhere is deep-cloned on assignment, so two slots never share the same underlying CST.
-This applies to intra-document (`doc["b"] = doc["a"]`) and cross-document (`d2["x"] = d1["x"]`) cases alike.
+A container that is already attached somewhere is deep-cloned on assignment, so two slots never share state.
+This applies whether the source and destination are in the same document (`doc["b"] = doc["a"]`) or different ones (`d2["x"] = d1["x"]`).
 
 ## Growing an array-of-tables
 


### PR DESCRIPTION
Replace terms that leak implementation details or assume too much:

- "underlying CST" → "state" (CST is internal-only and never defined in the docs)
- "EOL comment" → "end-of-line comment" (the abbreviation was introduced cold)
- "the user's reference" → "your reference" (addresses the reader directly)
- "intra-document / cross-document … alike" → a plainer "whether the source and destination are in the same document or different ones"