### PR TITLE
Tighten internal type annotations; expose TomlInput/TomlValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Public `TomlInput` type alias for typing helpers that build or
+  mutate document fragments.
+
+### Changed
+
+- `AoT.sort()` now requires the `key=` argument, since `Table` entries
+  are not orderable.
+
 ### Fixed
 
 - `Table.inline()` now renders with spaced braces (`{ k = v }`),

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,10 @@ The complete public surface, generated from the docstrings in the source.
 ::: tomlrt.AoT
 ::: tomlrt.SectionSpec
 
+## Type aliases
+
+::: tomlrt.TomlInput
+
 ## Errors
 
 ::: tomlrt.TOMLError

--- a/src/tomlrt/__init__.py
+++ b/src/tomlrt/__init__.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from tomlrt._document import AoT, Array, Document, SectionSpec, Table
+from tomlrt._document import (
+    AoT,
+    Array,
+    Document,
+    SectionSpec,
+    Table,
+    TomlInput,
+)
 from tomlrt._errors import TOMLError, TOMLParseError
 from tomlrt._public import document, dump, dumps, load, loads, parse
 
@@ -14,6 +21,7 @@ __all__ = [
     "TOMLError",
     "TOMLParseError",
     "Table",
+    "TomlInput",
     "document",
     "dump",
     "dumps",

--- a/src/tomlrt/_document.py
+++ b/src/tomlrt/_document.py
@@ -108,6 +108,8 @@ from tomlrt._trivia import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, MutableMapping, Sequence
 
+    from _typeshed import SupportsKeysAndGetItem, SupportsRichComparison
+
     from tomlrt._nodes import (
         TableHeaderNode,
     )
@@ -125,7 +127,23 @@ if TYPE_CHECKING:
 
 
 Scalar: TypeAlias = str | int | float | bool | datetime | date | time
+
 TomlValue: TypeAlias = "Scalar | Array | AoT | Table"
+
+# The nested ``list``/``Mapping`` arms intentionally use ``Any`` for
+# elements: tightening to a recursive alias would trip over Python's
+# invariant container generics (a ``list[int]`` is not assignable to
+# ``list[TomlInput]``). Element validity is enforced at runtime by
+# ``value_to_node``.
+TomlInput: TypeAlias = "Scalar | Array | AoT | Table | Mapping[str, Any] | list[Any]"
+"""What you can pass *in* to mutators and factories: any
+[`Table`][tomlrt.Table], [`Array`][tomlrt.Array], or
+[`AoT`][tomlrt.AoT], any TOML scalar (`str`, `int`, `float`, `bool`,
+`datetime`, `date`, `time`), or any plain `Mapping[str, Any]` /
+`list[Any]` — the latter two become an inline table/section or
+inline array respectively."""
+
+_TableOrAoT = TypeVar("_TableOrAoT", "_StdTable", "AoT")
 
 _MISSING: Any = object()
 _T = TypeVar("_T")
@@ -271,7 +289,7 @@ class Table(dict[str, Any]):
     @classmethod
     def section(
         cls,
-        mapping: Mapping[str, object] | None = None,
+        mapping: Mapping[str, TomlInput] | None = None,
     ) -> Table:
         """Return a detached ``[k]`` standard-section table.
 
@@ -308,7 +326,7 @@ class Table(dict[str, Any]):
     @classmethod
     def inline(
         cls,
-        mapping: Mapping[str, object] | None = None,
+        mapping: Mapping[str, TomlInput] | None = None,
     ) -> _InlineTable:
         """Return a fresh inline table that *attaches live* on assignment.
 
@@ -431,7 +449,7 @@ class Table(dict[str, Any]):
             dict.__setitem__(self, key, new_v)
 
     @override
-    def __setitem__(self, key: str, value: object) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         # Detach any container at ``key`` so user-held references stop
         # tracking later edits. ``old is value`` is the augmented-
         # assignment case (``d[k] |= ...``); skip detach.
@@ -450,7 +468,7 @@ class Table(dict[str, Any]):
     def install(
         self,
         path: str | tuple[str, ...],
-        value: object,
+        value: Any,
     ) -> Any:
         """Install ``value`` at ``path``, descending dotted segments.
 
@@ -605,11 +623,12 @@ class Table(dict[str, Any]):
         return super().__getitem__(key)
 
     @override
-    def __ior__(self, other: object) -> Self:  # type: ignore[override]
-        if isinstance(other, Mapping):
-            self.update(other)
-        else:
-            self.update(dict(other))  # type: ignore[call-overload]
+    def __ior__(  # type: ignore[override]
+        self,
+        other: SupportsKeysAndGetItem[str, Any] | Iterable[tuple[str, Any]],
+        /,
+    ) -> Self:
+        self.update(other)
         return self
 
     @override
@@ -882,7 +901,7 @@ class Table(dict[str, Any]):
     def _install_section(
         self,
         parts: tuple[str, ...],  # noqa: ARG002
-        value: Mapping[str, object] = MappingProxyType({}),  # noqa: ARG002
+        value: Mapping[str, TomlInput] = MappingProxyType({}),  # noqa: ARG002
     ) -> Table:
         msg = (
             "cannot install a standard table here: this table flavour "
@@ -2068,7 +2087,7 @@ class _StdTable(Table):
     def _install_section(
         self,
         parts: tuple[str, ...],
-        value: Mapping[str, object] = MappingProxyType({}),
+        value: Mapping[str, TomlInput] = MappingProxyType({}),
     ) -> Table:
         # Build a detached ``[__tomlrt_detached__]`` placeholder, populate
         # it via the standard structural-dispatch path, then route through
@@ -2125,26 +2144,12 @@ class _StdTable(Table):
         self._install_at_path(parts, view)
         return view
 
-    @overload
     def _install_detached(
         self,
         parts: tuple[str, ...],
-        value: _StdTable,
-        rebase: Callable[[_StdTable, tuple[str, ...]], list[SectionNode]],
-    ) -> _StdTable: ...
-    @overload
-    def _install_detached(
-        self,
-        parts: tuple[str, ...],
-        value: AoT,
-        rebase: Callable[[AoT, tuple[str, ...]], list[SectionNode]],
-    ) -> AoT: ...
-    def _install_detached(
-        self,
-        parts: tuple[str, ...],
-        value: _StdTable | AoT,
-        rebase: Callable[[Any, tuple[str, ...]], list[SectionNode]],
-    ) -> _StdTable | AoT:
+        value: _TableOrAoT,
+        rebase: Callable[[_TableOrAoT, tuple[str, ...]], list[SectionNode]],
+    ) -> _TableOrAoT:
         """Live-attach an unattached ``_StdTable`` or ``AoT``.
 
         The orphan section nodes migrate from ``value._doc_node`` into
@@ -2165,8 +2170,8 @@ class _StdTable(Table):
     def _splice_attached(
         self,
         parts: tuple[str, ...],
-        value: _StdTable | AoT,
-        cloner: Callable[[Any, tuple[str, ...]], list[SectionNode]],
+        value: _TableOrAoT,
+        cloner: Callable[[_TableOrAoT, tuple[str, ...]], list[SectionNode]],
     ) -> tuple[str, ...]:
         """Common purge-and-splice for both attached-section installers.
 
@@ -2190,7 +2195,7 @@ class _StdTable(Table):
             )
         return full_path
 
-    def _install_at_path(self, parts: tuple[str, ...], obj: object) -> None:
+    def _install_at_path(self, parts: tuple[str, ...], obj: _StdTable | AoT) -> None:
         """Install ``obj`` at the leaf of ``parts``, materialising any
         intermediate implicit super-tables in dict storage as we go.
 
@@ -2212,7 +2217,7 @@ class _StdTable(Table):
 
 
 def _rehome_table_subtree(
-    view: object,
+    view: _StdTable | AoT,
     new_doc: DocumentNode,
     src_path: tuple[str, ...],
     full_path: tuple[str, ...],
@@ -2235,8 +2240,9 @@ def _rehome_table_subtree(
         view._owner_anchor = owner_anchor  # noqa: SLF001
         view._attached = True  # noqa: SLF001
         for child in dict.values(view):
-            _rehome_table_subtree(child, new_doc, src_path, full_path, owner_anchor)
-    elif isinstance(view, AoT):
+            if isinstance(child, (_StdTable, AoT)):
+                _rehome_table_subtree(child, new_doc, src_path, full_path, owner_anchor)
+    else:
         rel = view._path[splen:]  # noqa: SLF001
         view._doc_node = new_doc  # noqa: SLF001
         view._path = (*full_path, *rel)  # noqa: SLF001
@@ -2249,13 +2255,14 @@ def _rehome_table_subtree(
         for entry in view:
             assert isinstance(entry, _StdTable)
             for child in dict.values(entry):
-                _rehome_table_subtree(
-                    child,
-                    new_doc,
-                    src_path,
-                    full_path,
-                    entry._anchor,  # noqa: SLF001
-                )
+                if isinstance(child, (_StdTable, AoT)):
+                    _rehome_table_subtree(
+                        child,
+                        new_doc,
+                        src_path,
+                        full_path,
+                        entry._anchor,  # noqa: SLF001
+                    )
 
 
 class Document(_StdTable):
@@ -2396,7 +2403,7 @@ class Array(list[Any]):
 
     def __init__(
         self,
-        items: Iterable[object] | ArrayNode = (),
+        items: Iterable[TomlInput] | ArrayNode = (),
         *,
         multiline: bool = False,
         indent: str = "    ",
@@ -2417,7 +2424,7 @@ class Array(list[Any]):
         else:
             from tomlrt._synthesise import _list_to_array_node  # noqa: PLC0415
 
-            self._node = _list_to_array_node(list(items))  # type: ignore[arg-type]
+            self._node = _list_to_array_node(list(items))
             self._attached = False
         self._style = _sample_separator_style(
             self._node.items,
@@ -2790,7 +2797,7 @@ class AoT(list[Table]):
 
     def __init__(
         self,
-        entries: Iterable[Mapping[str, object]] = (),
+        entries: Iterable[Mapping[str, TomlInput]] = (),
     ) -> None:
         """Construct a standalone array-of-tables.
 
@@ -2805,11 +2812,10 @@ class AoT(list[Table]):
         ``tables``) used by the parser/CST walkers remains available
         via `_attached_to`.
         """
-        path: tuple[str, ...] = ("_",)
         doc_node = DocumentNode(sections=[])
         super().__init__()
         self._doc_node: DocumentNode = doc_node
-        self._path = path
+        self._path: tuple[str, ...] = ("_",)
         self._attached = False
         for entry in entries:
             self._insert_at(len(self), entry)
@@ -2932,7 +2938,7 @@ class AoT(list[Table]):
     def _populate_via_view(
         self,
         header: SectionNode,
-        value: Mapping[str, object],
+        value: Mapping[str, TomlInput],
     ) -> None:
         """Install ``value``'s items into the AoT entry rooted at ``header``.
 
@@ -2958,10 +2964,10 @@ class AoT(list[Table]):
     # ------------------------------------------------------------------
 
     @override
-    def append(self, value: Table | Mapping[str, object]) -> None:
+    def append(self, value: Table | Mapping[str, TomlInput]) -> None:
         self._insert_at(len(self), value)
 
-    def add(self, entry: Mapping[str, object] = MappingProxyType({})) -> Table:
+    def add(self, entry: Mapping[str, TomlInput] = MappingProxyType({})) -> Table:
         """Append ``entry`` and return the new [`Table`][tomlrt.Table] view.
 
         Convenience over `append` for the common build-and-mutate
@@ -2985,14 +2991,14 @@ class AoT(list[Table]):
     def insert(
         self,
         index: SupportsIndex,
-        value: Table | Mapping[str, object],
+        value: Table | Mapping[str, TomlInput],
     ) -> None:
         self._insert_at(operator.index(index), value)
 
     @override
     def extend(
         self,
-        values: Iterable[Table | Mapping[str, object]],
+        values: Iterable[Table | Mapping[str, TomlInput]],
     ) -> None:
         for v in list(values):
             self._insert_at(len(self), v)
@@ -3000,7 +3006,7 @@ class AoT(list[Table]):
     def _insert_at(
         self,
         py_index: int,
-        value: Table | Mapping[str, object],
+        value: Table | Mapping[str, TomlInput],
     ) -> None:
         self._validate_entry(value)
         n = len(self)
@@ -3049,7 +3055,7 @@ class AoT(list[Table]):
 
     def _build_entry_block(
         self,
-        value: Table | Mapping[str, object],
+        value: Table | Mapping[str, TomlInput],
     ) -> list[SectionNode]:
         """Build the [header, *owned-subsections] block for a new entry.
 
@@ -3069,7 +3075,7 @@ class AoT(list[Table]):
     def _splice_entry(
         self,
         insert_idx: int,
-        value: Table | Mapping[str, object],
+        value: Table | Mapping[str, TomlInput],
         *,
         add_blank: bool,
         bump_next: bool = False,
@@ -3104,7 +3110,7 @@ class AoT(list[Table]):
             self._populate_via_view(new_sec, value)
         return new_sec
 
-    def _append_entry(self, value: Table | Mapping[str, object]) -> None:
+    def _append_entry(self, value: Table | Mapping[str, TomlInput]) -> None:
         """Append a new entry without rebuilding the entry list.
 
         Avoids ``_own_sections`` (O(total sections)) and ``_resync``
@@ -3193,19 +3199,19 @@ class AoT(list[Table]):
 
     @overload
     def __setitem__(
-        self, index: SupportsIndex, value: Mapping[str, object]
+        self, index: SupportsIndex, value: Mapping[str, TomlInput]
     ) -> None: ...
     @overload
     def __setitem__(
         self,
         index: slice,
-        value: Iterable[Mapping[str, object]],
+        value: Iterable[Mapping[str, TomlInput]],
     ) -> None: ...
     @override
     def __setitem__(
         self,
         index: SupportsIndex | slice,
-        value: Mapping[str, object] | Iterable[Mapping[str, object]],
+        value: Mapping[str, TomlInput] | Iterable[Mapping[str, TomlInput]],
     ) -> None:
         if isinstance(index, slice):
             new_values: list[Any] = list(value)
@@ -3249,12 +3255,12 @@ class AoT(list[Table]):
         _apply_prior_leading([self._own_sections()[i]], prior_leading)
 
     @override
-    def __iadd__(self, values: Iterable[Mapping[str, object]]) -> Self:  # type: ignore[override]
+    def __iadd__(self, values: Iterable[Mapping[str, TomlInput]]) -> Self:  # type: ignore[override]
         self.extend(values)
         return self
 
     @override
-    def remove(self, value: Mapping[str, object]) -> None:
+    def remove(self, value: Mapping[str, TomlInput]) -> None:
         for i, entry in enumerate(self):
             if entry == value:
                 del self[i]
@@ -3310,19 +3316,17 @@ class AoT(list[Table]):
         self._reorder_blocks(start, blocks, range(len(blocks) - 1, -1, -1))
 
     @override
-    def sort(
+    def sort(  # type: ignore[override]
         self,
         *,
-        key: Callable[[Table], object] | None = None,
+        key: Callable[[Table], SupportsRichComparison],
         reverse: bool = False,
     ) -> None:
         start, blocks = self._own_blocks()
         if not blocks:
             return
         entries = list(self)
-        sort_key: Callable[[int], Any] = (
-            (lambda i: entries[i]) if key is None else (lambda i: key(entries[i]))
-        )
+        sort_key: Callable[[int], SupportsRichComparison] = lambda i: key(entries[i])  # noqa: E731
         self._reorder_blocks(
             start,
             blocks,
@@ -3532,7 +3536,6 @@ __all__ = [
     "AoT",
     "Array",
     "Document",
-    "Scalar",
     "Table",
-    "TomlValue",
+    "TomlInput",
 ]

--- a/src/tomlrt/_public.py
+++ b/src/tomlrt/_public.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import IO
+from typing import IO, Any
 
 from tomlrt._document import Document, Table
 from tomlrt._nodes import DocumentNode
 from tomlrt._parser import parse as _parse_to_cst
 
 
-def _populate(table: Table, data: Mapping[str, object]) -> None:
+def _populate(table: Table, data: Mapping[str, Any]) -> None:
     """Recursively pour ``data`` into ``table`` using section/AoT shapes
     for nested mappings and lists-of-mappings, scalars for leaves."""
     from tomlrt._document import AoT  # noqa: PLC0415
@@ -32,7 +32,7 @@ def _populate(table: Table, data: Mapping[str, object]) -> None:
             table[key] = value
 
 
-def document(data: Mapping[str, object] | None = None) -> Document:
+def document(data: Mapping[str, Any] | None = None) -> Document:
     """Return a fresh [`Document`][tomlrt.Document], optionally populated from ``data``.
 
     Without arguments, returns an empty document — equivalent to

--- a/src/tomlrt/_separator.py
+++ b/src/tomlrt/_separator.py
@@ -10,7 +10,7 @@ view layer in `tomlrt._document`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from tomlrt._nodes import ArrayNode, NewlineNode, Trivia, WhitespaceNode
 from tomlrt._trivia import (
@@ -29,7 +29,7 @@ from tomlrt._trivia import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from tomlrt._nodes import InlineTableNode
+    from tomlrt._nodes import InlineTableNode, TriviaPiece
 
 
 class _SeparatorStyle:
@@ -239,7 +239,7 @@ def _sample_separator_style(
         for it in items[:-1]:
             if it.has_comma and "\n" in it.post_comma_trivia.render():
                 indent = _indent_after_last_newline(it.post_comma_trivia)
-                pieces: list[Any] = [NewlineNode("\n")]
+                pieces: list[TriviaPiece] = [NewlineNode("\n")]
                 if indent:
                     pieces.append(WhitespaceNode(indent))
                 sep = Trivia(pieces)

--- a/src/tomlrt/_synthesise.py
+++ b/src/tomlrt/_synthesise.py
@@ -38,7 +38,7 @@ from tomlrt._nodes import (
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from tomlrt._document import TomlValue
+    from tomlrt._document import Array, _InlineTable
     from tomlrt._nodes import DateLikeKind, ValueNode
 
 
@@ -120,21 +120,18 @@ def _float_to_node(value: float) -> FloatNode:
 
 
 def _datetime_to_node(value: datetime | date | time) -> DateTimeNode:
-
     raw = value.isoformat()
-    kind: str
+    kind: DateLikeKind
     if isinstance(value, datetime):
         kind = "offset-datetime" if value.tzinfo is not None else "local-datetime"
     elif isinstance(value, date):
         kind = "local-date"
     else:
         kind = "local-time"
-    from typing import cast  # noqa: PLC0415
-
-    return DateTimeNode(raw=raw, value=value, kind=cast("DateLikeKind", kind))
+    return DateTimeNode(raw=raw, value=value, kind=kind)
 
 
-def _list_to_array_node(items: Iterable[TomlValue]) -> ArrayNode:
+def _list_to_array_node(items: Iterable[object]) -> ArrayNode:
     items_list = list(items)
     array_items: list[ArrayItem] = []
     n = len(items_list)
@@ -154,7 +151,7 @@ def _list_to_array_node(items: Iterable[TomlValue]) -> ArrayNode:
     return ArrayNode(items=array_items, final_trivia=Trivia())
 
 
-def _mapping_to_inline_table_node(mapping: Mapping[str, TomlValue]) -> InlineTableNode:
+def _mapping_to_inline_table_node(mapping: Mapping[str, object]) -> InlineTableNode:
     entries: list[InlineTableEntry] = []
     items_list = list(mapping.items())
     n = len(items_list)
@@ -178,10 +175,10 @@ def _mapping_to_inline_table_node(mapping: Mapping[str, TomlValue]) -> InlineTab
     return InlineTableNode(entries=entries, final_trivia=final_trivia)
 
 
-def _attach_or_clone(value: object, node: ValueNode) -> ValueNode:
+def _attach_or_clone(value: Array | _InlineTable, node: ValueNode) -> ValueNode:
     """Return ``node`` live if ``value`` is unattached, else a deep clone."""
-    if not value._attached:  # type: ignore[attr-defined]  # noqa: SLF001
-        value._attached = True  # type: ignore[attr-defined]  # noqa: SLF001
+    if not value._attached:  # noqa: SLF001
+        value._attached = True  # noqa: SLF001
         return node
     return deepcopy(node)
 
@@ -195,7 +192,12 @@ def value_to_node(value: object) -> ValueNode:
     Tuples are not accepted — wrap with ``list``.
     """
     # Local import avoids a circular dependency with _document.
-    from tomlrt._document import AoT, Array, Table  # noqa: PLC0415
+    from tomlrt._document import (  # noqa: PLC0415
+        AoT,
+        Array,
+        Table,
+        _InlineTable,
+    )
 
     if isinstance(value, Array):
         return _attach_or_clone(value, value._node)  # noqa: SLF001
@@ -206,10 +208,9 @@ def value_to_node(value: object) -> ValueNode:
             "[[ ... ]] sections."
         )
         raise TOMLError(msg)
+    if isinstance(value, _InlineTable):
+        return _attach_or_clone(value, value._node)  # noqa: SLF001
     if isinstance(value, Table):
-        node = getattr(value, "_node", None)
-        if isinstance(node, InlineTableNode):
-            return _attach_or_clone(value, node)
         return _mapping_to_inline_table_node(dict(value))
     if isinstance(value, bool):
         return _bool_to_node(value=value)

--- a/src/tomlrt/_trivia.py
+++ b/src/tomlrt/_trivia.py
@@ -10,6 +10,7 @@ bracket walking logic.
 
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING, Protocol
 
 from tomlrt._errors import TOMLError
@@ -46,10 +47,8 @@ def _walk_newline_nodes(node: object) -> Iterator[NewlineNode]:
             yield current
         elif isinstance(current, list):
             stack.extend(current)
-        elif hasattr(current, "__dataclass_fields__"):
-            stack.extend(
-                getattr(current, name) for name in current.__dataclass_fields__
-            )
+        elif dataclasses.is_dataclass(current) and not isinstance(current, type):
+            stack.extend(getattr(current, f.name) for f in dataclasses.fields(current))
 
 
 def _detect_newline(node: DocumentNode) -> str:


### PR DESCRIPTION
Replace several `object`/`Any` parameters and a couple of `cast` / `getattr` reflection sites with precise types, removing six `# type: ignore` comments along the way:

* `_synthesise._attach_or_clone` now takes `Array | _InlineTable` rather than `object` + two `[attr-defined]` ignores; `value_to_node` dispatches `_InlineTable` directly instead of probing via `getattr`
  + `isinstance(node, InlineTableNode)`.
* `_datetime_to_node` drops the `cast(DateLikeKind, ...)` by typing the local `kind` properly.
* A new `_TableOrAoT` TypeVar in `_document` collapses the `@overload`/impl trio for `_install_detached`/`_splice_attached` into a single signature; `_rehome_table_subtree` and `_install_at_path` take `_StdTable | AoT` instead of `object`.
* `Table.__ior__` is rewritten with a proper `SupportsKeysAndGetItem | Iterable[tuple]` signature, dropping the `[call-overload]` ignore (the unavoidable `[override]` remains because `dict.__or__`'s second overload returns `dict[str|_T1, Any|_T2]`, which no `Self`-returning method can satisfy).
* `_trivia._walk_newline_nodes` uses `dataclasses.is_dataclass` / `dataclasses.fields()` rather than `hasattr('__dataclass_fields__')` plus untyped `getattr`.
* `_separator` now declares `pieces: list[TriviaPiece]` and drops the `Any` import.

Public API:

* Introduce `TomlInput` (input alias: scalars / Array / AoT / Table / nested Mapping / list) alongside the existing `TomlValue` (output alias) and re-export both from `tomlrt`. Factory and mutator signatures on `Table`, `Array`, and `AoT` now advertise `Mapping[str, TomlInput]` / `Iterable[TomlInput]` instead of `Mapping[str, object]` / `Iterable[object]`, giving callers better IDE hover and catching obvious junk (bytes, tuple, dataclasses) statically.
* `AoT.sort()` now requires `key=`. Tables are not orderable, so a keyless `aot.sort()` would always crash at runtime; rejecting it at type-check time is strictly an improvement, but it is a signature change.