### PR TITLE
Defer install() value rules to __setitem__

### DIFF
--- a/src/tomlrt/_document.py
+++ b/src/tomlrt/_document.py
@@ -623,7 +623,7 @@ class Table(dict[str, Any]):
         return {k: _to_plain(v) for k, v in self.items()}
 
     @override
-    def pop(self, key: str, default: object = _MISSING) -> Any:
+    def pop(self, key: str, default: Any = _MISSING) -> Any:
         """Remove ``key`` and return its value, like `dict.pop`.
 
         For [`Table`][tomlrt.Table] / [`AoT`][tomlrt.AoT] /
@@ -2459,7 +2459,7 @@ class Array(list[Any]):
         _write_item_leadings(self._node.items, leadings)
 
     @staticmethod
-    def _make_item(value: object, *, with_comma: bool) -> ArrayItem:
+    def _make_item(value: TomlInput, *, with_comma: bool) -> ArrayItem:
         from tomlrt._nodes import ArrayItem  # noqa: PLC0415
 
         return ArrayItem(
@@ -2545,14 +2545,14 @@ class Array(list[Any]):
     # ------------------------------------------------------------------
 
     @override
-    def append(self, value: object) -> None:
+    def append(self, value: Any) -> None:
         new_item = self._make_item(value, with_comma=False)
         self._node.items.append(new_item)
         _apply_separator_after_append(self._node, self._style)
         list.append(self, _value_for(new_item.value))
 
     @override
-    def extend(self, values: Iterable[object]) -> None:
+    def extend(self, values: Iterable[Any]) -> None:
         new_items = [self._make_item(v, with_comma=False) for v in list(values)]
         if not new_items:
             return
@@ -2561,7 +2561,7 @@ class Array(list[Any]):
         list.extend(self, [_value_for(it.value) for it in new_items])
 
     @override
-    def insert(self, index: SupportsIndex, value: object) -> None:
+    def insert(self, index: SupportsIndex, value: Any) -> None:
         idx = operator.index(index)
         leadings = _snapshot_item_leadings(self._node.items)
         new_item = self._make_item(value, with_comma=False)
@@ -2571,14 +2571,14 @@ class Array(list[Any]):
         list.insert(self, idx, _value_for(new_item.value))
 
     @overload
-    def __setitem__(self, index: SupportsIndex, value: object) -> None: ...
+    def __setitem__(self, index: SupportsIndex, value: Any) -> None: ...
     @overload
-    def __setitem__(self, index: slice, value: Iterable[object]) -> None: ...
+    def __setitem__(self, index: slice, value: Iterable[Any]) -> None: ...
     @override
     def __setitem__(
         self,
         index: SupportsIndex | slice,
-        value: object,
+        value: Any,
     ) -> None:
         if isinstance(index, slice):
             if not isinstance(value, Iterable):
@@ -2626,7 +2626,7 @@ class Array(list[Any]):
         return popped
 
     @override
-    def remove(self, value: object) -> None:
+    def remove(self, value: Any) -> None:
         idx = list.index(self, value)
         del self[idx]
 
@@ -2669,7 +2669,7 @@ class Array(list[Any]):
         self._resync()
 
     @override
-    def __iadd__(self, values: Iterable[object]) -> Self:
+    def __iadd__(self, values: Iterable[Any]) -> Self:
         self.extend(values)
         return self
 

--- a/src/tomlrt/_document.py
+++ b/src/tomlrt/_document.py
@@ -453,7 +453,7 @@ class Table(dict[str, Any]):
     def install(
         self,
         path: str | tuple[str, ...],
-        value: Any,
+        value: TomlInput,
     ) -> Any:
         """Install ``value`` at ``path``, descending dotted segments.
 
@@ -461,24 +461,12 @@ class Table(dict[str, Any]):
         of literal segments (use the tuple form to express a segment
         containing a literal dot, e.g. ``("foo.bar",)``).
 
-        ``value`` may be any of:
-
-        * a [`Table.section`][tomlrt.Table.section] result — installs a
-          ``[...]`` standard section;
-        * an [`AoT`][tomlrt.AoT] built standalone (``AoT([{...}])``) — installs
-          ``[[...]]`` array-of-tables entries;
-        * an [`Array`][tomlrt.Array] built standalone (``Array([...],
-          multiline=...)``) — installs an inline array with the
-          requested layout;
-        * any plain Python value (scalar, ``dict``, ``list``) —
-          assigned at the leaf with ordinary ``__setitem__`` semantics
-          (so a leaf ``dict`` becomes an inline table, a leaf ``list``
-          becomes an inline array).
-
-        Existing values at ``path`` (including sub-sections) are
-        replaced. Implicit intermediate tables are left implicit, so
-        ``install(("tool", "poetry"), Table.section({}))`` produces a
-        single ``[tool.poetry]`` header, not a ``[tool]`` + nested.
+        ``value`` follows the same rules as ordinary assignment
+        (``t[k] = value``); ``install`` only adds the dotted-path
+        descent. Existing values at ``path`` (including sub-sections)
+        are replaced. Implicit intermediate tables are left implicit,
+        so ``install(("tool", "poetry"), Table.section({}))`` produces
+        a single ``[tool.poetry]`` header, not a ``[tool]`` + nested.
 
         Returns the freshly-installed live view ([`Table`][tomlrt.Table],
         [`AoT`][tomlrt.AoT], [`Array`][tomlrt.Array]) or the leaf value.

