### PR TITLE
Drop redundant Table.copy override

### DIFF
--- a/docs/editing.md
+++ b/docs/editing.md
@@ -36,6 +36,15 @@ Reach for `Table.section`, `Table.inline`, or `Array` when you want live semanti
 A container that is already attached somewhere is deep-cloned on assignment, so two slots never share state.
 This applies whether the source and destination are in the same document (`doc["b"] = doc["a"]`) or different ones (`d2["x"] = d1["x"]`).
 
+## Removal and orphaning
+
+Removing a `Table`, `Array`, or `AoT` &mdash; via `del`, `pop`, `clear`, or overwrite &mdash; detaches the view. It keeps its data, but further mutations no longer reach the document:
+
+```python
+old = doc.pop("tool")        # detached Table view
+old["debug"] = True          # does NOT affect doc
+```
+
 ## Growing an array-of-tables
 
 `AoT.add()` appends a fresh entry and returns the new `Table` view, so you can keep mutating it:

--- a/src/tomlrt/_document.py
+++ b/src/tomlrt/_document.py
@@ -600,11 +600,6 @@ class Table(dict[str, Any]):
         self.update(other)
         return self
 
-    @override
-    def copy(self) -> dict[str, Any]:
-        """Return a shallow plain ``dict`` copy of this table."""
-        return dict(self)
-
     def to_dict(self) -> dict[str, Any]:
         """Return a deep, plain-Python copy of this table.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -60,3 +60,11 @@ show_source = false
 show_signature_annotations = true
 separate_signature = true
 members_order = "source"
+# Suppress overrides of stdlib dict/list methods so the rendered API
+# is the tomlrt-specific surface, not an inconsistent mix of which
+# overrides happened to acquire a docstring.
+filters = [
+  "!^_",
+  "!^(clear|copy|fromkeys|get|items|keys|pop|popitem|setdefault|update|values)$",
+  "!^(append|count|extend|index|insert|remove|reverse|sort)$",
+]


### PR DESCRIPTION
dict.copy() on a dict subclass already returns a plain dict, which is exactly what the override produced via dict(self). Array and AoT rely on the inherited list.copy() for the same reason; remove the asymmetry.