### PR TITLE
Tighten Any annotations in internal helpers

### DIFF
--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -301,7 +301,7 @@ class Container(dict[str, Any]):
         Raises ``TypeError`` if descent passes through a non-table.
         """
         parts = split_path(key)
-        cur: Any = self
+        cur: object = self
         for i, p in enumerate(parts):
             if not isinstance(cur, Container):
                 msg = f"cannot descend into {parts[i - 1]!r}: not a table"
@@ -1344,8 +1344,8 @@ def _install_attached_subtree(
     a ``Table.section`` snapshot is installed at ``dst_path`` to
     carry them.
     """
-    direct_kvs: list[tuple[str, Any]] = []
-    structural: list[tuple[str, Any]] = []
+    direct_kvs: list[tuple[str, object]] = []
+    structural: list[tuple[str, object]] = []
     for k, v in src_table.items():
         if isinstance(v, AoT) or (_is_section(v)):
             structural.append((k, v))
@@ -1582,13 +1582,13 @@ def _retarget_to_doc(val: Value, layout_root: Document | None) -> None:
 
 def _populate_inline_table(
     table: Table | Container,
-    items: list[tuple[Any, Any]],
+    items: list[tuple[object, object]],
     *,
     layout_root: Document | None,
     parent: Container | None,
     path: tuple[str, ...],
     owner: AoTEntry | None,
-) -> tuple[InlineTableValue, Any]:
+) -> tuple[InlineTableValue, Container]:
     """Wire ``table`` as an inline view and populate its entries.
 
     Two callers: the live-attach path (passes a user-supplied

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from tomlrt._kind import _Kind
 from tomlrt._scalar import is_scalar
@@ -2177,7 +2177,7 @@ def attach_section_at(
     parent: Container,
     sub_path: tuple[str, ...] | list[str],
     source: Mapping[str, Any] | Container | None = None,
-) -> Any:
+) -> Table:
     """Synthesise ``[parent_path.sub_path]`` (multi-component) at end-of-doc.
 
     Intermediate components in ``sub_path[:-1]`` become implicit tables;
@@ -2300,11 +2300,7 @@ def attach_section(
     case. ``source`` may be ``None`` (empty section) or a Mapping
     (initial body). Returns the live `Table` view.
     """
-    section = attach_section_at(parent, (key,), source)
-    from tomlrt._container import Table  # noqa: PLC0415
-
-    assert isinstance(section, Table)
-    return section
+    return attach_section_at(parent, (key,), source)
 
 
 def _items_for_synth(source: Mapping[str, Any] | Container) -> list[tuple[str, object]]:
@@ -2328,7 +2324,10 @@ def _last_aot_slot(aot: AoT) -> Slot | None:
     return None
 
 
-def _pop_or_remove(lst: list[Any], item: Any) -> None:
+_PopT = TypeVar("_PopT")
+
+
+def _pop_or_remove(lst: list[_PopT], item: _PopT) -> None:
     """O(1) pop if ``item`` is at the tail; else C-level ``list.remove``.
 
     Both branches are C-implemented; the tail check avoids an

--- a/src/tomlrt/_slots.py
+++ b/src/tomlrt/_slots.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from tomlrt._container import Container
@@ -79,7 +79,7 @@ class Slot:
     `unfile_ref` (unregisters).
     """
 
-    def __deepcopy__(self, memo: dict[int, Any]) -> Slot:
+    def __deepcopy__(self, memo: dict[int, object]) -> Slot:
         """Deep-copy without following ``_refs``/``_prev``/``_next``.
 
         Cloned slots start with a fresh empty ``_refs`` (callers
@@ -93,7 +93,7 @@ class Slot:
         for f in fields(self):
             match f.name:
                 case "_prev" | "_next":
-                    value: Any = None
+                    value: object = None
                 case "_refs":
                     value = []
                 case _:


### PR DESCRIPTION
A few internal helpers used Any out of habit where a concrete type (or a TypeVar) captures the actual contract. None of these are public API and tightening them does not change behaviour.

- _layout_ops._pop_or_remove is now generic over the element type.
- _layout_ops.attach_section_at returns Table directly; drop the redundant assert isinstance in attach_section.
- Container.entry's loop cursor uses object (it is narrowed via isinstance on each iteration anyway).
- _install_attached_subtree's direct_kvs / structural buckets and _populate_inline_table's items / return type now use object / Container instead of Any.
- Slot.__deepcopy__'s memo and local value annotations use object, matching the convention already used in _container.py / _array.py.

mypy --strict, ty check, ruff, and the full pytest suite all pass.