--- a/src/tomlrt/_document.py
+++ b/src/tomlrt/_document.py
@@ -359,7 +359,7 @@ class Table(dict[str, Any]):
     def _set_value(  # pragma: no cover
         self,
         key: str,
-        value: object,
+        value: TomlInput,
     ) -> TomlValue | None:
         """Mutate the CST so ``key`` binds to ``value``.
 
@@ -414,7 +414,7 @@ class Table(dict[str, Any]):
 
     # --- mutators ----------------------------------------------------------
 
-    def _commit_value(self, key: str, value: object) -> None:
+    def _commit_value(self, key: str, value: TomlInput) -> None:
         """Plain-value write at ``key`` then sync dict storage.
 
         When ``value`` is an unattached `_InlineTable` /
@@ -512,7 +512,7 @@ class Table(dict[str, Any]):
     def _install_flavoured(
         self,
         parts: tuple[str, ...],
-        value: object,
+        value: TomlInput,
     ) -> None:
         """Route a flavour-bearing value through the structural installers.
 
@@ -956,7 +956,7 @@ class _InlineTable(Table):
                 return entry
         return None
 
-    def _make_entry(self, path: tuple[str, ...], value: object) -> InlineTableEntry:
+    def _make_entry(self, path: tuple[str, ...], value: TomlInput) -> InlineTableEntry:
         pre, post = self._eq_padding
         # ``pre``/``post`` are WhitespaceNode|None value objects; sharing
         # the ref across entries is safe because their ``text`` field is
@@ -974,7 +974,7 @@ class _InlineTable(Table):
 
     # --- _DottedHost protocol ------------------------------------------------
 
-    def set_at(self, path: tuple[str, ...], value: object) -> None:
+    def set_at(self, path: tuple[str, ...], value: TomlInput) -> None:
         # Preserve in-place update for an exact path match (any depth) so
         # the entry's surrounding trivia and position survive round-tripping.
         for entry in self._node.entries:
@@ -986,7 +986,7 @@ class _InlineTable(Table):
     def _replace_prefix(
         self,
         prefix: tuple[str, ...],
-        value: object,
+        value: TomlInput,
     ) -> InlineTableEntry:
         """Purge any entry under ``prefix`` and append a fresh one.
 
@@ -1026,7 +1026,7 @@ class _InlineTable(Table):
     # --- mapping mutation ----------------------------------------------------
 
     @override
-    def _set_value(self, key: str, value: object) -> TomlValue | None:
+    def _set_value(self, key: str, value: TomlInput) -> TomlValue | None:
         # Fast path: brand-new head key (dict cache surfaces single-segment
         # entries and dotted-key sub-tables, so absence here is conclusive).
         prefix = (key,)
@@ -1063,7 +1063,7 @@ class _DottedHost(Protocol):
     top of it re-read live state instead of a stale snapshot.
     """
 
-    def set_at(self, path: tuple[str, ...], value: object) -> None: ...
+    def set_at(self, path: tuple[str, ...], value: TomlInput) -> None: ...
 
     def del_prefix(self, prefix: tuple[str, ...]) -> bool: ...
 
@@ -1080,7 +1080,7 @@ class _SectionDottedHost:
     def __init__(self, sections: list[SectionNode]) -> None:
         self._sections = sections
 
-    def set_at(self, path: tuple[str, ...], value: object) -> None:
+    def set_at(self, path: tuple[str, ...], value: TomlInput) -> None:
         # Preserve in-place update for an exact path match (any depth) so
         # the entry's surrounding trivia and position survive round-tripping.
         for sec in self._sections:
@@ -1205,7 +1205,7 @@ class _DottedSubTable(Table):
                 )
 
     @override
-    def _set_value(self, key: str, value: object) -> TomlValue | None:
+    def _set_value(self, key: str, value: TomlInput) -> TomlValue | None:
         self._host.set_at((*self._prefix, key), value)
         return None
 
@@ -1558,7 +1558,7 @@ class _StdTable(Table):
             ]
 
     @override
-    def _set_value(self, key: str, value: object) -> TomlValue | None:
+    def _set_value(self, key: str, value: TomlInput) -> TomlValue | None:
         kind, payload = self._classify(key)
         if kind in ("direct", "extras"):
             # In-place value swap: reuse the existing KV node.
@@ -1895,7 +1895,7 @@ class _StdTable(Table):
         _insert_section_block(self._doc_node, insert_at, new_secs, add_blank=True)
 
     @override
-    def _install_flavoured(self, parts: tuple[str, ...], value: object) -> None:
+    def _install_flavoured(self, parts: tuple[str, ...], value: TomlInput) -> None:
         if self._dispatch_structural(parts, value):
             return
         # Plain value (or same-slot identity case skipped by
@@ -1915,7 +1915,7 @@ class _StdTable(Table):
     def _dispatch_structural(
         self,
         parts: tuple[str, ...],
-        value: object,
+        value: TomlInput,
     ) -> bool:
         """Try to install ``value`` at ``parts`` as a structural edit.
 


### PR DESCRIPTION
The install() docstring enumerated the accepted value flavours (Table.section, AoT, Array, plain dict/list/scalar) but omitted Table.inline, which is in fact accepted and live-attaches via the plain-value path. Rather than patch the list, drop it: install() is just __setitem__ with dotted-path descent, so let it defer to __setitem__'s rules and keep the canonical enumeration in docs/editing.md.