### PR TITLE
ci(docs): drop --site-dir from zensical build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build site
-        run: uv run zensical build --site-dir site
+        run: uv run zensical build
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
zensical build does not accept --site-dir; the flag was a leftover from the mkdocs era and broke the docs workflow with:

  Error: No such option: --site-dir

zensical writes to ./site by default, which is what the upload-pages-artifact step already expects.