### PR TITLE
Fix synthesised AoT entries to adopt sibling KV indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blank-line and compact styles.
 - Replacing an AoT entry no longer injects a stray blank between
   the new entry and its surviving sibling in compact documents.
+- Newly appended/inserted AoT entries now adopt the indent style of
+  their siblings' KV lines instead of rendering flush-left.
 
 ## [1.0.0] - 2026-04-26
 

--- a/src/tomlrt/_document.py
+++ b/src/tomlrt/_document.py
@@ -2937,7 +2937,14 @@ class AoT(list[Table]):
         paths -- a nested ``Table.section`` becomes ``[path.k]``,
         a nested ``AoT`` becomes ``[[path.k]]`` -- instead of
         being inlined by the synthesiser.
+
+        After installing, adopt any sibling AoT entry's KV indent on
+        the first synthesised entry: ``[[xs]]`` siblings whose KVs
+        are indented expect a freshly-appended ``[[xs]]`` to match.
+        Seeding only the first entry is enough -- subsequent KVs go
+        through ``_detect_indent`` and inherit naturally.
         """
+        indent = self._sample_kv_indent()
         view = _StdTable(
             self._doc_node,
             self._path,
@@ -2946,6 +2953,24 @@ class AoT(list[Table]):
         )
         for k, v in value.items():
             view[k] = v
+            if indent and header.entries:
+                header.entries[0].leading.pieces.insert(0, WhitespaceNode(indent))
+                indent = ""
+
+    def _sample_kv_indent(self) -> str:
+        """Sample the indent of an existing AoT entry's KV lines.
+
+        Returns the indent of the last KV under the first sibling
+        entry that has any KVs, or ``""`` if no siblings have direct
+        KV content. Used to keep newly-appended/inserted ``[[xs]]``
+        entries visually consistent with their siblings.
+        """
+        for i in range(len(self)):
+            anchor = self._entry_anchor(i)
+            indent = _detect_indent(anchor)
+            if indent:
+                return indent
+        return ""
 
     # ------------------------------------------------------------------
     # Mutators

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -1478,3 +1478,62 @@ def test_aot_replace_in_blank_styled_doc_keeps_blank() -> None:
         [[xs]]
         c=3
         """)
+
+
+def test_aot_append_adopts_sibling_kv_indent() -> None:
+    """A new AoT entry should match the sibling entries' KV indent.
+
+    Regression: when sibling ``[[xs]]`` entries had indented KVs,
+    appending ``{"c": 3}`` synthesised a flush-left ``c = 3`` rather
+    than mirroring the user's chosen indent.
+    """
+    src = td("""
+        [[xs]]
+            a = 1
+        [[xs]]
+            b = 2
+        """)
+    doc = tomlrt.parse(src)
+    doc["xs"].append({"c": 3})
+    assert tomlrt.dumps(doc) == td("""
+        [[xs]]
+            a = 1
+        [[xs]]
+            b = 2
+        [[xs]]
+            c = 3
+        """)
+
+
+def test_aot_insert_at_zero_adopts_sibling_kv_indent() -> None:
+    """Insert at index 0 also adopts the sibling KV indent."""
+    src = td("""
+        [[xs]]
+            a = 1
+        """)
+    doc = tomlrt.parse(src)
+    doc["xs"].insert(0, {"c": 3})
+    assert tomlrt.dumps(doc) == td("""
+        [[xs]]
+            c = 3
+
+        [[xs]]
+            a = 1
+        """)
+
+
+def test_aot_append_with_no_sibling_indent_stays_flush() -> None:
+    """Control: no sibling indent signal means no indent is invented."""
+    src = td("""
+        [[xs]]
+        a = 1
+        """)
+    doc = tomlrt.parse(src)
+    doc["xs"].append({"b": 2})
+    assert tomlrt.dumps(doc) == td("""
+        [[xs]]
+        a = 1
+
+        [[xs]]
+        b = 2
+        """)


### PR DESCRIPTION
When an AoT's existing [[xs]] entries had indented KV content
(e.g. ``    a = 1``), appending or inserting a new entry from a
plain Mapping rendered the synthesised KVs flush-left, mixing
styles within the same series.

The synthesis path goes via _populate_via_view, which routes each KV through a fresh _StdTable view. The first such write hit a section with no entries, so _detect_indent returned "" and make_keyvalue_node produced an unindented kv; subsequent writes then chained off that empty leading and stayed unindented.

Sample a sibling entry's KV indent up front (the first sibling that has any KV content) and seed it into the new section's first direct entry the moment that entry lands. From the next iteration onwards _detect_indent reads the seeded indent off entries[-1] and produces correctly-indented kvs naturally, so we only have to intervene once -- not once per kv.