### PR TITLE
Inline attach_section into its sole caller

### DIFF
--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -557,7 +557,7 @@ class Container(dict[str, Any]):
             return
         if src_root is not None and src_root._is_private:  # noqa: SLF001
             _reset_table_for_rehome(value)
-        _layout_ops.attach_section(self, key, value)
+        _layout_ops.attach_section_at(self, (key,), value)
 
     def _scalar_replace(self, key: str, value: Any) -> None:
         refs = self._index.get(key)

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -2291,18 +2291,6 @@ def attach_section_at(
     return section
 
 
-def attach_section(
-    parent: Container, key: str, source: Mapping[str, Any] | Container | None = None
-) -> Table:
-    """Synthesise ``[parent_path.key]`` at end-of-doc and attach.
-
-    Thin wrapper around `attach_section_at` for the single-component
-    case. ``source`` may be ``None`` (empty section) or a Mapping
-    (initial body). Returns the live `Table` view.
-    """
-    return attach_section_at(parent, (key,), source)
-
-
 def _items_for_synth(source: Mapping[str, Any] | Container) -> list[tuple[str, object]]:
     """Iterate items of a Mapping/dict/Container source as (key, value)."""
     return list(source.items())
@@ -2889,7 +2877,6 @@ __all__ = [
     "add_aot_entry",
     "append_direct_kv",
     "attach_empty_aot",
-    "attach_section",
     "attach_section_at",
     "delete_key",
     "insert_after",

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -446,7 +446,7 @@ def test_synthesise_roundtrip(data: dict[str, Any]) -> None:
 # The bytes-level parser fuzzer in test_fuzz.py never touches the editing
 # API, and the existing mutation property only overrides existing top-
 # level scalar slots; this fills the gap that hid the
-# `attach_section` / `_maybe_demote_synthetic_empty_header` ancestor-
+# `attach_section_at` / `_maybe_demote_synthetic_empty_header` ancestor-
 # anchor bug.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
attach_section existed to narrow attach_section_at's Any return to Table for the one-component case. Now that attach_section_at is typed -> Table directly, the wrapper does nothing but wrap key into a 1-tuple, and has only one caller. Inline it.