### PR TITLE
Type dt_kind parameter as datetime

### DIFF
--- a/src/tomlrt/_scalar.py
+++ b/src/tomlrt/_scalar.py
@@ -96,6 +96,5 @@ def basic_string_lexeme(v: str) -> str:
     return "".join(out)
 
 
-def dt_kind(v: object) -> DateLikeKind:
-    assert isinstance(v, datetime)
+def dt_kind(v: datetime) -> DateLikeKind:
     return "offset-datetime" if v.tzinfo is not None else "local-datetime"


### PR DESCRIPTION
The single caller in coerce_scalar already guards on isinstance(v, datetime), so dt_kind never needs the runtime assertion — annotate the parameter correctly instead.