### PR TITLE
docs: keep __init__ in API reference

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -60,11 +60,13 @@ show_source = false
 show_signature_annotations = true
 separate_signature = true
 members_order = "source"
+group_by_category = false
 # Suppress overrides of stdlib dict/list methods so the rendered API
 # is the tomlrt-specific surface, not an inconsistent mix of which
 # overrides happened to acquire a docstring.
 filters = [
-  "!^_",
+  "!^_[^_]",
+  "!^__(?!init__$)",
   "!^(clear|copy|fromkeys|get|items|keys|pop|popitem|setdefault|update|values)$",
   "!^(append|count|extend|index|insert|remove|reverse|sort)$",
 ]


### PR DESCRIPTION
The previous filter cleanup excluded all underscore-prefixed members, which inadvertently dropped __init__ docstrings — most notably the user-facing constructor docs on Array and AoT. Tighten the filter to keep __init__ while still hiding other dunders and single-underscore private helpers, so the constructors render as documented members.