### PR TITLE
toml-sort migration feedback fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cloned subtree.
 - Cross-document `dst[k] = src[k]` now preserves the source table
   header's leading comment block.
+- Adding a sub-section to an empty placeholder section no longer
+  clears `Document.preamble`.
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-05-24
+
 ### Added
 
 - `Container.sort(*, key=None, reverse=False)` reorders a section,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Per-key clone of a sub-table that came from dotted-key form
+  (e.g. `dst["x"]["v"] = src["x"]["v"]` where the source was
+  `[x]\nv.w = 1`) now preserves the dotted form on the destination
+  instead of silently promoting it to an explicit `[x.v]` header.
 - Cross-document `dst["k"] = src["k"]` now preserves the source
   section header's indent even when no leading comment is attached.
 - Multi-component `install("a.b", value)` where the implicit parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   header's leading comment block.
 - Adding a sub-section to an empty placeholder section no longer
   clears `Document.preamble`.
+- Cross-document `dst[k] = src_section` under an empty placeholder
+  parent now demotes the parent to an implicit super-table instead
+  of leaving a stray bare `[parent]` header line.
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now consistently raises `TOMLError` with a clear message, including
   for detached `Table.inline()` factories (previously: silently
   accepted, then `NotImplementedError` at attach time).
+- Comments on dotted-key entries are now reachable through the
+  dotted-parent container (`project["urls"].comments["homepage"]`).
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cross-document `dst[k] = src[k]` and `aot.append(entry)` now
   preserve nested arrays-of-tables inside the cloned subtree.
+- Cross-document `dst[k] = src[k]` now preserves the source table
+  header's leading comment block.
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Container.leading_block` and `Table.header_leading_block` expose the
+  full leading-trivia region (including blank-line-separated "orphan"
+  comments) as a tuple of `str | None`, where `None` is a blank line.
 - `Table.is_inline` property to distinguish inline `{...}` tables from
   `[section]` blocks when walking a parsed document.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Container.sort(*, key=None, reverse=False)` reorders a section,
+  document, table, or inline table's direct child keys in place,
+  preserving per-key trivia. Mirrors `list.sort` / `AoT.sort`.
 - `Container.leading_block` and `Table.header_leading_block` expose the
   full leading-trivia region (including blank-line-separated "orphan"
   comments) as a tuple of `str | None`, where `None` is a blank line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-document `dst[k] = src_section` under an empty placeholder
   parent now demotes the parent to an implicit super-table instead
   of leaving a stray bare `[parent]` header line.
+- Assigning a section table or `AoT` as a value of an inline table
+  now consistently raises `TOMLError` with a clear message, including
+  for detached `Table.inline()` factories (previously: silently
+  accepted, then `NotImplementedError` at attach time).
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Cross-document `dst["k"] = src["k"]` now preserves the source
-  section header's leading-whitespace indent even when no leading
-  comment is present (previously the indent travelled only when a
-  comment was attached, breaking idempotency for sorters that strip
-  comments).
+  section header's indent even when no leading comment is attached.
 - Multi-component `install("a.b", value)` where the implicit parent
   must be synthesised now preserves source header trivia (leading
   comments) on the installed child, by routing through the standard
@@ -30,8 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cloned subtree.
 - Cross-document `dst[k] = src[k]` now preserves the source table
   header's leading comment block.
-- Adding a sub-section to an empty placeholder section no longer
-  clears `Document.preamble`.
+- Adding a sub-section to an empty placeholder section no longer clears
+  `Document.preamble`.
+- `Array.sort` / `Array.reverse` now keep per-item leading comments with
+  their items and stop the closing `]` from gluing to the new last item.
 - Cross-document `dst[k] = src_section` under an empty placeholder
   parent now demotes the parent to an implicit super-table instead
   of leaving a stray bare `[parent]` header line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepted, then `NotImplementedError` at attach time).
 - Comments on dotted-key entries are now reachable through the
   dotted-parent container (`project["urls"].comments["homepage"]`).
+- `Array.sort()` / `Array.reverse()` no longer leave the new item 0
+  carrying the old position-0 indent in multi-line arrays.
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Mutating `comments`, `leading_comments`, or `leading_block` on a
+  detached `Table.section()` / `Table.inline()` now raises a clear
+  `TOMLError` pointing at the attach-first workaround instead of a
+  misleading `KeyError("key '...' not in container")`.
 - `Container.leading_block` and `Table.header_leading_block` no longer
   overlap with `Document.preamble` at the document head slot.
   Round-tripping or reordering sections no longer migrates the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carrying the old position-0 indent in multi-line arrays.
 - Cross-document `dst[k] = src[k]` and `AoT.sort()` no longer drag the
   source document's preamble onto the destination or surviving entries.
+- `Array.leading_comments` del/pop/clear at non-zero indices, and
+  insert/append next to items carrying EOL comments, no longer
+  misattribute or duplicate adjacent comments on re-render.
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Table.is_inline` property to distinguish inline `{...}` tables from
   `[section]` blocks when walking a parsed document.
 
+### Fixed
+
+- Cross-document `dst[k] = src[k]` and `aot.append(entry)` now
+  preserve nested arrays-of-tables inside the cloned subtree.
+
 ## [1.4.3] - 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Multi-component `install("a.b", value)` where the implicit parent
+  must be synthesised now preserves source header trivia (leading
+  comments) on the installed child, by routing through the standard
+  `__setitem__` clone dispatch rather than the synthesis fallback.
+  Same fix applies to cross-document `dst["a"] = src["a"]` when the
+  source has only implicit parents.
 - Cross-document `dst[k] = src[k]`, `aot.append(entry)` and
   `aot[i] = entry` now preserve nested arrays-of-tables inside the
   cloned subtree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Table.is_inline` property to distinguish inline `{...}` tables from
+  `[section]` blocks when walking a parsed document.
+
 ## [1.4.3] - 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dotted-parent container (`project["urls"].comments["homepage"]`).
 - `Array.sort()` / `Array.reverse()` no longer leave the new item 0
   carrying the old position-0 indent in multi-line arrays.
+- Cross-document `dst[k] = src[k]` and `AoT.sort()` no longer drag the
+  source document's preamble onto the destination or surviving entries.
 
 ## [1.4.3] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cross-document `dst["k"] = src["k"]` now preserves the source
+  section header's leading-whitespace indent even when no leading
+  comment is present (previously the indent travelled only when a
+  comment was attached, breaking idempotency for sorters that strip
+  comments).
 - Multi-component `install("a.b", value)` where the implicit parent
   must be synthesised now preserves source header trivia (leading
   comments) on the installed child, by routing through the standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Cross-document `dst[k] = src[k]` and `aot.append(entry)` now
-  preserve nested arrays-of-tables inside the cloned subtree.
+- Cross-document `dst[k] = src[k]`, `aot.append(entry)` and
+  `aot[i] = entry` now preserve nested arrays-of-tables inside the
+  cloned subtree.
 - Cross-document `dst[k] = src[k]` now preserves the source table
   header's leading comment block.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Container.leading_block` and `Table.header_leading_block` no longer
+  overlap with `Document.preamble` at the document head slot.
+  Round-tripping or reordering sections no longer migrates the
+  preamble into a section body.
 - Per-key clone of a sub-table that came from dotted-key form
   (e.g. `dst["x"]["v"] = src["x"]["v"]` where the source was
   `[x]\nv.w = 1`) now preserves the dotted form on the destination

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,7 @@ code.
         - comments
         - leading_comments
         - leading_block
+        - sort
         - to_dict
 
 ::: tomlrt.Table
@@ -79,6 +80,7 @@ code.
         - comments
         - leading_comments
         - leading_block
+        - sort
         - to_dict
 
 ::: tomlrt.Array

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,8 +49,10 @@ code.
         - epilogue
         - header_comment
         - header_leading_comments
+        - header_leading_block
         - comments
         - leading_comments
+        - leading_block
         - to_dict
 
 ::: tomlrt.Table
@@ -73,8 +75,10 @@ code.
         - promote_array
         - header_comment
         - header_leading_comments
+        - header_leading_block
         - comments
         - leading_comments
+        - leading_block
         - to_dict
 
 ::: tomlrt.Array

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,7 @@ code.
       members:
         - section
         - inline
+        - is_inline
         - table
         - array
         - aot

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -86,8 +86,8 @@ assert doc["b"].header_leading_block == (None, "orphan", None)
 doc["b"].header_leading_block = ("orphan", None, "attached")
 ```
 
-For the first slot in a document this region overlaps with
-`Document.preamble`: writes through either are visible through the other.
+For the first slot in a document, `Document.preamble` is disjoint from
+this view: it is read and written through `Document.preamble` only.
 
 ## Document preamble and epilogue
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -56,6 +56,39 @@ tags.comments[0] = "primary"
 tags.leading_comments[1] = ("alternate",)
 ```
 
+## Orphan comments between sections
+
+`leading_comments` and `header_leading_comments` cover only the run of `# …`
+lines that sit *directly* above an entry or section header.
+A comment group separated from the entry by a blank line — for example a
+free-standing `# …` block between `[a]` and `[b]` — is not part of either
+view, and is silently dropped if the entry is removed and reinserted.
+
+`Table.leading_block` and `Table.header_leading_block` are the lossless
+counterparts: they expose the *whole* leading region — both the blank-
+separated groups above and the attached run immediately above the entry —
+as a tuple in which each `str` is a bare comment line and each `None` is
+a blank line. Round-tripping a value through them therefore preserves
+exact line structure.
+
+```toml
+[a]
+x = 1
+
+# orphan
+
+[b]
+y = 2
+```
+
+```python
+assert doc["b"].header_leading_block == (None, "orphan", None)
+doc["b"].header_leading_block = ("orphan", None, "attached")
+```
+
+For the first slot in a document this region overlaps with
+`Document.preamble`: writes through either are visible through the other.
+
 ## Document preamble and epilogue
 
 The top-of-file and bottom-of-file comment blocks are reachable via

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -88,6 +88,39 @@ entry = pkgs.add({"name": "foo"})
 entry["version"] = "1.0"
 ```
 
+## Sorting child keys
+
+`Container.sort(*, key=None, reverse=False)` reorders a `Document`'s
+or `Table`'s direct child keys in place, preserving per-key trivia.
+Mirrors `list.sort`. Inline tables (`{ ... }`) are also supported.
+
+```python
+doc = tomlrt.loads("""
+    # above b
+    b = 1
+    # above a
+    a = 2
+""")
+doc.sort()
+# a is now first, with its comment still attached.
+```
+
+For value-sorted orderings (e.g. leaves first, then sections), pass a
+custom `key`:
+
+```python
+def is_section(k: str) -> bool:
+    v = doc[k]
+    return isinstance(v, tomlrt.Table) and not v.is_inline
+
+doc.sort(key=lambda k: (is_section(k), k))
+```
+
+`sort` raises `ValueError` if the requested order would re-bind a leaf
+key under a structural section header.
+
+For sorting `AoT` entries, use `AoT.sort(key=...)`.
+
 ## Empty arrays-of-tables
 
 TOML has no syntax for an array-of-tables with zero entries, so an empty `AoT`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tomlrt"
-version = "1.4.3"
+version = "1.5.0"
 description = "A format-preserving TOML reader and writer for Python."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "pytest-cov>=5",
   "hypothesis>=6",
   "mypy>=1.11",
-  "tomli>=2; python_version < '3.11'",
+  "tomli>=2.2",
 ]
 docs = [
   "mkdocstrings[python]>=0.27",

--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -37,6 +37,7 @@ from tomlrt._trivia import (
     join_above_block,
     split_above_block,
     split_eol_section,
+    split_item_above,
     trivia_has_comment,
     trivia_has_newline,
 )
@@ -337,12 +338,11 @@ class Array(list[Any]):
             return
         # Non-empty: any above-`]` comment block in final_trivia
         # logically belongs ABOVE the new item we're about to add.
-        ft_pad, ft_above = split_above_block(self._value.final_trivia)
-        new_leading = join_above_block(style.inter_separator, ft_above)
+        self._value.final_trivia, new_leading = _migrate_bracket_above(
+            self._value.final_trivia, style.inter_separator
+        )
         _flip_to_internal(items[-1])
         new_item = _make_item(cst, leading=new_leading, has_comma=False)
-        if ft_above.pieces:
-            self._value.final_trivia = ft_pad
         items.append(new_item)
         _flip_to_terminal(new_item, style)
         # Under the canonical multiline model the row break + bracket
@@ -356,6 +356,7 @@ class Array(list[Any]):
             ft = self._value.final_trivia
             if not (ft.pieces and isinstance(ft.pieces[0], NewlineNode)):
                 ft.pieces = [NewlineNode(self._doc_newline), *ft.pieces]
+        _normalise_leading_nls(items, self._doc_newline, multiline=style.is_multiline)
         list.append(self, decoded)
 
     def _restamp_for_first_append(self) -> None:
@@ -451,11 +452,10 @@ class Array(list[Any]):
             # items[1]; the above-block migrates to its leading. The
             # new item gets bare leading; header_trivia retains only
             # its structural pad.
-            pad, above = split_above_block(self._value.header_trivia)
-            self._value.header_trivia = pad
             new_item = _make_item(cst, has_comma=True)
-            old_first = items[0]
-            old_first.leading = join_above_block(style.inter_separator, above)
+            self._value.header_trivia, items[0].leading = _migrate_bracket_above(
+                self._value.header_trivia, style.inter_separator
+            )
             items.insert(0, new_item)
         else:
             # Internal insert: new item with leading = inter_sep; the
@@ -466,6 +466,7 @@ class Array(list[Any]):
                 cst, leading=clone_trivia(style.inter_separator), has_comma=True
             )
             items.insert(i, new_item)
+        _normalise_leading_nls(items, self._doc_newline, multiline=style.is_multiline)
         list.insert(self, i, decoded)
 
     @override
@@ -609,7 +610,7 @@ class Array(list[Any]):
         new_first_above: Trivia = Trivia()
         if zero_removed and survivors_after_zero:
             k = survivors_after_zero[0]
-            _new_pad, new_first_above = split_above_block(items[k].leading)
+            _head, new_first_above, _tail = split_item_above(items[k].leading)
         # When the tail is removed, the surviving last item's
         # post_comma_trivia (if it had a comma) currently encodes a
         # post-comma bracket pad we need to recompute from style.
@@ -856,6 +857,59 @@ def _restamp_canonical_pads(
         sep = style.inter_separator
     for k, it in enumerate(value.items):
         it.leading = Trivia() if k == 0 else clone_trivia(sep)
+
+
+def _migrate_bracket_above(bracket: Trivia, separator: Trivia) -> tuple[Trivia, Trivia]:
+    """Migrate any above-bracket comment block onto a new item's leading.
+
+    An above-block in ``header_trivia`` / ``final_trivia`` (the
+    structural row(s) between the bracket and the next/last item)
+    conceptually belongs to the item below it. When a new boundary
+    item is being inserted or appended, the block migrates from the
+    bracket pad onto that item's leading.
+
+    Returns ``(new_bracket, new_leading)``.
+    """
+    pad, above = split_above_block(bracket)
+    return pad, join_above_block(separator, above)
+
+
+def _item_has_eol(item: ArrayItem) -> bool:
+    """True if the item carries an inline EOL comment.
+
+    When the item has a comma, the EOL section lives in
+    ``post_comma_trivia``; otherwise it lives in ``trailing``.
+    """
+    target = item.post_comma_trivia if item.has_comma else item.trailing
+    eol, _rest = split_eol_section(target)
+    return bool(eol.pieces)
+
+
+def _normalise_leading_nls(items: list[ArrayItem], nl: str, *, multiline: bool) -> None:
+    """Enforce the leading-NL invariant across the item list.
+
+    In a multiline array, ``items[i].leading`` (i >= 1) must start
+    with a NL iff ``items[i-1]`` carries no EOL. When the predecessor
+    has an EOL the row-terminating NL lives in its EOL section, so
+    ``items[i].leading`` starts with WS (indent) instead. Mutations
+    that change predecessor relationships must restore the invariant
+    or the comment block at the front of ``items[i].leading`` would
+    misattach to the predecessor as an EOL on reparse.
+
+    Idempotent and applied to every item, so mutation sites only have
+    to call this once at the end rather than track which predecessor
+    relationships they touched.
+    """
+    if not multiline:
+        return
+    for i in range(1, len(items)):
+        pred = items[i - 1]
+        pieces = items[i].leading.pieces
+        has_nl = bool(pieces) and isinstance(pieces[0], NewlineNode)
+        if _item_has_eol(pred) and has_nl:
+            items[i].leading = Trivia(pieces[1:])
+        elif not _item_has_eol(pred) and not has_nl:
+            items[i].leading = Trivia([NewlineNode(text=nl), *pieces])
 
 
 def _migrate_eol_trailing_to_post_comma(item: ArrayItem) -> None:

--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -22,6 +22,7 @@ from tomlrt import _layout_ops
 from tomlrt._array_comments import (
     ArrayEolView,
     ArrayLeadingView,
+    _slot_indent,
     apply_comments,
     clear_all_comments,
     snapshot_comments,
@@ -492,11 +493,14 @@ class Array(list[Any]):
         items = self._value.items
         if not items:
             return
-        # Capture style BEFORE swapping items so inter_sep reflects
-        # the original layout.
+        # Capture style and canonical indent BEFORE swapping items, so
+        # both reflect the original layout rather than mid-permutation
+        # neighbour leadings.
         style = self._style()
-        # Snapshot pad of header_trivia (everything bracket-side of the
-        # above-pos-0 block) so it stays put across the reorder.
+        canonical_indent = _slot_indent(self) if style.is_multiline else ""
+        # Snapshot pad of header_trivia: kept as the bracket pad for the
+        # flush (single-line) case where ``inter_separator`` is a bare
+        # space and would inject a stray leading WS.
         head_pad, _head_above = split_above_block(self._value.header_trivia)
         leadings, eols = snapshot_comments(self)
         new_items = [items[j] for j in order]
@@ -508,9 +512,19 @@ class Array(list[Any]):
         for v in new_decoded:
             list.append(self, v)
         # Re-stamp leadings and post_comma_trivia per canonical model.
-        # Above-blocks will be re-applied by ``apply_comments`` from
-        # the snapshot.
-        self._value.header_trivia = clone_trivia(head_pad)
+        # ``header_trivia`` is item 0's above-region, so for multi-line
+        # arrays its pad must be ``NL + canonical indent`` — otherwise
+        # after a reorder item 0 keeps the old position's indent while
+        # items[1..] inherit the canonical one.
+        if style.is_multiline:
+            self._value.header_trivia = Trivia(
+                [
+                    NewlineNode(text=self._doc_newline),
+                    WhitespaceNode(text=canonical_indent),
+                ]
+            )
+        else:
+            self._value.header_trivia = clone_trivia(head_pad)
         _restamp_canonical_leadings(items, style)
         for it in items:
             it.post_comma_trivia = Trivia()

--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -493,15 +493,10 @@ class Array(list[Any]):
         items = self._value.items
         if not items:
             return
-        # Capture style and canonical indent BEFORE swapping items, so
-        # both reflect the original layout rather than mid-permutation
-        # neighbour leadings.
+        # Sample style + indent before the permutation: _slot_indent
+        # reads items[1].leading, which is about to be overwritten.
         style = self._style()
         canonical_indent = _slot_indent(self) if style.is_multiline else ""
-        # Snapshot pad of header_trivia: kept as the bracket pad for the
-        # flush (single-line) case where ``inter_separator`` is a bare
-        # space and would inject a stray leading WS.
-        head_pad, _head_above = split_above_block(self._value.header_trivia)
         leadings, eols = snapshot_comments(self)
         new_items = [items[j] for j in order]
         new_decoded = [self[j] for j in order]
@@ -511,21 +506,16 @@ class Array(list[Any]):
         list.clear(self)
         for v in new_decoded:
             list.append(self, v)
-        # Re-stamp leadings and post_comma_trivia per canonical model.
-        # ``header_trivia`` is item 0's above-region, so for multi-line
-        # arrays its pad must be ``NL + canonical indent`` — otherwise
-        # after a reorder item 0 keeps the old position's indent while
-        # items[1..] inherit the canonical one.
+        # header_trivia is item 0's above-region; reset it to the
+        # canonical pad here. Any comment block it carried was captured
+        # in leadings[0] and will be re-applied by apply_comments.
+        # _restamp_canonical_pads handles items[1..] and final_trivia.
+        nl = self._doc_newline
         if style.is_multiline:
             self._value.header_trivia = Trivia(
-                [
-                    NewlineNode(text=self._doc_newline),
-                    WhitespaceNode(text=canonical_indent),
-                ]
+                [NewlineNode(text=nl), WhitespaceNode(text=canonical_indent)]
             )
-        else:
-            self._value.header_trivia = clone_trivia(head_pad)
-        _restamp_canonical_leadings(items, style)
+        _restamp_canonical_pads(self._value, style, nl, canonical_indent)
         for it in items:
             it.post_comma_trivia = Trivia()
             it.trailing = Trivia()
@@ -571,7 +561,8 @@ class Array(list[Any]):
             new_segment = [_make_item(cst, has_comma=False) for cst in new_csts]
             items[index] = new_segment
             list.__setitem__(self, index, new_decoded)
-            _restamp_canonical_leadings(items, style)
+            indent = _slot_indent(self) if style.is_multiline else ""
+            _restamp_canonical_pads(self._value, style, self._doc_newline, indent)
             _renormalise_commas(items, style)
             return
         # int index: just replace the value CST in place.
@@ -845,17 +836,26 @@ def _make_item(
     )
 
 
-def _restamp_canonical_leadings(items: list[ArrayItem], style: _ArrayStyle) -> None:
-    """Reset every item's ``leading`` to the canonical-model pad.
+def _restamp_canonical_pads(
+    value: ArrayValue, style: _ArrayStyle, nl: str, indent: str
+) -> None:
+    """Reset items[1..]'s leadings and ``final_trivia`` to canonical pads.
 
-    Under the canonical model ``items[0].leading`` is empty (its pad
-    lives in ``header_trivia``) and ``items[k>=1].leading`` carries
-    the inter-item separator. This helper is the structural reset
-    used after a reorder or whole-segment slice replacement; comments
-    are reapplied separately by the caller.
+    In source, an item's EOL absorbs the next item's opening NL — and
+    the last item's EOL absorbs ``final_trivia``'s NL. After a
+    permutation or whole-segment replacement the items that supplied
+    those EOLs may have moved or disappeared, so we cannot sample the
+    inter-item separator from ``items[1].leading``: we synthesise the
+    canonical multi-line pad here. Caller is responsible for
+    ``header_trivia`` and for reapplying comments.
     """
-    for k, it in enumerate(items):
-        it.leading = Trivia() if k == 0 else clone_trivia(style.inter_separator)
+    if style.is_multiline:
+        sep = Trivia([NewlineNode(text=nl), WhitespaceNode(text=indent)])
+        value.final_trivia = Trivia([NewlineNode(text=nl)])
+    else:
+        sep = style.inter_separator
+    for k, it in enumerate(value.items):
+        it.leading = Trivia() if k == 0 else clone_trivia(sep)
 
 
 def _migrate_eol_trailing_to_post_comma(item: ArrayItem) -> None:

--- a/src/tomlrt/_array_comments.py
+++ b/src/tomlrt/_array_comments.py
@@ -38,9 +38,9 @@ from tomlrt._trivia import (
     NewlineNode,
     Trivia,
     WhitespaceNode,
-    join_above_block,
     split_above_block,
     split_eol_section,
+    split_item_above,
 )
 
 if TYPE_CHECKING:
@@ -253,10 +253,9 @@ class ArrayEolView(_ArrayIntKeyedView[str]):
 def _render_above_block(
     raw_lines: tuple[str, ...], nl: str, ind: str
 ) -> list[TriviaPiece]:
-    """Render an above-block matching :func:`split_above_block` shape.
+    """Render a comment block as ``[WS(ind), Comment, NL] * n``.
 
-    Each comment line emits ``WS(ind), Comment(raw), NL``; no trailing
-    whitespace (the value indent lives in pad).
+    The value-indent WS lives in the surrounding pad, not here.
     """
     out: list[TriviaPiece] = []
     for raw in raw_lines:
@@ -266,16 +265,31 @@ def _render_above_block(
     return out
 
 
-def _ensure_pad(target: Trivia, nl: str, ind: str) -> Trivia:
-    """Return a usable pad.
+def _split_above_frame(value: ArrayValue, i: int) -> tuple[Trivia, Trivia]:
+    """Split item ``i``'s above-region into framing ``(head, tail)``.
 
-    Returns the existing pad from ``target`` when present, or a freshly
-    synthesised ``[NL, WS(ind)]`` when ``target`` has none.
+    Any current above-block is discarded; mutators that want to
+    preserve it must use the underlying splitter directly.
+
+    For ``i == 0`` the target is ``header_trivia`` (bracket-pad
+    context): a pre-NL comment is an EOL on ``[`` and stays in
+    ``head``. For ``i >= 1`` the target is ``items[i].leading``:
+    a pre-NL comment is the item's above-block, possibly hoisted
+    from item ``i-1``'s EOL onto its ``post_comma_trivia``.
     """
-    pad, _above = split_above_block(target)
-    if pad.pieces:
-        return pad
-    return Trivia([NewlineNode(nl), WhitespaceNode(ind)])
+    target = _above_target(value, i)
+    if i >= 1:
+        head, _drop, tail = split_item_above(target)
+        return head, tail
+    pad, _drop = split_above_block(target)
+    pieces = list(pad.pieces)
+    nl_idx = next(
+        (k for k, p in enumerate(pieces) if isinstance(p, NewlineNode)),
+        -1,
+    )
+    if nl_idx < 0:
+        return Trivia(pieces), Trivia()
+    return Trivia(pieces[: nl_idx + 1]), Trivia(pieces[nl_idx + 1 :])
 
 
 def _set_above_pieces(
@@ -287,20 +301,22 @@ def _set_above_pieces(
 ) -> None:
     """Replace the comment block in item ``i``'s above-region.
 
-    Preserves any structural pad already present (the opening newline
-    + value indent) and only rewrites the above-block portion.
+    Preserves any structural framing already present (leading NL,
+    trailing value-indent WS) and only rewrites the comment block
+    between.
     """
-    target = _above_target(value, i)
-    pad = _ensure_pad(target, nl, ind)
-    above = Trivia(_render_above_block(raw_lines, nl, ind))
-    target.pieces = list(join_above_block(pad, above).pieces)
+    head, tail = _split_above_frame(value, i)
+    if not head.pieces and not tail.pieces:
+        head = Trivia([NewlineNode(nl)])
+        tail = Trivia([WhitespaceNode(ind)])
+    above = _render_above_block(raw_lines, nl, ind)
+    _above_target(value, i).pieces = [*head.pieces, *above, *tail.pieces]
 
 
-def _clear_above_pieces(value: ArrayValue, i: int, nl: str, ind: str) -> None:
-    """Strip the comment block from item ``i``'s above-region; keep pad."""
-    target = _above_target(value, i)
-    pad = _ensure_pad(target, nl, ind)
-    target.pieces = list(pad.pieces)
+def _clear_above_pieces(value: ArrayValue, i: int) -> None:
+    """Strip the comment block from item ``i``'s above-region; keep framing."""
+    head, tail = _split_above_frame(value, i)
+    _above_target(value, i).pieces = [*head.pieces, *tail.pieces]
 
 
 class ArrayLeadingView(_ArrayIntKeyedView[tuple[str, ...]]):
@@ -348,8 +364,6 @@ class ArrayLeadingView(_ArrayIntKeyedView[tuple[str, ...]]):
         _clear_above_pieces(
             self._arr._value,  # noqa: SLF001
             idx,
-            self._arr._doc_newline,  # noqa: SLF001
-            _slot_indent(self._arr),
         )
 
     @override

--- a/src/tomlrt/_array_comments.py
+++ b/src/tomlrt/_array_comments.py
@@ -404,9 +404,10 @@ def apply_comments(
 ) -> None:
     """Re-apply per-item comments after a structural reorder.
 
-    Writes EOL comments first (so leading writes can split a known
-    canonical EOL section out of the prev item's post_comma_trivia),
-    then leading blocks. Skips empty entries.
+    Leadings are written before EOLs: setting an EOL strips the
+    structural NL from the next item's leading (or ``final_trivia``
+    for the last item), so writing leadings second would leave
+    above-blocks without an opening NL.
     """
     items = arr._value.items  # noqa: SLF001
     n = len(items)
@@ -415,9 +416,9 @@ def apply_comments(
     nl = arr._doc_newline  # noqa: SLF001
     ind = _slot_indent(arr)
     for i in range(n):
+        if leadings[i]:
+            _set_above_pieces(arr._value, i, leadings[i], nl, ind)  # noqa: SLF001
+    for i in range(n):
         eol_i = eols[i]
         if eol_i is not None:
             _set_eol_raw(arr, i, eol_i)
-    for i in range(n):
-        if leadings[i]:
-            _set_above_pieces(arr._value, i, leadings[i], nl, ind)  # noqa: SLF001

--- a/src/tomlrt/_comments.py
+++ b/src/tomlrt/_comments.py
@@ -245,35 +245,54 @@ def _split_attached_block(
     return above, attached, indent
 
 
-def _extract_leading_block(leading: Trivia) -> tuple[str | None, ...]:
-    """Return the leading as a tuple of comment strings and ``None`` blanks.
+def _slot_is_doc_head(c: Container, slot: Slot) -> bool:
+    """True if ``slot`` is the document's head slot.
+
+    The head slot's above-blank region doubles as
+    :attr:`Document.preamble`.  Read/write APIs that expose the slot's
+    full leading must omit (resp. preserve) that region for the head
+    slot so that round-tripping a section's trivia doesn't migrate
+    the preamble into the section body.
+    """
+    doc = c._layout_root  # noqa: SLF001
+    return doc is not None and slot is doc._head  # noqa: SLF001
+
+
+def _read_leading_block(c: Container, slot: Slot) -> tuple[str | None, ...]:
+    """Decoded leading block of ``slot``, omitting any document preamble.
 
     Comment-bearing lines decode to their text; blank or whitespace-only
     lines become ``None``.  The slot's own trailing indent line (if any)
-    is excluded.  Includes both the above-blank groups and the attached
-    block in source order, separated by their original blank lines.
+    is excluded.
+
+    For the document head slot the above-blank prefix is omitted: it is
+    exposed separately via :attr:`Document.preamble`.  For every other
+    slot the full leading region is returned, in source order.
     """
-    above, attached, _indent = _split_attached_block(leading)
-    out: list[str | None] = []
-    for line in (*above, *attached):
-        text: str | None = None
-        for p in line:
-            if isinstance(p, CommentNode):
-                text = _decode_comment(p.text)
-                break
-        out.append(text)
-    return tuple(out)
+    above, attached, _indent = _split_attached_block(slot.leading)
+    lines = attached if _slot_is_doc_head(c, slot) else (*above, *attached)
+    return tuple(_line_to_comment(line) for line in lines)
 
 
-def _set_leading_block(leading: Trivia, block: tuple[str | None, ...], nl: str) -> None:
-    """Replace ``leading`` with ``block`` (comment strings and ``None`` blanks).
+def _write_leading_block(
+    c: Container, slot: Slot, block: tuple[str | None, ...]
+) -> None:
+    """Replace ``slot``'s leading with ``block``, preserving any preamble.
 
     The slot's own trailing indent (column offset) is preserved.  Comment
     lines re-use that indent as their prefix; blank lines are emitted as
     a bare newline with no trailing whitespace.
+
+    For the document head slot the above-blank prefix is left in place
+    so that :attr:`Document.preamble` survives a round-trip of
+    :func:`_read_leading_block`.
     """
-    _above, _attached, indent = _split_attached_block(leading)
+    above, _attached, indent = _split_attached_block(slot.leading)
     new_pieces: list[TriviaPiece] = []
+    if _slot_is_doc_head(c, slot):
+        for line in above:
+            new_pieces.extend(line)
+    nl = c._doc_newline  # noqa: SLF001
     for entry in block:
         if entry is None:
             new_pieces.append(NewlineNode(nl))
@@ -282,7 +301,7 @@ def _set_leading_block(leading: Trivia, block: tuple[str | None, ...], nl: str) 
             new_pieces.append(CommentNode(_encode_comment(entry)))
             new_pieces.append(NewlineNode(nl))
     new_pieces.extend(indent)
-    leading.pieces = new_pieces
+    slot.leading.pieces = new_pieces
 
 
 def _validate_block_seq(value: object, name: str) -> tuple[str | None, ...]:
@@ -373,20 +392,24 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
     :class:`LeadingCommentView`, which only exposes the trailing attached
     block.  Writing replaces the entire leading; the slot's indent is
     re-applied to each comment line and to the slot itself.
+
+    For the document's head slot the above-blank region (preamble) is
+    disjoint from this view: it is exposed and mutated via
+    :attr:`Document.preamble` instead.
     """
 
     __slots__ = ()
 
     @override
     def _present(self, slot: KVSlot) -> bool:
-        return bool(_extract_leading_block(slot.leading))
+        return bool(_read_leading_block(self._c, slot))
 
     @override
     def __getitem__(self, key: str) -> tuple[str | None, ...]:
         slot = self._slot(key)
         if slot is None:
             raise KeyError(key)
-        block = _extract_leading_block(slot.leading)
+        block = _read_leading_block(self._c, slot)
         if not block:
             raise KeyError(key)
         return block
@@ -398,17 +421,16 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
             msg = f"key {key!r} not in container"
             raise KeyError(msg)
         block = _validate_block_seq(value, "leading_block")
-        _set_leading_block(slot.leading, block, self._c._doc_newline)  # noqa: SLF001
+        _write_leading_block(self._c, slot, block)
 
     @override
     def __delitem__(self, key: str) -> None:
         slot = self._slot(key)
         if slot is None:
             raise KeyError(key)
-        block = _extract_leading_block(slot.leading)
-        if not block:
+        if not _read_leading_block(self._c, slot):
             raise KeyError(key)
-        _set_leading_block(slot.leading, (), self._c._doc_newline)  # noqa: SLF001
+        _write_leading_block(self._c, slot, ())
 
 
 def _header_slot(c: Container) -> StructuralHeaderSlot | None:
@@ -479,7 +501,7 @@ def _header_leading_block_get(c: Container) -> tuple[str | None, ...]:
     if h is None:
         msg = "container has no header to attach a leading block to"
         raise TOMLError(msg)
-    return _extract_leading_block(h.leading)
+    return _read_leading_block(c, h)
 
 
 def _header_leading_block_set(c: Container, value: tuple[str | None, ...]) -> None:
@@ -488,7 +510,7 @@ def _header_leading_block_set(c: Container, value: tuple[str | None, ...]) -> No
         msg = "container has no header to attach a leading block to"
         raise TOMLError(msg)
     block = _validate_block_seq(value, "header_leading_block")
-    _set_leading_block(h.leading, block, c._doc_newline)  # noqa: SLF001
+    _write_leading_block(c, h, block)
 
 
 def _validate_comment_seq(value: object, name: str) -> tuple[str, ...]:
@@ -511,15 +533,17 @@ def _validate_comment_seq(value: object, name: str) -> tuple[str, ...]:
     return tuple(out)
 
 
+def _line_to_comment(line: Iterable[TriviaPiece]) -> str | None:
+    """Decoded comment text for a line, or ``None`` if it has no comment."""
+    for p in line:
+        if isinstance(p, CommentNode):
+            return _decode_comment(p.text)
+    return None
+
+
 def _lines_to_comments(lines: Iterable[Iterable[TriviaPiece]]) -> tuple[str, ...]:
     """Extract one decoded comment per line that contains a CommentNode."""
-    out: list[str] = []
-    for line in lines:
-        for p in line:
-            if isinstance(p, CommentNode):
-                out.append(_decode_comment(p.text))
-                break
-    return tuple(out)
+    return tuple(c for line in lines if (c := _line_to_comment(line)) is not None)
 
 
 def _set_attached_block(leading: Trivia, comments: tuple[str, ...], nl: str) -> None:

--- a/src/tomlrt/_comments.py
+++ b/src/tomlrt/_comments.py
@@ -107,6 +107,24 @@ def _direct_kv_slot(c: Container, key: str) -> KVSlot | None:
     return None
 
 
+def _require_attached(c: Container) -> None:
+    """Reject comment-view mutation on a container with no slot stream.
+
+    Detached containers (e.g. ``Table.section()`` before assignment into
+    a `Document`) have no slot stream, so the comment views have nowhere
+    to store the mutation. Raise a clear `TOMLError` pointing at the
+    fix instead of a misleading ``KeyError`` from the internal slot
+    lookup.
+    """
+    if c._layout_root is None:  # noqa: SLF001
+        msg = (
+            "comments view is unavailable on a detached container; "
+            "attach the container to a Document first (e.g. doc[k] = table) "
+            "and then mutate doc[k].comments"
+        )
+        raise TOMLError(msg)
+
+
 _T = TypeVar("_T")
 
 
@@ -173,6 +191,7 @@ class EolCommentView(_SlotKeyedView[str]):
 
     @override
     def __setitem__(self, key: str, value: str) -> None:
+        _require_attached(self._c)
         slot = self._slot(key)
         if slot is None:
             msg = f"key {key!r} not in container"
@@ -182,6 +201,7 @@ class EolCommentView(_SlotKeyedView[str]):
 
     @override
     def __delitem__(self, key: str) -> None:
+        _require_attached(self._c)
         slot = self._slot(key)
         if slot is None or slot.eol.comment is None:
             raise KeyError(key)
@@ -361,6 +381,7 @@ class LeadingCommentView(_SlotKeyedView[tuple[str, ...]]):
 
     @override
     def __setitem__(self, key: str, value: tuple[str, ...]) -> None:
+        _require_attached(self._c)
         slot = self._slot(key)
         if slot is None:
             msg = f"key {key!r} not in container"
@@ -370,6 +391,7 @@ class LeadingCommentView(_SlotKeyedView[tuple[str, ...]]):
 
     @override
     def __delitem__(self, key: str) -> None:
+        _require_attached(self._c)
         slot = self._slot(key)
         if slot is None:
             raise KeyError(key)
@@ -416,6 +438,7 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
 
     @override
     def __setitem__(self, key: str, value: tuple[str | None, ...]) -> None:
+        _require_attached(self._c)
         slot = self._slot(key)
         if slot is None:
             msg = f"key {key!r} not in container"
@@ -425,6 +448,7 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
 
     @override
     def __delitem__(self, key: str) -> None:
+        _require_attached(self._c)
         slot = self._slot(key)
         if slot is None:
             raise KeyError(key)

--- a/src/tomlrt/_comments.py
+++ b/src/tomlrt/_comments.py
@@ -245,6 +245,70 @@ def _split_attached_block(
     return above, attached, indent
 
 
+def _extract_leading_block(leading: Trivia) -> tuple[str | None, ...]:
+    """Return the leading as a tuple of comment strings and ``None`` blanks.
+
+    Comment-bearing lines decode to their text; blank or whitespace-only
+    lines become ``None``.  The slot's own trailing indent line (if any)
+    is excluded.  Includes both the above-blank groups and the attached
+    block in source order, separated by their original blank lines.
+    """
+    above, attached, _indent = _split_attached_block(leading)
+    out: list[str | None] = []
+    for line in (*above, *attached):
+        text: str | None = None
+        for p in line:
+            if isinstance(p, CommentNode):
+                text = _decode_comment(p.text)
+                break
+        out.append(text)
+    return tuple(out)
+
+
+def _set_leading_block(leading: Trivia, block: tuple[str | None, ...], nl: str) -> None:
+    """Replace ``leading`` with ``block`` (comment strings and ``None`` blanks).
+
+    The slot's own trailing indent (column offset) is preserved.  Comment
+    lines re-use that indent as their prefix; blank lines are emitted as
+    a bare newline with no trailing whitespace.
+    """
+    _above, _attached, indent = _split_attached_block(leading)
+    new_pieces: list[TriviaPiece] = []
+    for entry in block:
+        if entry is None:
+            new_pieces.append(NewlineNode(nl))
+        else:
+            new_pieces.extend(indent)
+            new_pieces.append(CommentNode(_encode_comment(entry)))
+            new_pieces.append(NewlineNode(nl))
+    new_pieces.extend(indent)
+    leading.pieces = new_pieces
+
+
+def _validate_block_seq(value: object, name: str) -> tuple[str | None, ...]:
+    """Type-check a leading-block tuple; entries are ``str`` or ``None``."""
+    if isinstance(value, str):
+        msg = f"{name} must be an iterable of comment strings or None"
+        raise TypeError(msg)
+    if not isinstance(value, Iterable):
+        msg = f"{name} must be an iterable of comment strings or None"
+        raise TypeError(msg)
+    out: list[str | None] = []
+    for c in value:
+        if c is None:
+            out.append(None)
+            continue
+        if not isinstance(c, str):
+            msg = f"{name} entries must be str or None"
+            raise TypeError(msg)
+        if "\n" in c or "\r" in c:
+            msg = f"{name} entries must not contain a line terminator"
+            raise TOMLError(msg)
+        _validate_comment_text(c)
+        out.append(c)
+    return tuple(out)
+
+
 def _extract_leading_comments(leading: Trivia) -> tuple[str, ...]:
     """Return only the *attached* run of comment-bearing lines.
 
@@ -298,6 +362,53 @@ class LeadingCommentView(_SlotKeyedView[tuple[str, ...]]):
             kept.extend(line)
         kept.extend(indent)
         slot.leading.pieces = kept
+
+
+class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
+    """Mapping view over the full leading-trivia block of each direct key.
+
+    Entries are tuples of comment strings and ``None`` (one ``None`` per
+    blank line), in source order; the slot's own column indent is not
+    included.  This is the full-fidelity peer of
+    :class:`LeadingCommentView`, which only exposes the trailing attached
+    block.  Writing replaces the entire leading; the slot's indent is
+    re-applied to each comment line and to the slot itself.
+    """
+
+    __slots__ = ()
+
+    @override
+    def _present(self, slot: KVSlot) -> bool:
+        return bool(_extract_leading_block(slot.leading))
+
+    @override
+    def __getitem__(self, key: str) -> tuple[str | None, ...]:
+        slot = self._slot(key)
+        if slot is None:
+            raise KeyError(key)
+        block = _extract_leading_block(slot.leading)
+        if not block:
+            raise KeyError(key)
+        return block
+
+    @override
+    def __setitem__(self, key: str, value: tuple[str | None, ...]) -> None:
+        slot = self._slot(key)
+        if slot is None:
+            msg = f"key {key!r} not in container"
+            raise KeyError(msg)
+        block = _validate_block_seq(value, "leading_block")
+        _set_leading_block(slot.leading, block, self._c._doc_newline)  # noqa: SLF001
+
+    @override
+    def __delitem__(self, key: str) -> None:
+        slot = self._slot(key)
+        if slot is None:
+            raise KeyError(key)
+        block = _extract_leading_block(slot.leading)
+        if not block:
+            raise KeyError(key)
+        _set_leading_block(slot.leading, (), self._c._doc_newline)  # noqa: SLF001
 
 
 def _header_slot(c: Container) -> StructuralHeaderSlot | None:
@@ -361,6 +472,23 @@ def _header_leading_set(c: Container, value: tuple[str, ...]) -> None:
         raise TOMLError(msg)
     comments = _validate_comment_seq(value, "header_leading_comments")
     _set_attached_block(h.leading, comments, c._doc_newline)  # noqa: SLF001
+
+
+def _header_leading_block_get(c: Container) -> tuple[str | None, ...]:
+    h = _header_slot(c)
+    if h is None:
+        msg = "container has no header to attach a leading block to"
+        raise TOMLError(msg)
+    return _extract_leading_block(h.leading)
+
+
+def _header_leading_block_set(c: Container, value: tuple[str | None, ...]) -> None:
+    h = _header_slot(c)
+    if h is None:
+        msg = "container has no header to attach a leading block to"
+        raise TOMLError(msg)
+    block = _validate_block_seq(value, "header_leading_block")
+    _set_leading_block(h.leading, block, c._doc_newline)  # noqa: SLF001
 
 
 def _validate_comment_seq(value: object, name: str) -> tuple[str, ...]:
@@ -496,4 +624,4 @@ def _doc_epilogue_set(doc: Document, value: tuple[str, ...]) -> None:
     doc._trailing.pieces = new_pieces  # noqa: SLF001
 
 
-__all__ = ["EolCommentView", "LeadingCommentView"]
+__all__ = ["EolCommentView", "LeadingBlockView", "LeadingCommentView"]

--- a/src/tomlrt/_comments.py
+++ b/src/tomlrt/_comments.py
@@ -12,10 +12,10 @@ Two primary views per `Container`:
 
 Implementation notes:
 
-- Only direct-KV slots are exposed.  Dotted-implicit shared slots
-  (e.g. ``b.c = 1`` under ``[a]`` viewed from ``a``) are not
-  addressable through the container's comment view; the slot's
-  trivia is instead reachable through the dotted parent's view.
+- A slot is exposed under its leaf key on whichever container is its
+  immediate parent. For a plain ``key = value``, that's the explicit
+  section it sits in; for a dotted KV like ``b.c = 1`` under ``[a]``,
+  that's ``a["b"]`` (not ``a``).
 - Inline-table containers do not expose a comment view (TOML
   forbids comments inside an inline table).
 """
@@ -99,14 +99,10 @@ def _direct_kv_slot(c: Container, key: str) -> KVSlot | None:
     refs = c._index.get(key)  # noqa: SLF001
     if not refs:
         return None
+    target = (*c._path, key)  # noqa: SLF001
     for ref in refs:
         slot = ref.slot
-        if (
-            isinstance(slot, KVSlot)
-            and slot.host_path == c._path  # noqa: SLF001
-            and len(slot.key_parts) == 1
-            and slot.key_parts[0].value == key
-        ):
+        if isinstance(slot, KVSlot) and slot.host_path + slot.key == target:
             return slot
     return None
 

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -133,7 +133,12 @@ class Container(dict[str, Any]):
 
     @property
     def comments(self) -> EolCommentView:
-        """Mapping view of EOL comments on this container's direct keys."""
+        """Mapping view of EOL comments on this container's direct keys.
+
+        Mutating the view requires the container to be attached to a
+        `Document`; mutate via the attached view, not on a detached
+        ``Table.section()`` / ``Table.inline()``.
+        """
         if self._inline:
             msg = "comment API is not available on inline tables"
             raise TOMLError(msg)
@@ -147,6 +152,9 @@ class Container(dict[str, Any]):
         (no blank line between).  For the full block — including any
         above-blank groups and the blank-line structure between them — see
         :attr:`leading_block`.
+
+        Mutating the view requires the container to be attached to a
+        `Document`.
         """
         if self._inline:
             msg = "comment API is not available on inline tables"
@@ -166,6 +174,9 @@ class Container(dict[str, Any]):
         At the document's head slot, :attr:`Document.preamble` is
         disjoint from this view: reading omits the preamble lines,
         and writing preserves them.
+
+        Mutating the view requires the container to be attached to a
+        `Document`.
         """
         if self._inline:
             msg = "comment API is not available on inline tables"

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -162,6 +162,10 @@ class Container(dict[str, Any]):
         the slot's own column indent is implicit and re-applied on write.
         Full-fidelity peer of :attr:`leading_comments`, which exposes only
         the trailing attached run.
+
+        At the document's head slot, :attr:`Document.preamble` is
+        disjoint from this view: reading omits the preamble lines,
+        and writing preserves them.
         """
         if self._inline:
             msg = "comment API is not available on inline tables"
@@ -207,9 +211,9 @@ class Container(dict[str, Any]):
         peer of :attr:`header_leading_comments`, which exposes only the
         trailing attached run.
 
-        On the first slot in a document this overlaps with
-        :attr:`Document.preamble` — they read and write the same
-        underlying storage.
+        For the first section in a document, :attr:`Document.preamble`
+        is disjoint from this view: reading omits the preamble lines,
+        and writing preserves them.
         """
         return _header_leading_block_get(self)
 

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -1055,9 +1055,18 @@ class Table(Container):
     Every nested mapping in a document is a [`Table`][tomlrt.Table].
     `Table` is a `dict` subclass, so ``isinstance(t, dict)`` holds
     and it can be passed wherever a `dict` or `Mapping` is expected.
+
+    The same `Table` class backs both standard ``[section]`` blocks
+    and inline ``{x = 1}`` tables. Use [`is_inline`][tomlrt.Table.is_inline]
+    to tell them apart when walking a parsed document.
     """
 
     __slots__ = ()
+
+    @property
+    def is_inline(self) -> bool:
+        """True for inline ``{...}`` tables, False for ``[section]`` blocks."""
+        return self._inline
 
     @classmethod
     def section(cls, mapping: Mapping[str, TomlInput] | None = None) -> Table:

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -835,25 +835,19 @@ class Container(dict[str, Any]):
             if i == len(parts) - 1:
                 cur[parts[-1]] = value
                 return cur[parts[-1]]
-            if is_aot:
-                # Multi-component AoT install: walk implicit
-                # intermediates, then let __setitem__ handle the
-                # final binding through add_aot_entry.
-                for p in parts[i : len(parts) - 1]:
-                    implicit = Table()
-                    implicit._wire(  # noqa: SLF001
-                        layout_root=cur._layout_root,  # noqa: SLF001
-                        parent=cur,
-                        path=(*cur._path, p),  # noqa: SLF001
-                        owner=cur._owner_aot_entry,  # noqa: SLF001
-                    )
-                    dict.__setitem__(cur, p, implicit)
-                    cur = implicit
-                cur[parts[-1]] = value
-                return cur[parts[-1]]
-            sub = parts[i:]
-            assert isinstance(value, (Table, Mapping)) or value is None
-            return _layout_ops.attach_section_at(cur, sub, value)
+            # Build the implicit-table intermediates, then dispatch the
+            # final binding via __setitem__ so it flows through the
+            # standard Container dispatchers (_install_section /
+            # _attach_aot). Those already pick the right path for
+            # every source state — attached header-bearing sections
+            # clone via clone_section_as_section, attached implicit
+            # sources recurse via _install_attached_subtree, attached
+            # AoTs clone via clone_aot, detached / private values
+            # synthesise — so we don't need to second-guess the
+            # source state here.
+            anchor = _layout_ops.ensure_implicit_chain(cur, tuple(parts[i:-1]))
+            anchor[parts[-1]] = value
+            return anchor[parts[-1]]
         host = self if len(parts) == 1 else self.ensure_table(parts[:-1])
         host[parts[-1]] = value
         return host[parts[-1]]

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -64,9 +64,9 @@ from tomlrt._values import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
-    from _typeshed import SupportsKeysAndGetItem
+    from _typeshed import SupportsKeysAndGetItem, SupportsRichComparison
     from typing_extensions import Self
 
     from tomlrt._slots import AoTEntry, Slot, SlotRef
@@ -734,6 +734,35 @@ class Container(dict[str, Any]):
         self[key] = default
         return dict.__getitem__(self, key)
 
+    def sort(
+        self,
+        *,
+        key: Callable[[str], SupportsRichComparison] | None = None,
+        reverse: bool = False,
+    ) -> None:
+        """Sort direct child keys in place, preserving per-key trivia.
+
+        Mirrors ``list.sort`` / :meth:`AoT.sort`: keyword-only ``key``
+        / ``reverse``, stable, in-place. Works for sections, the
+        document root, and inline tables.
+
+        Raises:
+            ValueError: the proposed order places a leaf KV after a
+                structural section/AoT key (would re-bind it as
+                nested under the preceding section).
+        """
+        current = list(dict.keys(self))
+        if len(current) <= 1:
+            return
+        new_order = sorted(current, key=key, reverse=reverse)
+        if new_order == current:
+            return
+        if self._inline:
+            _inline_ops.reorder_inline(self, new_order)
+        elif self._layout_root is not None:
+            _layout_ops.reorder_container(self, new_order)
+        _reorder_dict_storage(self, new_order)
+
     @override
     def __ior__(  # type: ignore[override]
         self,
@@ -1089,6 +1118,19 @@ class Container(dict[str, Any]):
                     if saved_eol.trailing_ws is not None:
                         last_slot.eol.trailing_ws = saved_eol.trailing_ws
         return result
+
+
+def _reorder_dict_storage(c: Container, new_key_order: list[str]) -> None:
+    """Reorder ``c``'s dict storage in place to match ``new_key_order``.
+
+    Bypasses ``Container.__setitem__`` so no validation, slot rebuild,
+    or attach paths fire. ``new_key_order`` is trusted to be a
+    permutation of ``dict.keys(c)``.
+    """
+    values = [(k, dict.__getitem__(c, k)) for k in new_key_order]
+    dict.clear(c)
+    for k, v in values:
+        dict.__setitem__(c, k, v)
 
 
 def _populate_unattached(t: Container, mapping: Mapping[str, Any]) -> None:

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -1417,13 +1417,18 @@ def _install_attached_subtree(
     """Recursively install an attached implicit / Document source.
 
     Walks ``src_table.items()`` and re-installs each entry under
-    ``dst_parent`` using tuple-path :meth:`Container.install` so that
-    attached sections clone via ``clone_section_as_section`` and
-    AoTs clone via ``clone_aot``. Implicit chains stay implicit
-    (no ``[k]`` header is synthesised unless there are direct KVs to
-    host); when there *are* direct scalar / inline KVs at this level,
-    a ``Table.section`` snapshot is installed at ``dst_path`` to
-    carry them.
+    ``dst_parent``. Section / AoT children clone via tuple-path
+    :meth:`Container.install` (so attached sections preserve their
+    headers and AoTs clone slot-for-slot). Direct (non-structural)
+    entries at this implicit level are written as dotted KVs hosted
+    by ``dst_parent``'s nearest header-bearing ancestor, so the
+    source's dotted form is preserved on per-key clone.
+
+    Note: bucketing into directs vs structurals can reorder relative
+    to ``src_table.items()`` — at a given implicit level all dotted
+    leaves emit before any subsection. TOML is structurally
+    insensitive to that order; the dotted-form preservation is the
+    win.
     """
     direct_kvs: list[tuple[str, object]] = []
     structural: list[tuple[str, object]] = []
@@ -1434,10 +1439,7 @@ def _install_attached_subtree(
             direct_kvs.append((k, v))
 
     if direct_kvs:
-        snapshot = Table.section()
-        for k, v in direct_kvs:
-            snapshot[k] = _to_python(v)
-        dst_parent.install(dst_path, snapshot)
+        _install_dotted_direct_kvs(dst_parent, dst_path, direct_kvs)
 
     for k, v in structural:
         sub_path = (*dst_path, k)
@@ -1447,6 +1449,42 @@ def _install_attached_subtree(
             dst_parent.install(sub_path, v)
         elif isinstance(v, Container):
             _install_attached_subtree(dst_parent, sub_path, v)
+
+
+def _install_dotted_direct_kvs(
+    dst_parent: Container,
+    dst_path: tuple[str, ...],
+    direct_kvs: list[tuple[str, object]],
+) -> None:
+    """Emit each ``(k, v)`` in ``direct_kvs`` as a dotted KV under host.
+
+    ``host`` is the nearest header-bearing ancestor at-or-above
+    ``dst_parent`` (or the doc / AoT-entry root). Creates implicit
+    intermediates between host and the leaf as needed. Each value is
+    deep-cloned via ``_to_python`` + ``_synth_value`` so the source's
+    CST is not disturbed.
+    """
+    host: Container = dst_parent
+    while host._header_ref is None and host._parent is not None:  # noqa: SLF001
+        host = host._parent  # noqa: SLF001
+    parent_to_host = dst_parent._path[len(host._path) :]  # noqa: SLF001
+    layout_root = dst_parent._layout_root  # noqa: SLF001
+    owner = host._owner_aot_entry  # noqa: SLF001
+    for k, v in direct_kvs:
+        leaf_keypath = (*parent_to_host, *dst_path, k)
+        leaf_parent = _layout_ops.ensure_implicit_chain(host, leaf_keypath[:-1])
+        py = _to_python(v)
+        cst, decoded = _synth_value(
+            py,
+            layout_root=layout_root,
+            parent=leaf_parent,
+            path=(*host._path, *leaf_keypath),  # noqa: SLF001
+            owner=owner,
+        )
+        _layout_ops.install_dotted_kv_slot(
+            host, leaf_keypath, cst, leaf_parent=leaf_parent
+        )
+        dict.__setitem__(leaf_parent, k, decoded)
 
 
 def _to_python(v: Any) -> Any:

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -24,6 +24,7 @@ else:  # pragma: no cover -- backport for Python < 3.12
 from tomlrt import _inline_ops, _layout_ops
 from tomlrt._comments import (
     EolCommentView,
+    LeadingBlockView,
     LeadingCommentView,
     _direct_kv_slot,
     _doc_epilogue_get,
@@ -32,6 +33,8 @@ from tomlrt._comments import (
     _doc_preamble_set,
     _header_comment_get,
     _header_comment_set,
+    _header_leading_block_get,
+    _header_leading_block_set,
     _header_leading_get,
     _header_leading_set,
 )
@@ -138,11 +141,32 @@ class Container(dict[str, Any]):
 
     @property
     def leading_comments(self) -> LeadingCommentView:
-        """Mapping view of leading-comment blocks on this container's direct keys."""
+        """Mapping view of leading-comment blocks on this container's direct keys.
+
+        Returns only the *attached* comment run immediately above each key
+        (no blank line between).  For the full block — including any
+        above-blank groups and the blank-line structure between them — see
+        :attr:`leading_block`.
+        """
         if self._inline:
             msg = "comment API is not available on inline tables"
             raise TOMLError(msg)
         return LeadingCommentView(self)
+
+    @property
+    def leading_block(self) -> LeadingBlockView:
+        """Mapping view of full leading-trivia blocks on direct keys.
+
+        Each entry is a ``tuple[str | None, ...]`` of comment strings
+        interleaved with ``None`` (one per blank line), in source order;
+        the slot's own column indent is implicit and re-applied on write.
+        Full-fidelity peer of :attr:`leading_comments`, which exposes only
+        the trailing attached run.
+        """
+        if self._inline:
+            msg = "comment API is not available on inline tables"
+            raise TOMLError(msg)
+        return LeadingBlockView(self)
 
     @property
     def header_comment(self) -> str | None:
@@ -159,7 +183,11 @@ class Container(dict[str, Any]):
 
     @property
     def header_leading_comments(self) -> tuple[str, ...]:
-        """The leading comment block immediately above this container's header."""
+        """The attached comment block immediately above this container's header.
+
+        Excludes any above-blank groups — those are visible via
+        :attr:`header_leading_block`.
+        """
         return _header_leading_get(self)
 
     @header_leading_comments.setter
@@ -169,6 +197,29 @@ class Container(dict[str, Any]):
     @header_leading_comments.deleter
     def header_leading_comments(self) -> None:
         _header_leading_set(self, ())
+
+    @property
+    def header_leading_block(self) -> tuple[str | None, ...]:
+        """The full leading-trivia block above this container's header.
+
+        A ``tuple[str | None, ...]`` of comment strings interleaved with
+        ``None`` (one per blank line), in source order.  Full-fidelity
+        peer of :attr:`header_leading_comments`, which exposes only the
+        trailing attached run.
+
+        On the first slot in a document this overlaps with
+        :attr:`Document.preamble` — they read and write the same
+        underlying storage.
+        """
+        return _header_leading_block_get(self)
+
+    @header_leading_block.setter
+    def header_leading_block(self, value: tuple[str | None, ...]) -> None:
+        _header_leading_block_set(self, value)
+
+    @header_leading_block.deleter
+    def header_leading_block(self) -> None:
+        _header_leading_block_set(self, ())
 
     @property
     def _doc_newline(self) -> str:
@@ -1174,6 +1225,13 @@ class Document(Container):
         Setter accepts a sequence of bare comment texts (without the
         leading ``#``) and replaces the current preamble; assign ``()``
         to remove. Newlines inside any line are rejected.
+
+        On a document whose first slot is a section header or KV key, the
+        preamble is stored as the above-blank prefix of that slot's
+        leading trivia — the same storage that
+        :attr:`Table.header_leading_block` / :attr:`Container.leading_block`
+        expose for the first slot.  Writes through either path are
+        visible through the other.
         """
         return _doc_preamble_get(self)
 

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -353,6 +353,17 @@ class Container(dict[str, Any]):
         if isinstance(value, (bytes, bytearray)):
             msg = f"cannot assign bytes to TOML key {key!r}; use a string"
             raise TypeError(msg)
+        # Inline tables can't host sections / AoTs as values; check
+        # eagerly so the error fires at the actual point of mistake
+        # rather than deferring to the synth-path at attach time. Runs
+        # for both attached and detached inline factories.
+        if self._inline:
+            if isinstance(value, AoT):
+                msg = "Cannot store an array-of-tables inside an inline table"
+                raise TOMLError(msg)
+            if _is_section(value):
+                msg = "Cannot store a section-style table inside an inline-style table"
+                raise TOMLError(msg)
         # Unattached factory mode: dict-only storage, transplant on attach.
         if self._layout_root is None:
             dict.__setitem__(self, key, value)
@@ -695,12 +706,9 @@ class Container(dict[str, Any]):
     # ------------------------------------------------------------------
 
     def _inline_setitem(self, key: str, value: Any) -> None:
-        if isinstance(value, AoT):
-            msg = "Cannot store an array-of-tables inside an inline table"
-            raise TOMLError(msg)
-        if _is_section(value):
-            msg = "Cannot store a section-style table inside an inline-style table"
-            raise TOMLError(msg)
+        # ``__setitem__`` has already rejected ``AoT`` / section values
+        # for inline hosts. What remains is the live-attach gap for
+        # typed sub-containers.
         if not is_scalar(value) and not _is_synth_inline(value):
             msg = (
                 "live-attach of typed Container/Array/AoT into an inline table "
@@ -1523,20 +1531,19 @@ def _synth_value(
 
     Plain ``dict`` / ``Mapping`` → ``InlineTableValue`` + inline ``Table``.
     ``list`` / ``Array`` view → ``ArrayValue`` + ``Array``.
-    Section ``Container`` / ``AoT`` raise NIE.
+    Section ``Container`` / ``AoT`` raise ``TOMLError`` — those can't
+    live as inline values.
     Anything else raises ``TypeError`` (mentioning the type name and
     the prefix ``"Cannot convert"``).
     """
     if is_scalar(v):
         return coerce_scalar(v), v
     if isinstance(v, AoT):
-        msg = "live-attach of AoT through value synthesis is not supported"
-        raise NotImplementedError(msg)
+        msg = "Cannot store an array-of-tables inside an inline table"
+        raise TOMLError(msg)
     if _is_section(v):
-        msg = (
-            "live-attach of section Container through value synthesis is not supported"
-        )
-        raise NotImplementedError(msg)
+        msg = "Cannot store a section-style table inside an inline-style table"
+        raise TOMLError(msg)
     # Unattached inline Container or Array — live-attach: rehome the
     # existing object (so the user's reference stays the document's
     # view) instead of synthesising a fresh one. Inline tables that

--- a/src/tomlrt/_inline_ops.py
+++ b/src/tomlrt/_inline_ops.py
@@ -34,6 +34,8 @@ from tomlrt._trivia import (
     Trivia,
     WhitespaceNode,
     clone_trivia,
+    join_above_block,
+    split_above_block,
     trivia_has_comment,
 )
 from tomlrt._values import InlineTableEntry, inter_item_separator, make_keyparts
@@ -265,4 +267,77 @@ def _fix_head_after_delete(iv: InlineTableValue, removed_idx: int) -> None:
     iv.entries[0].leading = Trivia()
 
 
-__all__ = ["append_entry", "delete_entry", "replace_entry_value"]
+def reorder_inline(c: Container, new_key_order: list[str]) -> None:
+    """Reorder direct children of an inline-table container.
+
+    Permutes ``InlineTableValue.entries`` so that the c-direct-child
+    keys appear in ``new_key_order``. Each entry's above-block (the
+    comment block visually attached to it; lives in ``header_trivia``
+    for entries[0]) travels with the entry. Positional state — the
+    inter-entry pad, ``has_comma``, ``post_comma_trivia``, ``trailing``
+    — stays at its position, so e.g. the entry that ends up at the
+    last position correctly drops its trailing comma.
+
+    Foreign entries (whose key path doesn't start with c's prefix —
+    only possible when c is a dotted-inner navigator) keep their
+    absolute positions; only owned positions are reordered.
+
+    ``new_key_order`` is trusted to be a permutation of
+    ``dict.keys(c)``. Only mutates the CST; dict storage is the
+    caller's responsibility.
+    """
+    root = _outermost_inline(c)
+    iv = root._value  # noqa: SLF001
+    assert iv is not None
+
+    prefix = c._path[len(root._path) :]  # noqa: SLF001
+    plen = len(prefix)
+
+    blocks: dict[str, list[InlineTableEntry]] = {k: [] for k in new_key_order}
+    owned_positions: list[int] = []
+    for i, e in enumerate(iv.entries):
+        kp = tuple(p.value for p in e.key_parts)
+        if len(kp) > plen and kp[:plen] == prefix and kp[plen] in blocks:
+            blocks[kp[plen]].append(e)
+            owned_positions.append(i)
+
+    if len(owned_positions) <= 1:
+        return
+
+    # Snapshot positional state (stays at position) and above-block
+    # (travels with entry) for each owned position. entries[0]'s
+    # above-block lives in iv.header_trivia under the canonical model.
+    pos_state: dict[int, tuple[Trivia, bool, Trivia, Trivia]] = {}
+    above_by_entry: dict[int, Trivia] = {}
+    for i in owned_positions:
+        e = iv.entries[i]
+        src = iv.header_trivia if i == 0 else e.leading
+        pad, above = split_above_block(src)
+        pos_state[i] = (pad, e.has_comma, e.post_comma_trivia, e.trailing)
+        above_by_entry[id(e)] = above
+
+    new_owned = [e for k in new_key_order for e in blocks[k]]
+    new_entries = list(iv.entries)
+    for pos, e in zip(owned_positions, new_owned, strict=True):
+        new_entries[pos] = e
+    iv.entries = new_entries
+
+    # Restore positional state, re-stitch each entry's leading to
+    # positional_pad + its travelling above-block. The head entry's
+    # above-block goes into iv.header_trivia; its leading stays empty
+    # under the canonical model.
+    for pos in owned_positions:
+        e = iv.entries[pos]
+        pad, has_comma, post_comma, trailing = pos_state[pos]
+        e.has_comma = has_comma
+        e.post_comma_trivia = post_comma
+        e.trailing = trailing
+        above = above_by_entry[id(e)]
+        if pos == 0:
+            iv.header_trivia = join_above_block(pad, above)
+            e.leading = Trivia()
+        else:
+            e.leading = join_above_block(pad, above)
+
+
+__all__ = ["append_entry", "delete_entry", "reorder_inline", "replace_entry_value"]

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1691,8 +1691,9 @@ def clone_aot_entry(
     Returns the new ``Table`` view.
     """
     if isinstance(src, AoTEntry):
-        src_entry: AoTEntry = src
-        src_layout_root: Document | None = None
+        src_entry = src
+        src_layout_root = None
+        src_slots: list[Slot] = list(src_entry.entry_slots)
     else:
         owner = src._owner_aot_entry  # noqa: SLF001
         if owner is None:  # pragma: no cover
@@ -1700,11 +1701,15 @@ def clone_aot_entry(
             raise RuntimeError(msg)
         src_entry = owner
         src_layout_root = src._layout_root  # noqa: SLF001
+        # _gather_subtree_slots (not just entry.entry_slots) so nested
+        # ``[[a.x]]`` entries living physically inside this entry's
+        # body come along — entry_slots only holds the entry's *own*
+        # slots, not those owned by nested AoTEntries.
+        src_slots = _gather_subtree_slots(src)
 
     layout_root = aot._layout_root  # noqa: SLF001
     path = aot._path  # noqa: SLF001
     target_path = dst_path if dst_path is not None else path
-    src_slots = list(src_entry.entry_slots)
     same_aot_clone = target_path == src_entry.path and src_layout_root is layout_root
     return _install_cloned_aot_entry(
         aot,
@@ -1740,7 +1745,6 @@ def _install_cloned_structural_block(
         entry_table=table,
         cloned_slots=cloned_slots[1:],
         target_prefix=target_path,
-        body_owner=owner,
         doc=doc,
     )
 
@@ -1889,12 +1893,14 @@ def clone_aot_entry_as_table(
     return _install_cloned_section(parent, key, src_slots, src_entry.path)
 
 
-def _gather_section_slots(src_table: Container) -> list[Slot]:
-    """Collect a standard section's owned slots in doc-stream order.
+def _gather_subtree_slots(src_table: Container) -> list[Slot]:
+    """Collect a container subtree's owned slots in doc-stream order.
 
-    Includes the section's own header, every direct/dotted KV slot,
-    and every nested sub-section's header + KV slots — i.e. the
-    entire physical body of ``src_table``.
+    Includes the container's own header, every direct/dotted KV slot,
+    every nested sub-section's header + KV slots, and every nested
+    ``[[a.x]]`` aot-entry's header + KV slots — i.e. the entire
+    physical body of ``src_table``. Works on both standard sections
+    and AoT-entry tables (both expose a ``_header_ref``).
     """
     assert src_table._header_ref is not None  # noqa: SLF001
 
@@ -1930,7 +1936,7 @@ def clone_table_as_aot_entry(
     section path to ``aot._path``. Preserves per-slot leading / EOL
     / lexeme bytes (so per-section comments survive).
     """
-    src_slots = _gather_section_slots(src_table)
+    src_slots = _gather_subtree_slots(src_table)
     if not isinstance(src_slots[0], StructuralHeaderSlot):  # pragma: no cover
         msg = "Source section's first owned slot is not a header"
         raise AssertionError(msg)  # noqa: TRY004
@@ -1959,7 +1965,7 @@ def clone_section_as_section(
     by deep-cloning every owned slot and rebasing paths from
     ``src_table._path`` to ``parent._path + (key,)``.
     """
-    src_slots = _gather_section_slots(src_table)
+    src_slots = _gather_subtree_slots(src_table)
     if not isinstance(src_slots[0], StructuralHeaderSlot):  # pragma: no cover
         msg = "Source section's first owned slot is not a header"
         raise AssertionError(msg)  # noqa: TRY004
@@ -2021,43 +2027,63 @@ def _clone_entry_slots(
     keeps physical ownership coherent). ``new_entry`` is the
     AoTEntry the cloned slots are *logically* owned by — used for
     the head's ``entry`` back-pointer and for the ``entry_slots``
-    membership list, and propagated to any nested aot-entry header
-    in the body.
+    membership list.
+
+    Nested aot-entry headers inside the body keep their AoT shape:
+    a fresh `AoTEntry` is allocated per unique source entry found
+    in the body, cloned slots are repointed to it, and the
+    discriminator (`StructuralHeaderSlot.entry`) is preserved so
+    ``_populate_entry_views`` can rebuild the AoT view. Without
+    this, cross-doc whole-section copy would downgrade nested
+    ``[[a.x]]`` to a duplicated ``[a.x]`` (issue #108).
 
     ``dst_newline`` is the destination document's line ending; every
     cloned slot's structural-newline trivia is retargeted to it so a
     cross-document graft does not leave alien ``\r\n`` / ``\n``
     pieces behind in the destination's slot stream.
     """
+    body_start = 1 if has_header else 0
+    nested_entry_map: dict[int, AoTEntry] = {}
+    if has_header and new_entry is not None:
+        head_src = src_slots[0]
+        assert isinstance(head_src, StructuralHeaderSlot)
+        if head_src.entry is not None:
+            nested_entry_map[id(head_src.entry)] = new_entry
+    for s in src_slots[body_start:]:
+        if not isinstance(s, StructuralHeaderSlot) or s.entry is None:
+            continue
+        if id(s.entry) in nested_entry_map:
+            continue
+        nested_entry_map[id(s.entry)] = AoTEntry(
+            path=_rebase_path(s.entry.path, src_prefix, target_prefix),
+            ordinal=s.entry.ordinal,
+        )
+
     cloned: list[Slot] = []
     for s in src_slots:
         c: Slot = copy.deepcopy(s)
         c._prev = None  # noqa: SLF001
         c._next = None  # noqa: SLF001
         retarget_slot_newlines(c, dst_newline)
+        src_owner = s.owner_aot_entry
+        mapped = nested_entry_map.get(id(src_owner)) if src_owner else None
+        dst_owner = mapped if mapped is not None else body_owner
         if isinstance(c, KVSlot):
-            c.owner_aot_entry = body_owner
+            c.owner_aot_entry = dst_owner
             c.host_path = _rebase_path(c.host_path, src_prefix, target_prefix)
         elif isinstance(c, StructuralHeaderSlot):
-            c.owner_aot_entry = body_owner
+            assert isinstance(s, StructuralHeaderSlot)
+            c.owner_aot_entry = dst_owner
             c.path = _rebase_path(c.path, src_prefix, target_prefix)
             c.key_parts = make_keyparts(c.path)
             c.key_seps = ["."] * (len(c.key_parts) - 1)
-            # Nested aot-entry header in the body — repoint to new
-            # owning entry. Non-aot (table) headers stay as-is.
-            if c.entry is not None:
-                c.entry = new_entry
+            if s.entry is not None:
+                c.entry = nested_entry_map.get(id(s.entry))
         cloned.append(c)
-        if new_entry is not None:
-            new_entry.entry_slots.append(c)
+        filing_entry = mapped if mapped is not None else new_entry
+        if filing_entry is not None:
+            filing_entry.entry_slots.append(c)
 
-    if not has_header or not cloned:
-        return cloned
-    head = cloned[0]
-    assert isinstance(head, StructuralHeaderSlot)
-    head.entry = new_entry
-    if new_entry is not None:
-        head.owner_aot_entry = new_entry
     return cloned
 
 
@@ -2079,7 +2105,6 @@ def _populate_entry_views(
     entry_table: Container,
     cloned_slots: list[Slot],
     target_prefix: tuple[str, ...],
-    body_owner: AoTEntry | None,
     doc: Document,
 ) -> None:
     """Walk cloned non-header slots, building child Container views.
@@ -2087,17 +2112,29 @@ def _populate_entry_views(
     Mirrors the parser's slot-builder for an entry: KV slots file
     refs into their host container; sub-section headers create child
     Containers under the entry root and file own-header refs +
-    parent-binding refs.
+    parent-binding refs. Nested ``[[a.b]]`` aot-entry headers are
+    handled too: a fresh `AoT` view (and entry `Table`) is created
+    or extended at the rebased path so cross-doc graft preserves
+    AoT structure.
+
+    Owner inheritance: every newly created container inherits its
+    parent's ``_owner_aot_entry``, which matches how the parser
+    resolves implicit containers under an entry. The caller wires
+    the root ``entry_table`` with the correct owner.
 
     Decoded Python values are derived from each slot's (already
     deep-cloned) ``Value`` via ``_decode_value`` — never aliased
     from the source dict — so the destination view is fully
     independent of the source.
     """
+    from tomlrt._array import AoT  # noqa: PLC0415
     from tomlrt._build import _decode_value  # noqa: PLC0415
     from tomlrt._container import Table  # noqa: PLC0415
 
     # path -> Container for every container in the entry sub-tree.
+    # When a new AoT entry opens, its descendant entries are evicted
+    # so re-opened sub-paths (e.g. ``[a.x.sub]`` repeated under each
+    # ``[[a.x]]`` entry) resolve to a fresh container per entry.
     containers: dict[tuple[str, ...], Container] = {target_prefix: entry_table}
 
     def _ensure_container(path: tuple[str, ...]) -> Container:
@@ -2110,29 +2147,75 @@ def _populate_entry_views(
             if cur_path in containers:
                 cur = containers[cur_path]
                 continue
-            child = _init_implicit_table(doc, cur_path, cur, body_owner)
+            existing = cur.get(comp)
+            if isinstance(existing, AoT) and existing:
+                cur = existing[-1]
+                containers[cur_path] = cur
+                continue
+            child = _init_implicit_table(
+                doc,
+                cur_path,
+                cur,
+                cur._owner_aot_entry,  # noqa: SLF001
+            )
             containers[cur_path] = child
             dict.__setitem__(cur, comp, child)
             cur = child
         return cur
 
+    def _evict_subtree(prefix: tuple[str, ...]) -> None:
+        """Drop cached descendants of ``prefix`` (exclusive).
+
+        Called when a new AoT entry opens — the previous entry's
+        ``[a.x.sub]`` containers must not be reused by a later
+        ``[a.x.sub]`` belonging to the new entry.
+        """
+        n = len(prefix)
+        stale = [p for p in containers if len(p) > n and p[:n] == prefix]
+        for p in stale:
+            del containers[p]
+
     for s in cloned_slots:
         if isinstance(s, StructuralHeaderSlot):
+            if s.kind == "aot-entry":
+                assert s.entry is not None
+                aot_path = s.path
+                parent_view = _ensure_container(aot_path[:-1])
+                name = aot_path[-1]
+                aot = parent_view.get(name)
+                if aot is None:
+                    aot = AoT()
+                    aot._layout_root = doc  # noqa: SLF001
+                    aot._path = aot_path  # noqa: SLF001
+                    aot._parent = parent_view  # noqa: SLF001
+                    dict.__setitem__(parent_view, name, aot)
+                assert isinstance(aot, AoT)
+                ent_table = Table()
+                ent_table._wire(  # noqa: SLF001
+                    layout_root=doc,
+                    parent=parent_view,
+                    path=aot_path,
+                    owner=s.entry,
+                )
+                ent_table._header_ref = record_ref(ent_table, s)  # noqa: SLF001
+                ent_table._body_tail = s  # noqa: SLF001
+                record_ref(parent_view, s)
+                list.append(aot, ent_table)
+                _evict_subtree(aot_path)
+                containers[aot_path] = ent_table
+                continue
             assert s.kind == "table"
             container = _ensure_container(s.path)
-            own_ref = SlotRef(slot=s, container=container)
-            container._refs.append(own_ref)  # noqa: SLF001
-            container._header_ref = own_ref  # noqa: SLF001
+            container._header_ref = record_ref(container, s)  # noqa: SLF001
             if s.path == target_prefix:
                 continue
-            parent_path = s.path[:-1]
-            parent_view = _ensure_container(parent_path)
-            binding = SlotRef(slot=s, container=parent_view)
-            _file_ref_at_tail(parent_view, binding)
+            parent_view = _ensure_container(s.path[:-1])
+            record_ref(parent_view, s)
             continue
         assert isinstance(s, KVSlot)
         host = _ensure_container(s.host_path)
         slot_value = s.value
+        host_owner = host._owner_aot_entry  # noqa: SLF001
         if len(s.key_parts) == 1:
             key = s.key_parts[0].value
             kv_ref = SlotRef(slot=s, container=host)
@@ -2142,7 +2225,7 @@ def _populate_entry_views(
                 layout_root=doc,
                 parent=host,
                 path=(*host._path, key),  # noqa: SLF001
-                owner=body_owner,
+                owner=host_owner,
             )
             dict.__setitem__(host, key, decoded)
         else:
@@ -2152,7 +2235,12 @@ def _populate_entry_views(
                 ref = SlotRef(slot=s, container=cur)
                 _file_ref_at_tail(cur, ref)
                 if comp not in cur:
-                    sub = _init_implicit_table(doc, (*cur._path, comp), cur, body_owner)  # noqa: SLF001
+                    sub = _init_implicit_table(
+                        doc,
+                        (*cur._path, comp),  # noqa: SLF001
+                        cur,
+                        host_owner,
+                    )
                     containers[sub._path] = sub  # noqa: SLF001
                     dict.__setitem__(cur, comp, sub)
                 nxt = dict.__getitem__(cur, comp)
@@ -2168,7 +2256,7 @@ def _populate_entry_views(
                 layout_root=doc,
                 parent=cur,
                 path=(*cur._path, leaf_key),  # noqa: SLF001
-                owner=body_owner,
+                owner=host_owner,
             )
             dict.__setitem__(cur, leaf_key, decoded)
 
@@ -2589,7 +2677,6 @@ def replace_aot_entry_with_clone(
         entry_table=dst_entry_table,
         cloned_slots=cloned_body,
         target_prefix=path,
-        body_owner=dst_entry,
         doc=doc,
     )
 

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1535,16 +1535,19 @@ def _maybe_demote_synthetic_empty_header(parent: Container) -> None:
 
 
 def _split_leading_structural(leading: Trivia) -> tuple[Trivia, Trivia]:
-    """Split a leading-trivia stream into (structural-prefix, comment-remainder).
+    """Split a leading-trivia stream into (structural-prefix, slot-remainder).
 
     The structural prefix is the run of whitespace and newline pieces
-    before the first comment piece (if any). The remainder starts at
-    the first comment piece and includes everything after it. If
-    there is no comment piece, the whole leading is structural and
-    the remainder is empty.
+    that precedes the first comment piece **and** the slot's own
+    column-offset indent (trailing whitespace-only piece on the slot's
+    own line, if any). The remainder starts at the first comment piece
+    if one exists, otherwise at that trailing indent. Both the comment
+    block and the slot's own indent travel with the slot — only the
+    blank-line / indentation separator between *peers* stays positional.
 
-    Used by AoT reorder: structural separators stay positional;
-    comment remainders travel with their entry.
+    Used by AoT reorder and cross-doc clone: structural separators
+    stay positional; comments and the slot's own indent travel with
+    the slot.
     """
     pieces = leading.pieces
     cut = len(pieces)
@@ -1552,6 +1555,12 @@ def _split_leading_structural(leading: Trivia) -> tuple[Trivia, Trivia]:
         if isinstance(p, CommentNode):
             cut = i
             break
+    # Rescue the slot's own column indent (trailing whitespace-only
+    # piece on the slot's own line, if any) into the remainder so it
+    # travels with the slot. When a comment was already found this is
+    # a no-op: the trailing whitespace is past the cut already.
+    if cut > 0 and cut == len(pieces) and isinstance(pieces[-1], WhitespaceNode):
+        cut -= 1
     return Trivia(list(pieces[:cut])), Trivia(list(pieces[cut:]))
 
 

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -2641,7 +2641,7 @@ def replace_aot_entry_with_clone(
     assert dst_entry is not None
     assert src_entry is not None
 
-    src_slots = list(src_entry.entry_slots)
+    src_slots = _gather_subtree_slots(src_entry_table)
     src_prefix = src_entry.path
 
     # Save the destination header (we keep it in place, only its body
@@ -2653,6 +2653,7 @@ def replace_aot_entry_with_clone(
     # Pre-clone source body before any destructive cleanup, so a clone
     # failure can't leave the destination half-emptied. Also covers
     # the source-inside-destination case (e.g. self-nested clone).
+    prev_count = len(dst_entry.entry_slots)
     cloned_body = (
         _clone_entry_slots(
             src_slots[1:],
@@ -2666,11 +2667,11 @@ def replace_aot_entry_with_clone(
         if len(src_slots) > 1
         else []
     )
-    # _clone_entry_slots appended the cloned slots to dst_entry's
-    # entry_slots prematurely; we splice them in below, so back them
-    # out to keep ownership state consistent during clear().
-    if cloned_body:
-        dst_entry.entry_slots = dst_entry.entry_slots[: -len(cloned_body)]
+    # ``_clone_entry_slots`` files dst-owned slots onto
+    # ``dst_entry.entry_slots`` straight away. Defer them until after
+    # ``clear()`` so it sees the pre-clone state of the entry.
+    new_dst_slots = dst_entry.entry_slots[prev_count:]
+    del dst_entry.entry_slots[prev_count:]
 
     # Reuse the structural-delete path to tear down the destination's
     # body: orphans held sub-sections / AoTs into a PrivateRoot,
@@ -2682,7 +2683,7 @@ def replace_aot_entry_with_clone(
     assert dst_entry.entry_slots == [dst_header]
 
     _splice_block_after(cloned_body, dst_header, doc)
-    dst_entry.entry_slots.extend(cloned_body)
+    dst_entry.entry_slots.extend(new_dst_slots)
 
     # Rebuild views / dict storage from the cloned body.
     _populate_entry_views(

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1512,6 +1512,22 @@ def _split_leading_structural(leading: Trivia) -> tuple[Trivia, Trivia]:
     return Trivia(list(pieces[:cut])), Trivia(list(pieces[cut:]))
 
 
+def _retarget_header_separator(
+    header: StructuralHeaderSlot,
+    new_separator: Trivia,
+) -> None:
+    """Replace ``header.leading``'s structural prefix while keeping comments.
+
+    A cloned header arrives carrying the source document's spacing
+    (blank-line gap, indentation) plus any header-leading comments.
+    The destination wants its own spacing convention to drive layout
+    but must not lose comments that semantically belong to the
+    section being copied.
+    """
+    _structural, remainder = _split_leading_structural(header.leading)
+    header.leading = Trivia([*new_separator.pieces, *remainder.pieces])
+
+
 def _build_section_leading(doc: Document) -> Trivia:
     """Trivia for a fresh section header.
 
@@ -1794,13 +1810,9 @@ def _install_cloned_aot_entry(
     assert isinstance(head, StructuralHeaderSlot)
     cloned_header: StructuralHeaderSlot = head
     if ordinal == 0:
-        _structural, remainder = _split_leading_structural(cloned_header.leading)
-        sep = _build_section_leading(doc)
-        cloned_header.leading = Trivia([*sep.pieces, *remainder.pieces])
+        _retarget_header_separator(cloned_header, _build_section_leading(doc))
     elif rewrite_separator:
-        _structural, remainder = _split_leading_structural(cloned_header.leading)
-        sep = _aot_separator(aot, doc)
-        cloned_header.leading = Trivia([*sep.pieces, *remainder.pieces])
+        _retarget_header_separator(cloned_header, _aot_separator(aot, doc))
     # else: keep source leading verbatim (cross-doc / cross-key).
 
     entry_table = Table()
@@ -1855,7 +1867,7 @@ def _install_cloned_section(
     head = cloned_slots[0]
     assert isinstance(head, StructuralHeaderSlot)
     cloned_header: StructuralHeaderSlot = head
-    cloned_header.leading = _build_section_leading(doc)
+    _retarget_header_separator(cloned_header, _build_section_leading(doc))
 
     section = Table.section()
     _install_cloned_structural_block(

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -32,6 +32,7 @@ import contextlib
 import copy
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from tomlrt._comments import _split_attached_block
 from tomlrt._kind import _Kind
 from tomlrt._scalar import is_scalar
 from tomlrt._slots import (
@@ -1535,48 +1536,42 @@ def _maybe_demote_synthetic_empty_header(parent: Container) -> None:
 
 
 def _split_leading_structural(leading: Trivia) -> tuple[Trivia, Trivia]:
-    """Split a leading-trivia stream into (structural-prefix, slot-remainder).
+    """Split a leading-trivia stream into (positional-prefix, slot-remainder).
 
-    The structural prefix is the run of whitespace and newline pieces
-    that precedes the first comment piece **and** the slot's own
-    column-offset indent (trailing whitespace-only piece on the slot's
-    own line, if any). The remainder starts at the first comment piece
-    if one exists, otherwise at that trailing indent. Both the comment
-    block and the slot's own indent travel with the slot — only the
-    blank-line / indentation separator between *peers* stays positional.
+    The positional prefix is the run of "above-blank" lines (preamble
+    or archived comment blocks separated from the slot by a blank
+    line) plus any pure-structural blanks; it stays at the slot's
+    current doc-stream position when the slot moves. The remainder
+    is the attached comment block (immediately above the slot, with
+    no blank line between) plus the slot's own column-offset indent;
+    it travels with the slot.
 
-    Used by AoT reorder and cross-doc clone: structural separators
-    stay positional; comments and the slot's own indent travel with
-    the slot.
+    Used by AoT reorder (rotates positional prefixes among entries
+    while remainders travel with their entry) and by cross-doc clone
+    (which drops the positional prefix entirely — preamble belongs
+    to the source document, not the section being copied).
     """
     pieces = leading.pieces
-    cut = len(pieces)
-    for i, p in enumerate(pieces):
-        if isinstance(p, CommentNode):
-            cut = i
-            break
-    # Rescue the slot's own column indent (trailing whitespace-only
-    # piece on the slot's own line, if any) into the remainder so it
-    # travels with the slot. When a comment was already found this is
-    # a no-op: the trailing whitespace is past the cut already.
-    if cut > 0 and cut == len(pieces) and isinstance(pieces[-1], WhitespaceNode):
-        cut -= 1
-    return Trivia(list(pieces[:cut])), Trivia(list(pieces[cut:]))
+    _above, attached, indent = _split_attached_block(leading)
+    remainder: list[TriviaPiece] = []
+    for line in attached:
+        remainder.extend(line)
+    remainder.extend(indent)
+    cut = len(pieces) - len(remainder)
+    return Trivia(list(pieces[:cut])), Trivia(remainder)
 
 
 def _retarget_header_separator(
     header: StructuralHeaderSlot,
     new_separator: Trivia,
 ) -> None:
-    """Replace ``header.leading``'s structural prefix while keeping comments.
+    """Replace ``header.leading``'s positional prefix with ``new_separator``.
 
-    A cloned header arrives carrying the source document's spacing
-    (blank-line gap, indentation) plus any header-leading comments.
-    The destination wants its own spacing convention to drive layout
-    but must not lose comments that semantically belong to the
-    section being copied.
+    See :func:`_split_leading_structural`: the slot's attached
+    comments and own indent are kept; the source's positional
+    prefix is dropped.
     """
-    _structural, remainder = _split_leading_structural(header.leading)
+    _positional, remainder = _split_leading_structural(header.leading)
     header.leading = Trivia([*new_separator.pieces, *remainder.pieces])
 
 

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -3062,6 +3062,161 @@ def _move_slots_to_anchor(
             c._body_tail = _recompute_body_tail(c)  # noqa: SLF001
 
 
+def _direct_child_key(
+    slot: Slot, parent_path: tuple[str, ...], parent_plen: int
+) -> str | None:
+    """Return the direct child key of ``parent_path`` that ``slot`` binds, or None.
+
+    Determined by the slot's binding root: ``path`` for a structural
+    header, ``(*host_path, key_parts[0])`` for a KV. Returns the
+    first path component beyond ``parent_path`` if the binding root
+    starts with ``parent_path`` and is strictly deeper, else None.
+    """
+    if isinstance(slot, StructuralHeaderSlot):
+        root: tuple[str, ...] = tuple(slot.path)
+    elif isinstance(slot, KVSlot):
+        root = (*slot.host_path, slot.key_parts[0].value)
+    else:
+        return None
+    if len(root) > parent_plen and root[:parent_plen] == parent_path:
+        return root[parent_plen]
+    return None
+
+
+def reorder_container(c: Container, new_key_order: list[str]) -> None:
+    """Reorder ``c``'s direct children to ``new_key_order``.
+
+    ``new_key_order`` is trusted to be a permutation of
+    ``dict.keys(c)``. Each key's slots — KV slots filed under the
+    key, plus any header / body / entry slots of a child section or
+    AoT, gathered from anywhere in the doc-stream — are spliced
+    together as one contiguous block at the key's new position. All
+    slots' leadings are preserved as-is, except the head of each
+    key's block (which receives the *positional separator* recorded
+    at its new position, plus the head slot's own attached-comment
+    remainder).
+
+    Non-contiguous keys (e.g. ``[a]; [other]; [a.sub]`` where 'a'
+    has two runs at root) are handled by collecting both runs and
+    splicing them together. Foreign slots interleaved in the owned
+    span are pushed out of the way to wherever the splice leaves
+    them — typically just after the reordered region.
+
+    Only mutates the CST; dict storage is the caller's responsibility.
+
+    Raises:
+        ValueError: the proposed order places a leaf KV after a
+            structural section/AoT key (would re-bind it as nested).
+    """
+    doc = c._layout_root  # noqa: SLF001
+    assert doc is not None
+
+    c_path = c._path  # noqa: SLF001
+    c_plen = len(c_path)
+
+    # 1. Bucket slots by direct-child key, in doc-stream order. Also
+    # capture each key's first-appearance physical order — the basis
+    # for positional separator snapshots below.
+    blocks: dict[str, list[Slot]] = {k: [] for k in new_key_order}
+    physical_order: list[str] = []
+    seen_in_physical: set[str] = set()
+    cur: Slot | None = doc._head  # noqa: SLF001
+    while cur is not None:
+        bind_key = _direct_child_key(cur, c_path, c_plen)
+        if bind_key is not None and bind_key in blocks:
+            blocks[bind_key].append(cur)
+            if bind_key not in seen_in_physical:
+                physical_order.append(bind_key)
+                seen_in_physical.add(bind_key)
+        cur = cur._next  # noqa: SLF001
+
+    # 2. Reject orders that would re-bind a leaf KV under a structural
+    # section header. Slotless keys (empty AoT bindings) don't
+    # participate in physical layout, so skip them in the check.
+    def _is_structural(slots: list[Slot]) -> bool:
+        return any(isinstance(s, StructuralHeaderSlot) for s in slots)
+
+    seen_structural = False
+    for k in new_key_order:
+        block = blocks[k]
+        if not block:
+            continue
+        if _is_structural(block):
+            seen_structural = True
+        elif seen_structural:
+            msg = (
+                f"reorder: leaf key {k!r} cannot follow a structural "
+                f"section/AoT key (would rebind it as nested)"
+            )
+            raise ValueError(msg)
+
+    owned_ids = {id(s) for slots in blocks.values() for s in slots}
+    if not owned_ids:
+        return
+
+    # 3. Find splice anchor: slot just before the earliest owned slot.
+    earliest: Slot | None = None
+    cur = doc._head  # noqa: SLF001
+    while cur is not None:
+        if id(cur) in owned_ids:
+            earliest = cur
+            break
+        cur = cur._next  # noqa: SLF001
+    assert earliest is not None
+    anchor_prev = earliest._prev  # noqa: SLF001
+
+    # 4. Snapshot positional separators (by *physical* position, not
+    # dict order) and remainders (travel with their key). Mirrors
+    # renormalise_aot_order, except AoT list order = physical order so
+    # it doesn't need this distinction.
+    structural_by_position: list[Trivia] = []
+    remainder_by_key: dict[str, Trivia] = {}
+    for k in physical_order:
+        head_slot = blocks[k][0]
+        structural, remainder = _split_leading_structural(head_slot.leading)
+        structural_by_position.append(structural)
+        remainder_by_key[k] = remainder
+
+    # 5. Splice: unlink owned slots, reinsert in new key order after
+    # the saved anchor. Foreign slots interleaved in the original span
+    # collapse together as a side effect — typically ending up just
+    # after the reordered region.
+    for slots in blocks.values():
+        for s in slots:
+            unlink_slot(s, doc, strip_new_head_leading=False)
+
+    insert_after_slot = anchor_prev
+    for k in new_key_order:
+        for slot in blocks[k]:
+            if insert_after_slot is None:
+                insert_before_head(slot, doc)
+            else:
+                insert_after(insert_after_slot, slot, doc)
+            insert_after_slot = slot
+
+    # 6. Re-stitch new head-slot leading: positional[new_pos] + remainder[k].
+    # Indexed across slotful keys only, since structural_by_position
+    # captured one entry per physically-present block.
+    slotful_new_order = [k for k in new_key_order if blocks[k]]
+    for new_pos, k in enumerate(slotful_new_order):
+        head_slot = blocks[k][0]
+        structural = structural_by_position[new_pos]
+        remainder = remainder_by_key[k]
+        head_slot.leading = Trivia(list(structural.pieces) + list(remainder.pieces))
+
+    # 7. Resort _refs / _index on c and ancestor chain; recompute
+    # cached body tails that the splice may have invalidated.
+    chain: list[Container] = [c]
+    anc: Container | None = c._parent  # noqa: SLF001
+    while anc is not None:
+        chain.append(anc)
+        anc = anc._parent  # noqa: SLF001
+    _resort_refs_by_doc_order(chain, doc)
+    for cn in chain:
+        if cn._body_tail is not None:  # noqa: SLF001
+            cn._body_tail = _recompute_body_tail(cn)  # noqa: SLF001
+
+
 __all__ = [
     "add_aot_entry",
     "append_direct_kv",
@@ -3073,6 +3228,7 @@ __all__ = [
     "insert_before_head",
     "remove_aot_entry",
     "renormalise_aot_order",
+    "reorder_container",
     "replace_aot_entry",
     "reposition_install",
     "unlink_slot",

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -3067,15 +3067,17 @@ def _direct_child_key(
 ) -> str | None:
     """Return the direct child key of ``parent_path`` that ``slot`` binds, or None.
 
-    Determined by the slot's binding root: ``path`` for a structural
-    header, ``(*host_path, key_parts[0])`` for a KV. Returns the
-    first path component beyond ``parent_path`` if the binding root
-    starts with ``parent_path`` and is strictly deeper, else None.
+    Determined by the slot's full binding path: ``path`` for a
+    structural header, ``(*host_path, *key_parts)`` for a KV (so
+    dotted KVs like ``a.b.c = 1`` are recognised at every prefix
+    depth, not just their host). Returns the first path component
+    beyond ``parent_path`` if the binding path starts with
+    ``parent_path`` and is strictly deeper, else None.
     """
     if isinstance(slot, StructuralHeaderSlot):
         root: tuple[str, ...] = tuple(slot.path)
     elif isinstance(slot, KVSlot):
-        root = (*slot.host_path, slot.key_parts[0].value)
+        root = (*slot.host_path, *(p.value for p in slot.key_parts))
     else:
         return None
     if len(root) > parent_plen and root[:parent_plen] == parent_path:

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -284,6 +284,40 @@ def _init_implicit_table(
     return child
 
 
+def ensure_implicit_chain(
+    parent: Container,
+    sub_path: tuple[str, ...],
+) -> Container:
+    """Navigate or create implicit Tables along ``sub_path`` under ``parent``.
+
+    Returns the deepest container. Missing components become new
+    implicit (header-less) tables wired into ``parent._attached_doc``;
+    existing components must already be ``Container`` instances.
+    """
+    from tomlrt._container import Container  # noqa: PLC0415
+
+    doc = parent._attached_doc  # noqa: SLF001
+    owner = parent._owner_aot_entry  # noqa: SLF001
+    cur: Container = parent
+    for j, comp in enumerate(sub_path):
+        if comp in cur:
+            nxt = dict.__getitem__(cur, comp)
+            if not isinstance(nxt, Container):
+                msg = f"intermediate {comp!r} is not a table"
+                raise TypeError(msg)
+            cur = nxt
+            continue
+        implicit = _init_implicit_table(
+            doc,
+            (*parent._path, *sub_path[: j + 1]),  # noqa: SLF001
+            cur,
+            owner,
+        )
+        dict.__setitem__(cur, comp, implicit)
+        cur = implicit
+    return cur
+
+
 def _rebuild_index_for_key(c: Container, local_key: str) -> None:
     """Restore ``c._index[local_key]`` as the doc-stream subset of ``c._refs``.
 
@@ -2295,7 +2329,6 @@ def attach_section_at(
     a `Table` (rehomed) or a Mapping (snapshotted) or ``None``.
     """
     from tomlrt._container import (  # noqa: PLC0415
-        Container,
         Table,
         _is_synth_inline,
         _synth_value,
@@ -2316,26 +2349,10 @@ def attach_section_at(
         owner_aot_entry=owner,
     )
 
-    # Build implicit chain: each intermediate is a Table view living
-    # in dict storage but with no own header ref.
-    chain: list[Container] = [parent]
-    for j, comp in enumerate(sub[:-1]):
-        cur = chain[-1]
-        if comp in cur:
-            nxt = dict.__getitem__(cur, comp)
-            if not isinstance(nxt, Container):
-                msg = f"intermediate {comp!r} is not a table"
-                raise TypeError(msg)
-            chain.append(nxt)
-            continue
-        implicit = _init_implicit_table(
-            doc,
-            (*parent._path, *sub[: j + 1]),  # noqa: SLF001
-            cur,
-            owner,
-        )
-        dict.__setitem__(cur, comp, implicit)
-        chain.append(implicit)
+    # Build implicit chain: intermediates become header-less Tables
+    # living in dict storage; the deepest is where the new explicit
+    # header is filed.
+    deepest_parent = ensure_implicit_chain(parent, sub[:-1])
 
     if isinstance(source, Table) and source._layout_root is None:  # noqa: SLF001
         section = source
@@ -2349,7 +2366,7 @@ def attach_section_at(
         section,
         doc=doc,
         path=full_path,
-        parent=chain[-1],
+        parent=deepest_parent,
         owner=None,
         header=header,
     )
@@ -2363,7 +2380,6 @@ def attach_section_at(
 
     # File the binding ref under the deepest implicit parent and
     # propagate ancestor-prefix bindings up to the doc root.
-    deepest_parent = chain[-1]
     _file_header_binding_chain(deepest_parent, header)
     dict.__setitem__(deepest_parent, sub[-1], section)
 

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1772,6 +1772,7 @@ def _install_cloned_structural_block(
         target_prefix=target_path,
         doc=doc,
     )
+    _maybe_demote_synthetic_empty_header(parent)
 
 
 def _install_cloned_aot_entry(

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1027,12 +1027,129 @@ def _build_kv_slot(c: Container, key: str, value: Value, doc: Document) -> KVSlo
     )
 
 
+def install_dotted_kv_slot(
+    host: Container,
+    leaf_keypath: tuple[str, ...],
+    value: Value,
+    *,
+    leaf_parent: Container,
+) -> None:
+    """Insert a single dotted-KV slot hosted by ``host``.
+
+    Files the new slot's refs on ``host`` + every implicit
+    intermediate in the chain ``[host, ..., leaf_parent]`` per the
+    dotted-KV ref-propagation rule, updates ``_body_tail`` along the
+    chain, and maintains ``AoTEntry.entry_slots`` order when host has
+    an owner. The caller is responsible for dict storage at
+    ``leaf_parent``.
+
+    Pre-conditions (checked by caller):
+      * ``host`` has a header, is the doc root, or is an AoT entry root.
+      * The implicit chain along ``leaf_keypath[:-1]`` already exists
+        under ``host`` (run ``ensure_implicit_chain`` first).
+      * ``leaf_parent`` is the existing container at
+        ``host._path + leaf_keypath[:-1]``.
+      * ``leaf_keypath[-1]`` is not yet bound at ``leaf_parent``.
+      * ``len(leaf_keypath) >= 2`` — a single-keypart leaf is not
+        dotted; use ``append_direct_kv`` for that.
+    """
+    assert len(leaf_keypath) >= 2
+    doc = host._attached_doc  # noqa: SLF001
+
+    # Build chain [host, ..., leaf_parent] via _parent walk + reverse.
+    chain: list[Container] = []
+    cur: Container | None = leaf_parent
+    while cur is not host:
+        assert cur is not None
+        chain.append(cur)
+        cur = cur._parent  # noqa: SLF001
+    chain.append(host)
+    chain.reverse()
+    assert len(chain) == len(leaf_keypath)
+
+    body_tail = leaf_parent._body_tail or host._body_tail  # noqa: SLF001
+    header_ref = host._header_ref  # noqa: SLF001
+    owner = host._owner_aot_entry  # noqa: SLF001
+    if body_tail is not None:
+        _ensure_terminator(body_tail, doc)
+
+    new_slot = _new_kv_slot(
+        host_path=host._path,  # noqa: SLF001
+        key=leaf_keypath,
+        value=value,
+        doc=doc,
+        owner=owner,
+        leading=_kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
+    )
+
+    # Splice into the doc-stream linked list. Anchor preference:
+    # host's body_tail > host's header > head-of-doc seam > empty doc.
+    inserted_at_head = False
+    if body_tail is not None:
+        insert_after(body_tail, new_slot, doc)
+    elif header_ref is not None:
+        insert_after(header_ref.slot, new_slot, doc)
+    elif doc._head is not None:  # noqa: SLF001
+        old_head = doc._head  # noqa: SLF001
+        insert_before_head(new_slot, doc)
+        _ensure_leading_blank_line(old_head, doc)
+        inserted_at_head = True
+    else:
+        insert_before_head(new_slot, doc)
+
+    # File refs on every chain ancestor. ``_refs`` is the doc-stream
+    # subset; ``_index`` preserves "primary at index 0 + all
+    # contributors". The anchor for host is body_tail or its header;
+    # implicit intermediates we created are fresh with empty ``_refs``
+    # so any append is equivalent to insert-at-0.
+    anchor_slot: Slot | None = body_tail or (
+        header_ref.slot if header_ref is not None else None
+    )
+    for i, anc in enumerate(chain):
+        new_ref = SlotRef(slot=new_slot, container=anc)
+        if anchor_slot is not None and any(
+            r.slot is anchor_slot
+            for r in anc._refs  # noqa: SLF001
+        ):
+            anchor_idx = _find_ref_index_by_slot(anc, anchor_slot)
+            anc._refs.insert(anchor_idx + 1, new_ref)  # noqa: SLF001
+        elif inserted_at_head and anc._refs:  # noqa: SLF001
+            # New slot is the new doc head; its ref must precede any
+            # existing refs (e.g. section-header refs on the doc root)
+            # to keep ``_refs`` in doc-stream order.
+            anc._refs.insert(0, new_ref)  # noqa: SLF001
+        else:
+            anc._refs.append(new_ref)  # noqa: SLF001
+        # Rebuild ``_index[local_key]`` rather than blindly appending —
+        # appending is only correct when the new ref is also the last
+        # with its key in ``_refs``, which fails when the ancestor has
+        # later refs under the same key (e.g. ``a.x = 1`` then
+        # ``[a.b]`` — the new ``a.z`` slot sits before the ``[a.b]``
+        # header in ``_index['a']``, not at the end).
+        _rebuild_index_for_key(anc, leaf_keypath[i])
+        if anc._body_tail is body_tail or anc._body_tail is None:  # noqa: SLF001
+            # Propagate the body_tail bump up the chain. ``is body_tail``
+            # is the old-path case (every chain ancestor of an implicit
+            # ``c`` tracks the same body_tail as ``c``); ``is None`` is
+            # the fresh-intermediate case (``ensure_implicit_chain``
+            # may have minted new implicits below host whose own
+            # ``_body_tail`` is still empty).
+            anc._body_tail = new_slot  # noqa: SLF001
+
+    if owner is not None:
+        if body_tail is not None:
+            anchor_idx = owner.entry_slots.index(body_tail)
+            owner.entry_slots.insert(anchor_idx + 1, new_slot)
+        else:
+            owner.entry_slots.append(new_slot)
+
+
 def _append_dotted_kv_under_implicit(c: Container, key: str, value: Value) -> None:
     """Insert into an implicit-headerless container via dotted KV.
 
-    Routes through the nearest header-bearing ancestor (or the doc
-    root). Files refs on every implicit ancestor between that host
-    and ``c`` per the dotted-KV ref-propagation rule.
+    Thin wrapper over :func:`install_dotted_kv_slot` that derives the
+    host and leaf keypath from ``c``. Routes through the nearest
+    header-bearing ancestor (or the doc root).
 
     Pre-conditions (checked by caller):
       * ``c._path`` is non-empty (c is not the doc root)
@@ -1040,76 +1157,18 @@ def _append_dotted_kv_under_implicit(c: Container, key: str, value: Value) -> No
       * ``c._body_tail is not None`` (c has at least one dotted-KV
         contributor — anchors the new slot)
     """
-    body_tail = c._body_tail  # noqa: SLF001
-    assert body_tail is not None
-    doc = c._attached_doc  # noqa: SLF001
+    assert c._body_tail is not None  # noqa: SLF001
 
-    # Find host: nearest ancestor with a header, or the doc root.
     host: Container = c
     while host._parent is not None and host._header_ref is None:  # noqa: SLF001
         host = host._parent  # noqa: SLF001
 
-    # Build chain [host, ..., c] via _parent walk + reverse.
-    chain: list[Container] = []
-    cur: Container | None = c
-    while cur is not host:
-        assert cur is not None
-        chain.append(cur)
-        cur = cur._parent  # noqa: SLF001
-    chain.append(host)
-    chain.reverse()
-
-    # Per-step local keys: from host's path down to (key,).
-    local_keys = [*c._path[len(host._path) :], key]  # noqa: SLF001
-    assert len(local_keys) == len(chain)
-
-    # AoT consistency: every container in the chain shares the same
-    # owner. (The host is either the AoT entry root itself, or the
-    # doc root; either way owners match all the way down.)
-    owner = c._owner_aot_entry  # noqa: SLF001
-
-    _ensure_terminator(body_tail, doc)
-
-    # Build the dotted slot: keypath = host..key.
-    keypath = (*c._path[len(host._path) :], key)  # noqa: SLF001
-    new_slot = _new_kv_slot(
-        host_path=host._path,  # noqa: SLF001
-        key=keypath,
-        value=value,
-        doc=doc,
-        owner=owner,
-        leading=_kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
+    install_dotted_kv_slot(
+        host,
+        (*c._path[len(host._path) :], key),  # noqa: SLF001
+        value,
+        leaf_parent=c,
     )
-
-    insert_after(body_tail, new_slot, doc)
-
-    # File refs on every chain ancestor. ``_refs`` is the doc-stream
-    # subset; ``_index`` preserves "primary at index 0 + all
-    # contributors". Appending to ``_index`` keeps any existing
-    # structural primary (e.g. a header-owning ref on the host) at
-    # index 0; a new dotted contributor is always secondary.
-    for i, anc in enumerate(chain):
-        new_ref = SlotRef(slot=new_slot, container=anc)
-        anchor_idx = _find_ref_index_by_slot(anc, body_tail)
-        anc._refs.insert(anchor_idx + 1, new_ref)  # noqa: SLF001
-        # ``_index[local_key]`` must equal the doc-stream-ordered
-        # subset of ``_refs`` for that key (an invariant). Rebuild it
-        # for the affected key rather than blindly appending —
-        # appending is only correct when the new ref is also the
-        # last with its key in ``_refs``, which fails when the
-        # ancestor has later structural-header refs under the same
-        # name (e.g. ``a.x = 1`` then ``[a.b]`` — the ``[a.b]``
-        # header sits after our new ``a.z`` slot, so the new ref
-        # belongs in the middle of ``doc._index['a']``, not the end).
-        _rebuild_index_for_key(anc, local_keys[i])
-        if anc._body_tail is body_tail:  # noqa: SLF001
-            anc._body_tail = new_slot  # noqa: SLF001
-
-    # Maintain AoTEntry.entry_slots in doc-stream order. body_tail is by
-    # invariant filed in entry_slots when owner is set.
-    if owner is not None:
-        anchor_idx = owner.entry_slots.index(body_tail)
-        owner.entry_slots.insert(anchor_idx + 1, new_slot)
 
 
 def _synthesise_header_then_insert_kv(c: Container, key: str, value: Value) -> None:

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1469,7 +1469,16 @@ def _maybe_demote_synthetic_empty_header(parent: Container) -> None:
     assert isinstance(layout_root, Document)
     doc = layout_root
     # Remove the header from the doc stream and from all caches.
+    # Hand the demoted header's leading trivia (which carries the
+    # file preamble when it sits at doc head) off to the successor
+    # so comments aren't silently dropped on promotion to implicit.
+    successor = header._next  # noqa: SLF001
     unlink_slot(header, doc, strip_new_head_leading=True)
+    if successor is not None and header.leading.pieces:
+        successor.leading.pieces = [
+            *header.leading.pieces,
+            *successor.leading.pieces,
+        ]
     parent._header_ref = None  # noqa: SLF001
     parent._refs = [r for r in parent._refs if r is not hdr_ref]  # noqa: SLF001
     # Also clear it from any prefix container's _refs / _index.

--- a/src/tomlrt/_trivia.py
+++ b/src/tomlrt/_trivia.py
@@ -151,6 +151,31 @@ def join_above_block(pad: Trivia, above: Trivia) -> Trivia:
     return Trivia([pieces[0], *above.pieces, *pieces[1:]])
 
 
+def split_item_above(t: Trivia) -> tuple[Trivia, Trivia, Trivia]:
+    """Split an item-leading region into ``(head_pad, above, tail_pad)``.
+
+    Distinct from :func:`split_above_block` — which is for the bracket
+    pad (``header_trivia`` / ``final_trivia``) and treats a pre-NL
+    comment as an EOL glued to the bracket. This splitter is for
+    ``items[i].leading`` (i >= 1) in an inline array or inline table,
+    where there is no bracket and the leading NL may be absent
+    because item ``i-1``'s EOL hoisted it onto its
+    ``post_comma_trivia``.
+
+    ``head_pad`` is the leading NL (or empty); ``tail_pad`` is the
+    trailing value-indent WS (or empty); ``above`` is the comment
+    block between them (typically ``[WS, Comment, NL] * n``).
+    """
+    rest = list(t.pieces)
+    head: list[TriviaPiece] = []
+    if rest and isinstance(rest[0], NewlineNode):
+        head = [rest.pop(0)]
+    tail: list[TriviaPiece] = []
+    if rest and isinstance(rest[-1], WhitespaceNode):
+        tail = [rest.pop()]
+    return Trivia(head), Trivia(rest), Trivia(tail)
+
+
 def split_eol_section(t: Trivia) -> tuple[Trivia, Trivia]:
     """Split ``t`` into the inline EOL section and the structural rest.
 
@@ -219,6 +244,7 @@ __all__ = [
     "retarget_trivia_newlines",
     "split_above_block",
     "split_eol_section",
+    "split_item_above",
     "trivia_has_comment",
     "trivia_has_newline",
 ]

--- a/src/tomlrt/_values.py
+++ b/src/tomlrt/_values.py
@@ -20,9 +20,8 @@ from typing import TYPE_CHECKING, Literal
 from tomlrt._trivia import (
     Trivia,
     WhitespaceNode,
-    clone_trivia,
     retarget_trivia_newlines,
-    split_above_block,
+    split_item_above,
 )
 
 if TYPE_CHECKING:
@@ -287,10 +286,8 @@ def inter_item_separator(items: Sequence[CommaItem]) -> Trivia:
     leading rather than to the separator.
     """
     if len(items) >= 2:
-        pad, _above = split_above_block(items[1].leading)
-        if pad.pieces:
-            return pad
-        return clone_trivia(items[1].leading)
+        head, _above, tail = split_item_above(items[1].leading)
+        return Trivia([*head.pieces, *tail.pieces])
     return Trivia([WhitespaceNode(text=" ")])
 
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -2,21 +2,20 @@
 
 * :func:`td` — write TOML fixtures as indented triple-quoted literals
   so tests don't degenerate into walls of ``\\n``-escaped strings.
-* :func:`reparses` — re-parse a rendered document with stdlib ``tomllib``
-  to sanity-check that the output is still valid TOML carrying the
-  expected logical values.
+* :func:`reparses` — re-parse a rendered document with ``tomli`` to
+  sanity-check that the output is still valid TOML carrying the
+  expected logical values. ``tomli`` is preferred over the stdlib
+  ``tomllib`` because as of writing (Python 3.14) ``tomllib`` is TOML
+  1.0 only, whereas ``tomli`` 2.4+ accepts TOML 1.1 syntax (multi-line
+  inline tables, etc.).
 """
 
 from __future__ import annotations
 
-import sys
 from textwrap import dedent
 from typing import Any
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:  # pragma: no cover -- backport for Python < 3.11
-    import tomli as tomllib
+import tomli
 
 
 def td(src: str) -> str:
@@ -42,5 +41,5 @@ def td(src: str) -> str:
 
 
 def reparses(src: str) -> dict[str, Any]:
-    """Parse ``src`` with stdlib ``tomllib`` and return the result."""
-    return tomllib.loads(src)
+    """Parse ``src`` with ``tomli`` and return the result."""
+    return tomli.loads(src)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -168,6 +168,30 @@ def test_inline_table_access() -> None:
     assert dict(p) == {"x": 1, "y": 2}
 
 
+def test_table_is_inline_distinguishes_section_from_inline() -> None:
+    doc = tomlrt.loads(
+        td(
+            """
+            inline = { y = 2 }
+
+            [section]
+            x = 1
+            """,
+        ),
+    )
+    section = doc["section"]
+    inline = doc["inline"]
+    assert isinstance(section, tomlrt.Table)
+    assert isinstance(inline, tomlrt.Table)
+    assert section.is_inline is False
+    assert inline.is_inline is True
+
+
+def test_table_is_inline_for_factory_constructors() -> None:
+    assert tomlrt.Table.section().is_inline is False
+    assert tomlrt.Table.inline().is_inline is True
+
+
 def test_nested_tables_and_dotted_keys() -> None:
     src = dedent(
         """\

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1834,3 +1834,74 @@ def test_same_doc_aot_assigned_under_new_key_preserves_subsections() -> None:
     assert "y = 2" in out
     # Source is unchanged.
     assert "[a.sub]" in out
+
+
+# ---------------------------------------------------------------------------
+# Dotted-key comments are reached through the dotted-parent container.
+# ---------------------------------------------------------------------------
+
+
+def test_dotted_key_comments_exposed_via_dotted_parent() -> None:
+    src = td("""
+        [project]
+        # leading comment on urls.homepage
+        urls.homepage = "x"  # eol comment
+        """)
+    doc = tomlrt.loads(src)
+    project = doc.table("project")
+    # Not visible from the explicit ancestor — "urls" is implicit, not a leaf.
+    assert dict(project.comments) == {}
+    assert dict(project.leading_comments) == {}
+    urls = project.table("urls")
+    assert urls.comments["homepage"] == "eol comment"
+    assert urls.leading_comments["homepage"] == ("leading comment on urls.homepage",)
+
+
+def test_dotted_key_comments_write_round_trips() -> None:
+    src = td("""
+        [project]
+        # old leading
+        urls.homepage = "x"  # old eol
+        """)
+    doc = tomlrt.loads(src)
+    urls = doc.table("project").table("urls")
+    urls.comments["homepage"] = "new eol"
+    urls.leading_comments["homepage"] = ("new leading 1", "new leading 2")
+    assert tomlrt.dumps(doc) == td("""
+        [project]
+        # new leading 1
+        # new leading 2
+        urls.homepage = "x"  # new eol
+        """)
+
+
+def test_dotted_key_comments_delete_round_trips() -> None:
+    src = td("""
+        [project]
+        # leading
+        urls.homepage = "x"  # eol
+        """)
+    doc = tomlrt.loads(src)
+    urls = doc.table("project").table("urls")
+    del urls.comments["homepage"]
+    del urls.leading_comments["homepage"]
+    assert tomlrt.dumps(doc) == td("""
+        [project]
+        urls.homepage = "x"
+        """)
+
+
+def test_dotted_key_comments_only_exposed_at_immediate_parent() -> None:
+    src = td("""
+        [section]
+        # c-comment
+        a.b.c = 1  # eol-c
+        """)
+    doc = tomlrt.loads(src)
+    section = doc.table("section")
+    a = section.table("a")
+    b = a.table("b")
+    assert dict(section.comments) == {}
+    assert dict(a.comments) == {}
+    assert b.comments["c"] == "eol-c"
+    assert b.leading_comments["c"] == ("c-comment",)

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1581,6 +1581,85 @@ def test_array_leading_comments_set_on_inline_array_synthesises_indent() -> None
     assert tomlrt.loads(out).array("xs").leading_comments[1] == ("about two",)
 
 
+def test_array_leading_comments_delitem_after_prior_eol() -> None:
+    """Regression for #122: ``del arr.leading_comments[i]`` for i > 0.
+
+    When the prior item carries an EOL comment, the structural newline
+    is hoisted into its ``post_comma_trivia``, so ``items[i].leading``
+    lacks a leading NL. The mutation path must handle that shape.
+    """
+    src = td("""
+        arr = [
+            # leading z
+            "z",
+            "a", # eol a
+            # leading m
+            "M",
+        ]
+        """)
+    doc = tomlrt.loads(src)
+    arr = doc.array("arr")
+    del arr.leading_comments[2]
+    assert 2 not in arr.leading_comments
+    assert tomlrt.dumps(doc) == td("""
+        arr = [
+            # leading z
+            "z",
+            "a", # eol a
+            "M",
+        ]
+        """)
+
+
+def test_array_leading_comments_setitem_after_prior_eol() -> None:
+    """Regression for #122: setting ``leading_comments[i]`` for i > 0
+    when item ``i-1`` has an EOL must not duplicate the indent or
+    corrupt the surrounding shape.
+    """
+    src = td("""
+        arr = [
+            "a", # eol a
+            "b",
+        ]
+        """)
+    doc = tomlrt.loads(src)
+    arr = doc.array("arr")
+    arr.leading_comments[1] = ("about b",)
+    assert tomlrt.dumps(doc) == td("""
+        arr = [
+            "a", # eol a
+            # about b
+            "b",
+        ]
+        """)
+
+
+def test_array_leading_comments_clear_after_prior_eol() -> None:
+    """Regression for #122: ``.clear()`` must terminate (no infinite
+    loop from a silently-failing ``__delitem__``).
+    """
+    src = td("""
+        arr = [
+            # leading z
+            "z",
+            "a", # eol a
+            # leading m
+            "M",
+        ]
+        """)
+    doc = tomlrt.loads(src)
+    arr = doc.array("arr")
+    arr.leading_comments.clear()
+    assert dict(arr.leading_comments) == {}
+    assert tomlrt.dumps(doc) == td("""
+        arr = [
+            "z",
+            "a", # eol a
+            "M",
+        ]
+        """)
+
+
 def test_array_eol_comment_del_on_last_no_comma_item() -> None:
     """Deleting an EOL on a trailing item without a comma needs no NL restore."""
     src = td("""

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -2008,8 +2008,10 @@ def test_header_leading_block_exposes_orphan_between_sections() -> None:
 
 def test_header_leading_block_round_trips_attached_and_above_blank() -> None:
     src = td("""
-        # preamble line 1
-        # preamble line 2
+        [first]
+        x = 1
+        # above-blank line 1
+        # above-blank line 2
 
         # attached line 1
         # attached line 2
@@ -2018,8 +2020,8 @@ def test_header_leading_block_round_trips_attached_and_above_blank() -> None:
         """)
     doc = tomlrt.loads(src)
     assert doc["a"].header_leading_block == (
-        "preamble line 1",
-        "preamble line 2",
+        "above-blank line 1",
+        "above-blank line 2",
         None,
         "attached line 1",
         "attached line 2",
@@ -2043,7 +2045,7 @@ def test_header_leading_block_set_writes_blank_lines_faithfully() -> None:
         """)
 
 
-def test_header_leading_block_first_slot_overlaps_with_document_preamble() -> None:
+def test_header_leading_block_first_section_excludes_document_preamble() -> None:
     src = td("""
         # preamble
 
@@ -2052,11 +2054,85 @@ def test_header_leading_block_first_slot_overlaps_with_document_preamble() -> No
         """)
     doc = tomlrt.loads(src)
     assert doc.preamble == ("preamble",)
-    assert doc["a"].header_leading_block == ("preamble", None)
-    # Writing through header_leading_block reflects in preamble.
-    doc["a"].header_leading_block = ("new", None, "attached")
-    assert doc.preamble == ("new",)
+    assert doc["a"].header_leading_block == ()
+    # Writing through header_leading_block leaves preamble intact.
+    doc["a"].header_leading_block = ("attached",)
+    assert doc.preamble == ("preamble",)
     assert doc["a"].header_leading_comments == ("attached",)
+    assert tomlrt.dumps(doc) == td("""
+        # preamble
+
+        # attached
+        [a]
+        x = 1
+        """)
+
+
+def test_header_leading_block_round_trip_preserves_document_preamble() -> None:
+    src = td("""
+        # preamble line 1
+        # preamble line 2
+
+        # section a comment
+        [a]
+        x = 1
+
+        # section b comment
+        [b]
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    assert doc.preamble == ("preamble line 1", "preamble line 2")
+    assert doc["a"].header_leading_block == ("section a comment",)
+    assert doc["b"].header_leading_block == (None, "section b comment")
+    # In-place read+write of the first section's block must not migrate
+    # the document preamble into the section body.
+    doc["a"].header_leading_block = doc["a"].header_leading_block
+    assert tomlrt.dumps(doc) == src
+
+
+def test_header_leading_block_delete_first_section_preserves_preamble() -> None:
+    src = td("""
+        # preamble
+
+        # attached
+        [a]
+        x = 1
+        """)
+    doc = tomlrt.loads(src)
+    assert doc["a"].header_leading_block == ("attached",)
+    del doc["a"].header_leading_block
+    assert doc.preamble == ("preamble",)
+    assert tomlrt.dumps(doc) == td("""
+        # preamble
+
+        [a]
+        x = 1
+        """)
+
+
+def test_leading_block_first_kv_excludes_document_preamble() -> None:
+    src = td("""
+        # preamble
+
+        # attached to x
+        x = 1
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    assert doc.preamble == ("preamble",)
+    assert doc.leading_block["x"] == ("attached to x",)
+    # Round-trip leaves preamble intact.
+    doc.leading_block["x"] = doc.leading_block["x"]
+    assert tomlrt.dumps(doc) == src
+    del doc.leading_block["x"]
+    assert doc.preamble == ("preamble",)
+    assert tomlrt.dumps(doc) == td("""
+        # preamble
+
+        x = 1
+        y = 2
+        """)
 
 
 def test_header_leading_block_delete_clears_above_blank_and_attached() -> None:

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1984,3 +1984,205 @@ def test_dotted_key_comments_only_exposed_at_immediate_parent() -> None:
     assert dict(a.comments) == {}
     assert b.comments["c"] == "eol-c"
     assert b.leading_comments["c"] == ("c-comment",)
+
+
+# ---------------------------------------------------------------------------
+# leading_block / header_leading_block — full-fidelity above-blank access (#123)
+# ---------------------------------------------------------------------------
+
+
+def test_header_leading_block_exposes_orphan_between_sections() -> None:
+    src = td("""
+        [a]
+        x = 1
+
+        # orphan
+
+        [b]
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    assert doc["b"].header_leading_block == (None, "orphan", None)
+    assert doc["b"].header_leading_comments == ()
+
+
+def test_header_leading_block_round_trips_attached_and_above_blank() -> None:
+    src = td("""
+        # preamble line 1
+        # preamble line 2
+
+        # attached line 1
+        # attached line 2
+        [a]
+        x = 1
+        """)
+    doc = tomlrt.loads(src)
+    assert doc["a"].header_leading_block == (
+        "preamble line 1",
+        "preamble line 2",
+        None,
+        "attached line 1",
+        "attached line 2",
+    )
+    assert doc["a"].header_leading_comments == ("attached line 1", "attached line 2")
+
+
+def test_header_leading_block_set_writes_blank_lines_faithfully() -> None:
+    doc = tomlrt.loads("[a]\nx = 1\n[b]\ny = 2\n")
+    doc["b"].header_leading_block = ("orphan-1", None, "orphan-2", None, "attached")
+    assert tomlrt.dumps(doc) == td("""
+        [a]
+        x = 1
+        # orphan-1
+
+        # orphan-2
+
+        # attached
+        [b]
+        y = 2
+        """)
+
+
+def test_header_leading_block_first_slot_overlaps_with_document_preamble() -> None:
+    src = td("""
+        # preamble
+
+        [a]
+        x = 1
+        """)
+    doc = tomlrt.loads(src)
+    assert doc.preamble == ("preamble",)
+    assert doc["a"].header_leading_block == ("preamble", None)
+    # Writing through header_leading_block reflects in preamble.
+    doc["a"].header_leading_block = ("new", None, "attached")
+    assert doc.preamble == ("new",)
+    assert doc["a"].header_leading_comments == ("attached",)
+
+
+def test_header_leading_block_delete_clears_above_blank_and_attached() -> None:
+    src = td("""
+        [a]
+        x = 1
+
+        # orphan
+        # attached
+        [b]
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    assert doc["b"].header_leading_block == (None, "orphan", "attached")
+    del doc["b"].header_leading_block
+    assert doc["b"].header_leading_block == ()
+    assert tomlrt.dumps(doc) == td("""
+        [a]
+        x = 1
+        [b]
+        y = 2
+        """)
+
+
+def test_leading_block_on_kv_round_trips_above_blank() -> None:
+    src = td("""
+        x = 1
+
+        # orphan
+
+        # attached
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    assert doc.leading_block["y"] == (None, "orphan", None, "attached")
+    assert doc.leading_comments["y"] == ("attached",)
+
+
+def test_leading_block_setitem_round_trips_orphan_and_attached() -> None:
+    doc = tomlrt.loads("x = 1\ny = 2\n")
+    doc.leading_block["y"] = ("orphan", None, "attached")
+    assert tomlrt.dumps(doc) == td("""
+        x = 1
+        # orphan
+
+        # attached
+        y = 2
+        """)
+
+
+def test_leading_block_preserves_indent_on_nested_key() -> None:
+    src = td("""
+        [section]
+            # original
+            nested = 1
+        """)
+    doc = tomlrt.loads(src)
+    section = doc.table("section")
+    section.leading_block["nested"] = ("first", None, "second")
+    assert tomlrt.dumps(doc) == td("""
+        [section]
+            # first
+
+            # second
+            nested = 1
+        """)
+
+
+def test_leading_block_absent_key_is_missing_from_view() -> None:
+    doc = tomlrt.loads("x = 1\n")
+    assert "x" not in doc.leading_block
+    with pytest.raises(KeyError):
+        _ = doc.leading_block["x"]
+
+
+def test_leading_block_rejects_non_string_non_none_entries() -> None:
+    doc = tomlrt.loads("x = 1\n")
+    with pytest.raises(TypeError):
+        doc.leading_block["x"] = ("ok", 5)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+
+
+def test_leading_block_rejects_newline_inside_entry() -> None:
+    doc = tomlrt.loads("x = 1\n")
+    with pytest.raises(tomlrt.TOMLError):
+        doc.leading_block["x"] = ("a\nb",)
+
+
+def test_header_leading_block_unavailable_on_inline_table() -> None:
+    doc = tomlrt.loads("x = { a = 1 }\n")
+    with pytest.raises(tomlrt.TOMLError):
+        _ = doc.table("x").header_leading_block
+
+
+def test_leading_block_unavailable_on_inline_table() -> None:
+    doc = tomlrt.loads("x = { a = 1 }\n")
+    with pytest.raises(tomlrt.TOMLError):
+        _ = doc.table("x").leading_block
+
+
+def test_reorder_via_block_preserves_orphan_between_sections() -> None:
+    src = td("""
+        [a]
+        x = 1
+
+        # orphan
+
+        [b]
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    a, b = doc["a"], doc["b"]
+    a_block = doc["a"].header_leading_block
+    b_block = doc["b"].header_leading_block
+    del doc["a"]
+    del doc["b"]
+    doc["b"] = b
+    doc["a"] = a
+    # User decides to anchor the orphan above the new [a] (was below it).
+    doc["b"].header_leading_block = a_block
+    doc["a"].header_leading_block = b_block
+    assert tomlrt.dumps(doc) == td("""
+        [b]
+        y = 2
+
+        # orphan
+
+        [a]
+        x = 1
+        """)

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -2262,3 +2262,56 @@ def test_reorder_via_block_preserves_orphan_between_sections() -> None:
         [a]
         x = 1
         """)
+
+
+# ---------------------------------------------------------------------------
+# Detached-container comment mutation: clear error message
+# ---------------------------------------------------------------------------
+
+
+def test_detached_table_comments_setitem_raises_clear_error() -> None:
+    """Setting a comment on a detached Table should raise TOMLError, not KeyError."""
+    elem = tomlrt.Table.section()
+    elem["x"] = 1
+    assert "x" in elem
+    with pytest.raises(tomlrt.TOMLError, match="detached container"):
+        elem.comments["x"] = "eol"
+    with pytest.raises(tomlrt.TOMLError, match="detached container"):
+        elem.leading_comments["x"] = ("above",)
+    with pytest.raises(tomlrt.TOMLError, match="detached container"):
+        elem.leading_block["x"] = (None, "above")
+
+
+def test_detached_table_comments_delitem_raises_clear_error() -> None:
+    elem = tomlrt.Table.section()
+    elem["x"] = 1
+    with pytest.raises(tomlrt.TOMLError, match="detached container"):
+        del elem.comments["x"]
+    with pytest.raises(tomlrt.TOMLError, match="detached container"):
+        del elem.leading_comments["x"]
+    with pytest.raises(tomlrt.TOMLError, match="detached container"):
+        del elem.leading_block["x"]
+
+
+def test_detached_table_comments_reads_are_forgiving() -> None:
+    """Reads still return empty / None on detached containers."""
+    elem = tomlrt.Table.section()
+    elem["x"] = 1
+    assert elem.comments.get("x") is None
+    assert list(elem.comments) == []
+    assert len(elem.comments) == 0
+    assert "x" not in elem.comments
+    assert list(elem.leading_comments) == []
+    assert list(elem.leading_block) == []
+
+
+def test_detached_aot_element_comments_documented_workaround() -> None:
+    """Attach-first workaround from #127: detached AoT element comments."""
+    aot = tomlrt.AoT()
+    src = tomlrt.Table.section()
+    src["x"] = 1
+    aot.append(src)
+    doc = tomlrt.loads("")
+    doc["items"] = aot
+    doc["items"][-1].comments["x"] = "eol"
+    assert tomlrt.dumps(doc) == "[[items]]\nx = 1 # eol\n"

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -715,6 +715,50 @@ def test_cross_doc_section_header_indent_preserved_without_comment() -> None:
     assert tomlrt.dumps(dst) == "   [POWER]\nplay = true\n"
 
 
+def test_cross_doc_section_assign_does_not_drag_source_preamble() -> None:
+    """Issue #121: ``dst[k] = src[k]`` must not append the source
+    document's preamble onto the destination's. The src section's
+    header carries the file preamble in its leading trivia (an
+    "above-blank" block); only the attached comment block (and the
+    slot's own indent) should travel with the cloned section.
+    """
+    src = tomlrt.loads("# pre\n\n[a]\nx = 1\n")
+    dst = Document()
+    dst.preamble = src.preamble
+    dst["a"] = src["a"]
+    assert dst.preamble == ("pre",)
+    assert tomlrt.dumps(dst) == "# pre\n\n[a]\nx = 1\n"
+
+
+def test_clone_section_drops_above_blank_block() -> None:
+    """Same-doc clone shares ``_install_cloned_section`` with cross-doc
+    assign and so must apply the same positional-vs-travelling-trivia
+    split: any above-blank block (preamble or "archived" comments
+    separated from the header by a blank line) belongs to the source
+    document position, not the section being copied.
+    """
+    doc = tomlrt.loads("# pre\n\n[a]\nx = 1\n")
+    doc["b"] = doc["a"]
+    assert tomlrt.dumps(doc) == "# pre\n\n[a]\nx = 1\n\n[b]\nx = 1\n"
+
+    doc = tomlrt.loads("[before]\nfoo = 1\n\n# archived\n\n[a]\nx = 1\n")
+    doc["b"] = doc["a"]
+    expected = "[before]\nfoo = 1\n\n# archived\n\n[a]\nx = 1\n\n[b]\nx = 1\n"
+    assert tomlrt.dumps(doc) == expected
+
+
+def test_aot_sort_does_not_drag_source_preamble() -> None:
+    """Sister to #121 in the AoT renormalise path: sorting an AoT
+    whose first entry header carries the file preamble must leave
+    the preamble at doc position 0, not drag it along with the
+    originally-first entry.
+    """
+    doc = tomlrt.loads("# pre\n\n[[a]]\nv = 2\n\n[[a]]\nv = 1\n")
+    doc["a"].sort(key=lambda e: e["v"])
+    assert doc.preamble == ("pre",)
+    assert tomlrt.dumps(doc) == "# pre\n\n[[a]]\nv = 1\n\n[[a]]\nv = 2\n"
+
+
 def test_cross_doc_implicit_parent_preserves_child_header_comments() -> None:
     """Issue #117: when source parent is implicit, child sub-tables'
     ``header_leading_comments`` / ``header_comment`` must survive the move.

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -2757,6 +2757,29 @@ def test_preamble_migration_for_install_section_and_aot() -> None:
         assert tomlrt.loads(rendered).preamble == ("Top",), op_name
 
 
+def test_preamble_preserved_when_empty_section_promoted_to_implicit() -> None:
+    """Setting a sub-section on an empty placeholder section promotes
+    the parent to an implicit super-table; the demoted parent header
+    used to carry the file preamble in its leading trivia, and the
+    promotion silently dropped it.
+    """
+    doc = Document()
+    doc.preamble = ("hi",)
+    doc["project"] = Table.section()
+    assert doc.preamble == ("hi",)
+    project = doc.get_table("project")
+    assert project is not None
+    project["urls"] = Table.section()
+    assert doc.preamble == ("hi",)
+    rendered = tomlrt.dumps(doc)
+    assert rendered == td("""
+        # hi
+
+        [project.urls]
+        """)
+    assert tomlrt.loads(rendered).preamble == ("hi",)
+
+
 def test_aot_insert_on_empty_doc_migrates_preamble() -> None:
     """``AoT.insert`` was bypassing the preamble-migration choke-point,
     so on an empty doc with a preamble the comment ended up after the

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -657,6 +657,27 @@ def test_cross_doc_assign_repeats_subsection_under_distinct_aot_entries() -> Non
     assert "z = 2" in dst.render()
 
 
+def test_cross_doc_table_assign_preserves_header_leading_comments() -> None:
+    """Cross-doc ``dst[k] = src[k]`` preserves the source header's
+    leading comment block (and its EOL comment).
+
+    The clone path rewrites the structural prefix of the head's
+    leading trivia (so the destination doc's spacing convention wins)
+    but keeps any comment pieces — they belong to the section being
+    copied.
+    """
+    src = tomlrt.loads("# bee\n[b]  # eol\nval = 2\n")
+    dst = Document()
+    dst["b"] = src["b"]
+    table = dst.get_table("b")
+    assert table is not None
+    assert table.header_leading_comments == ("bee",)
+    assert table.header_comment == "eol"
+    out = dst.render()
+    assert "# bee" in out
+    assert "# eol" in out
+
+
 def test_cross_doc_table_assign_preserves_comments() -> None:
     """Cross-doc copy of a section preserves its comments and layout."""
     src = td("""

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -3114,6 +3114,35 @@ def test_array_sort_normalises_mismatched_indents() -> None:
     assert tomlrt.dumps(doc) == expected_rev
 
 
+def test_array_sort_leading_comments_travel_with_items() -> None:
+    """Regression for tomlrt #120: per-item leading comments must move
+    with their item under :meth:`Array.sort`, and the closing ``]`` must
+    stay on its own line even when the new last item lacks an EOL.
+    """
+    src = td("""
+        arr = [
+            # leading z
+            "z",
+            "a", # eol a
+        ]
+        """)
+    doc = tomlrt.loads(src)
+    doc["arr"].sort()
+    expected = td("""
+        arr = [
+            "a", # eol a
+            # leading z
+            "z",
+        ]
+        """)
+    assert tomlrt.dumps(doc) == expected
+    # Sort is idempotent: a second sort on the already-sorted result
+    # must not perturb the layout.
+    doc2 = tomlrt.loads(tomlrt.dumps(doc))
+    doc2["arr"].sort()
+    assert tomlrt.dumps(doc2) == expected
+
+
 def test_array_insert_zero_pushes_existing_leading_comment_to_new_position() -> None:
     """``insert(0, x)`` must not duplicate the leading-of-(formerly) item-0
     onto both the new item and its old (now position-1) item."""

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -593,6 +593,70 @@ def test_cross_doc_table_assign_with_nested_aot() -> None:
     assert "MUT" not in tomlrt.dumps(b)
 
 
+def test_cross_doc_table_assign_with_explicit_header_and_nested_aot() -> None:
+    """Issue #108: cross-doc whole-section assignment must preserve nested AoT.
+
+    The source has an explicit ``[a]`` header (so cross-doc copy of ``a``
+    goes through ``clone_section_as_section`` rather than the implicit
+    subtree-walk branch). The body contains an AoT (``[[a.x]]``). The
+    AoT must survive as ``[[a.x]]`` in the destination, not be downgraded
+    to two ``[a.x]`` headers (invalid TOML).
+    """
+    src = tomlrt.loads("[a]\n[[a.x]]\ny = 1\n\n[[a.x]]\ny = 2\n")
+    dst = Document()
+    dst["a"] = src["a"]
+    out = dst.render()
+    assert "[[a.x]]" in out
+    assert _reparses(out) == _reparses("[a]\n[[a.x]]\ny = 1\n\n[[a.x]]\ny = 2\n")
+
+
+def test_aot_append_entry_preserves_nested_aot() -> None:
+    """Appending a parent AoT entry must preserve its nested AoT children.
+
+    ``aot.append(some_entry)`` (``clone_aot_entry``) historically copied
+    only the entry's own ``entry_slots``, which excludes slots owned by
+    nested ``[[a.x]]`` entries living physically inside the parent
+    entry. The nested entries were silently dropped — output stayed
+    valid TOML but ``q`` values were lost. Same class as #108.
+    """
+    src = tomlrt.loads(
+        "[[outer]]\nv = 1\n[outer.sub]\ns = 2\n"
+        "[[outer.aot]]\nq = 3\n[[outer.aot]]\nq = 4\n",
+    )
+    dst = tomlrt.loads("[[outer]]\nv = 10\n")
+    dst["outer"].append(src["outer"][0])
+    out = dst.render()
+    reparsed = _reparses(out)
+    assert reparsed["outer"][1] == {
+        "v": 1,
+        "sub": {"s": 2},
+        "aot": [{"q": 3}, {"q": 4}],
+    }
+
+
+def test_cross_doc_assign_repeats_subsection_under_distinct_aot_entries() -> None:
+    """Repeated ``[a.x.sub]`` under separate ``[[a.x]]`` entries must
+    materialise as distinct view containers, not share one.
+
+    Each ``[[a.x]]`` opens a fresh entry, and the following ``[a.x.sub]``
+    belongs to that entry only. Without per-entry container scoping, a
+    cross-doc clone would conflate the two ``sub`` containers — the
+    first entry's ``sub`` would end up holding the second's value, and
+    the second entry would lose its ``sub`` key entirely.
+    """
+    src = tomlrt.loads(
+        "[a]\n[[a.x]]\ny = 1\n[a.x.sub]\nz = 1\n[[a.x]]\ny = 2\n[a.x.sub]\nz = 2\n",
+    )
+    dst = Document()
+    dst["a"] = src["a"]
+    entries = list(dst["a"]["x"])
+    assert dict(entries[0]) == {"y": 1, "sub": {"z": 1}}
+    assert dict(entries[1]) == {"y": 2, "sub": {"z": 2}}
+    dst["a"]["x"][0]["sub"]["z"] = 99
+    assert "z = 99" in dst.render()
+    assert "z = 2" in dst.render()
+
+
 def test_cross_doc_table_assign_preserves_comments() -> None:
     """Cross-doc copy of a section preserves its comments and layout."""
     src = td("""

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -634,6 +634,30 @@ def test_aot_append_entry_preserves_nested_aot() -> None:
     }
 
 
+def test_aot_replace_entry_preserves_nested_aot() -> None:
+    """Replacing an AoT entry (``aot[i] = src_entry``) preserves nested AoTs.
+
+    ``replace_aot_entry_with_clone`` historically copied only
+    ``src_entry.entry_slots``, which excludes slots owned by nested
+    ``[[a.x]]`` entries living physically inside the source entry —
+    those entries were silently dropped. Same class as the
+    ``aot.append(...)`` bug fixed in #108.
+    """
+    src = tomlrt.loads(
+        "[[outer]]\nv = 1\n[outer.sub]\ns = 2\n"
+        "[[outer.aot]]\nq = 3\n[[outer.aot]]\nq = 4\n",
+    )
+    dst = tomlrt.loads("[[outer]]\nv = 99\n")
+    dst["outer"][0] = src["outer"][0]
+    out = dst.render()
+    reparsed = _reparses(out)
+    assert reparsed["outer"][0] == {
+        "v": 1,
+        "sub": {"s": 2},
+        "aot": [{"q": 3}, {"q": 4}],
+    }
+
+
 def test_cross_doc_assign_repeats_subsection_under_distinct_aot_entries() -> None:
     """Repeated ``[a.x.sub]`` under separate ``[[a.x]]`` entries must
     materialise as distinct view containers, not share one.

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -3038,6 +3038,34 @@ def test_array_sort_with_leading_comments_follows_items() -> None:
     assert tomlrt.dumps(doc) == expected
 
 
+def test_array_sort_normalises_mismatched_indents() -> None:
+    """``sort`` / ``reverse`` must not leave item 0 carrying the old
+    position-0 indent while items[1..] inherit the canonical one."""
+    src = "x = [\n    'z',\n  # comment\n      'a',\n   'm',\n]\n"
+    doc = tomlrt.loads(src)
+    doc.array("x").sort()
+    expected = td("""
+        x = [
+              # comment
+              'a',
+              'm',
+              'z',
+        ]
+        """)
+    assert tomlrt.dumps(doc) == expected
+    doc = tomlrt.loads(src)
+    doc.array("x").reverse()
+    expected_rev = td("""
+        x = [
+              'm',
+              # comment
+              'a',
+              'z',
+        ]
+        """)
+    assert tomlrt.dumps(doc) == expected_rev
+
+
 def test_array_insert_zero_pushes_existing_leading_comment_to_new_position() -> None:
     """``insert(0, x)`` must not duplicate the leading-of-(formerly) item-0
     onto both the new item and its old (now position-1) item."""

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -2780,6 +2780,18 @@ def test_preamble_preserved_when_empty_section_promoted_to_implicit() -> None:
     assert tomlrt.loads(rendered).preamble == ("hi",)
 
 
+def test_cross_doc_section_assign_demotes_empty_parent_to_implicit() -> None:
+    """Cross-doc clone of a sub-section under an empty placeholder
+    parent used to skip the synthetic-header demotion, leaving a
+    spurious bare ``[a]`` line for what is now an implicit super-table.
+    """
+    src = tomlrt.loads("[a.b]\nx = 1\n")
+    dst = Document()
+    dst["a"] = Table.section()
+    dst["a"]["b"] = src["a"]["b"]
+    assert tomlrt.dumps(dst) == "[a.b]\nx = 1\n"
+
+
 def test_aot_insert_on_empty_doc_migrates_preamble() -> None:
     """``AoT.insert`` was bypassing the preamble-migration choke-point,
     so on an empty doc with a preamble the comment ended up after the

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -702,6 +702,19 @@ def test_cross_doc_table_assign_preserves_header_leading_comments() -> None:
     assert "# eol" in out
 
 
+def test_cross_doc_section_header_indent_preserved_without_comment() -> None:
+    """Issue #118: a section header's leading-whitespace indent travels
+    with the section across a cross-doc move, even when no leading
+    comment is present. Previously only the with-comment case preserved
+    indent, breaking idempotency for downstream sorters that strip
+    comments.
+    """
+    src = tomlrt.loads("   [POWER]\nplay = true\n")
+    dst = Document()
+    dst["POWER"] = src["POWER"]
+    assert tomlrt.dumps(dst) == "   [POWER]\nplay = true\n"
+
+
 def test_cross_doc_implicit_parent_preserves_child_header_comments() -> None:
     """Issue #117: when source parent is implicit, child sub-tables'
     ``header_leading_comments`` / ``header_comment`` must survive the move.

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -702,6 +702,41 @@ def test_cross_doc_table_assign_preserves_header_leading_comments() -> None:
     assert "# eol" in out
 
 
+def test_cross_doc_implicit_parent_preserves_child_header_comments() -> None:
+    """Issue #117: when source parent is implicit, child sub-tables'
+    ``header_leading_comments`` / ``header_comment`` must survive the move.
+    """
+    src = tomlrt.loads("# alpha header\n[servers.alpha]  # eol\nx = 1\n")
+    dst = Document()
+    dst["servers"] = src["servers"]
+    servers = dst.get_table("servers")
+    assert servers is not None
+    alpha = servers.get_table("alpha")
+    assert alpha is not None
+    assert alpha.header_leading_comments == ("alpha header",)
+    assert alpha.header_comment == "eol"
+
+
+def test_install_multi_component_attached_section_preserves_comments() -> None:
+    """``install("a.b", attached_section)`` must clone the source's CST
+    trivia rather than synthesise a fresh ``[a.b]`` header.
+
+    Same root cause as #117: the multi-component install path was routing
+    attached header-bearing sections through the synthesis path
+    (``attach_section_at``) instead of the clone path
+    (``clone_section_as_section``).
+    """
+    src = tomlrt.loads("# c\n[x]  # eol\ny = 1\n")
+    dst = Document()
+    dst.install("a.b", src["x"])
+    a = dst.get_table("a")
+    assert a is not None
+    b = a.get_table("b")
+    assert b is not None
+    assert b.header_leading_comments == ("c",)
+    assert b.header_comment == "eol"
+
+
 def test_cross_doc_table_assign_preserves_comments() -> None:
     """Cross-doc copy of a section preserves its comments and layout."""
     src = td("""

--- a/tests/test_live_attach.py
+++ b/tests/test_live_attach.py
@@ -15,6 +15,7 @@ import pytest
 
 import tomlrt
 from _helpers import reparses as _reparses
+from _helpers import td
 from tomlrt import AoT, Array, Table
 
 # ---------------------------------------------------------------------------
@@ -796,3 +797,159 @@ def test_held_view_after_delete_does_not_corrupt_doc() -> None:
     held["new"] = 99
     assert tomlrt.dumps(doc) == "[b]\ny = 2\n"
     assert held["new"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Per-key clone of dotted-form sub-tables preserves dotted form.
+# ---------------------------------------------------------------------------
+
+
+def test_per_key_clone_of_dotted_preserves_dotted_form() -> None:
+    src = tomlrt.loads(
+        td("""
+        [x]
+        v.w = "hi"
+        """)
+    )
+    dst = tomlrt.loads(
+        td("""
+        [x]
+        """)
+    )
+    dst["x"]["v"] = src["x"]["v"]
+    assert tomlrt.dumps(dst) == td("""
+        [x]
+        v.w = "hi"
+        """)
+
+
+def test_cross_document_clone_of_dotted_preserves_dotted_form() -> None:
+    src = tomlrt.loads(
+        td("""
+        [x]
+        v.w = 1
+        """)
+    )
+    dst = tomlrt.loads(
+        td("""
+        [x]
+        """)
+    )
+    dst["x"]["v"] = src["x"]["v"]
+    # Source unchanged after clone.
+    assert tomlrt.dumps(src) == td("""
+        [x]
+        v.w = 1
+        """)
+    assert tomlrt.dumps(dst) == td("""
+        [x]
+        v.w = 1
+        """)
+
+
+def test_per_key_clone_of_implicit_super_table_still_synthesises_header() -> None:
+    src = tomlrt.loads(
+        td("""
+        [x.v.w]
+        a = 1
+        """)
+    )
+    dst = tomlrt.loads(
+        td("""
+        [x]
+        """)
+    )
+    dst["x"]["v"] = src["x"]["v"]
+    assert tomlrt.dumps(dst) == td("""
+        [x]
+
+        [x.v.w]
+        a = 1
+        """)
+
+
+def test_per_key_clone_of_mixed_emits_dotted_kvs_and_subsection() -> None:
+    src = tomlrt.loads(
+        td("""
+        [x]
+        v.w = 1
+
+        [x.v.q]
+        a = 2
+        """)
+    )
+    dst = tomlrt.loads(
+        td("""
+        [x]
+        """)
+    )
+    dst["x"]["v"] = src["x"]["v"]
+    assert tomlrt.dumps(dst) == td("""
+        [x]
+        v.w = 1
+
+        [x.v.q]
+        a = 2
+        """)
+
+
+def test_top_level_clone_of_dotted_preserves_dotted_form() -> None:
+    src = tomlrt.loads("v.w = 1\n")
+    dst = tomlrt.loads("")
+    dst["v"] = src["v"]
+    assert tomlrt.dumps(dst) == "v.w = 1\n"
+
+
+def test_clone_of_nested_dotted_preserves_full_dotted_path() -> None:
+    src = tomlrt.loads(
+        td("""
+        [x]
+        v.w.z = 1
+        """)
+    )
+    dst = tomlrt.loads(
+        td("""
+        [x]
+        """)
+    )
+    dst["x"]["v"] = src["x"]["v"]
+    assert tomlrt.dumps(dst) == td("""
+        [x]
+        v.w.z = 1
+        """)
+
+
+def test_clone_of_dotted_with_inline_value_preserves_dotted_form() -> None:
+    src = tomlrt.loads(
+        td("""
+        [x]
+        v.w = { a = 1 }
+        """)
+    )
+    dst = tomlrt.loads(
+        td("""
+        [x]
+        """)
+    )
+    dst["x"]["v"] = src["x"]["v"]
+    assert tomlrt.dumps(dst) == td("""
+        [x]
+        v.w = { a = 1 }
+        """)
+
+
+def test_clone_dotted_to_top_level_before_existing_section() -> None:
+    src = tomlrt.loads("v.w = 1\n")
+    dst = tomlrt.loads(
+        td("""
+        [a]
+        y = 2
+        """)
+    )
+    dst["v"] = src["v"]
+    assert tomlrt.dumps(dst) == td("""
+        v.w = 1
+
+        [a]
+        y = 2
+        """)

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -3043,6 +3043,43 @@ def test_sort_dotted_kvs_treated_as_one_block() -> None:
     assert _reparses(tomlrt.dumps(doc))
 
 
+def test_sort_on_dotted_intermediate_reorders_kvs() -> None:
+    # Sorting the implicit container reached through a dotted key
+    # (here doc['parent']['a']) must reorder the underlying dotted
+    # KV slots, not just the dict storage.
+    src = td("""
+        [parent]
+        a.z = 1
+        a.x = 2
+        a.y = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.table(("parent", "a")).sort()
+    assert tomlrt.dumps(doc) == td("""
+        [parent]
+        a.x = 2
+        a.y = 3
+        a.z = 1
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_on_dotted_intermediate_at_root() -> None:
+    src = td("""
+        a.z = 1
+        a.x = 2
+        a.y = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.table("a").sort()
+    assert tomlrt.dumps(doc) == td("""
+        a.x = 2
+        a.y = 3
+        a.z = 1
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
 def test_sort_inside_section() -> None:
     src = td("""
         [s]

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -432,6 +432,87 @@ def test_array_insert_at_zero_does_not_duplicate_leading_comment() -> None:
         """)
 
 
+def test_array_delete_zero_keeps_next_leading_comment_after_prior_eol() -> None:
+    """Regression for #122: ``del arr[0]`` when ``items[1].leading`` is in
+    post-EOL shape must migrate item 1's leading comment into ``header_trivia``
+    rather than dropping it.
+    """
+    doc = tomlrt.loads(
+        td("""
+        arr = [
+            # leading a
+            "a", # eol a
+            # leading b
+            "b",
+        ]
+        """)
+    )
+    arr = doc.array("arr")
+    del arr[0]
+    assert tomlrt.dumps(doc) == td("""
+        arr = [
+            # leading b
+            "b",
+        ]
+        """)
+
+
+def test_array_insert_after_eol_item_does_not_duplicate_following_comment() -> None:
+    """Regression for #122: when inserting between an EOL-bearing item
+    and a follower whose ``leading`` carries an above-block in post-EOL
+    shape, the follower's leading comment must remain attached to the
+    follower (not be reassigned to the inserted item as an EOL).
+    """
+    doc = tomlrt.loads(
+        td("""
+        arr = [
+            # leading a
+            "a", # eol a
+            # leading b
+            "b",
+        ]
+        """)
+    )
+    arr = doc.array("arr")
+    arr.insert(1, "z")
+    assert tomlrt.dumps(doc) == td("""
+        arr = [
+            # leading a
+            "a", # eol a
+            "z",
+            # leading b
+            "b",
+        ]
+        """)
+
+
+def test_array_append_after_eol_item_does_not_duplicate_prior_comment() -> None:
+    """Regression for #122: appending after an EOL-bearing item must not
+    leave the appended item sharing the EOL row of the previous item.
+    """
+    doc = tomlrt.loads(
+        td("""
+        arr = [
+            # leading a
+            "a", # eol a
+            # leading b
+            "b",
+        ]
+        """)
+    )
+    arr = doc.array("arr")
+    arr.append("z")
+    assert tomlrt.dumps(doc) == td("""
+        arr = [
+            # leading a
+            "a", # eol a
+            # leading b
+            "b",
+            "z",
+        ]
+        """)
+
+
 # Every Array/AoT mutator must be wired through the CST so the
 # rendered output stays in sync with in-memory mutations.
 @pytest.mark.parametrize(

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -2163,6 +2163,48 @@ def test_dotted_add_respects_blank_line_policy() -> None:
         """)
 
 
+def test_dotted_add_anchors_at_implicit_tail_not_host_tail() -> None:
+    """A new dotted sibling must group with its implicit-region peers,
+    not be appended after unrelated host-level KVs that follow them in
+    doc-stream order.
+    """
+    src = td("""
+        [x]
+        v.w = 1
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    doc["x"]["v"]["z"] = 3
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        [x]
+        v.w = 1
+        v.z = 3
+        y = 2
+        """)
+
+
+def test_dotted_add_anchors_at_implicit_tail_with_unrelated_dotted_trailer() -> None:
+    """Even when the trailing host slot is another dotted KV (under a
+    different implicit prefix), the new sibling must anchor at its
+    own implicit region's tail, not host's.
+    """
+    src = td("""
+        [s]
+        a.b = 1
+        q.r = 2
+        """)
+    doc = tomlrt.loads(src)
+    doc["s"]["a"]["c"] = 3
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        [s]
+        a.b = 1
+        a.c = 3
+        q.r = 2
+        """)
+
+
 def test_clear_doc_with_sections_drops_all_and_keeps_doc_empty() -> None:
     src = td("""
         [a]

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -2898,3 +2898,364 @@ def test_collapse_multiline_with_nested_inline_table_comment_raises() -> None:
     arr = doc.array("xs")
     with pytest.raises(tomlrt.TOMLError):
         arr.set_multiline(multiline=False)
+
+
+# ---------------------------------------------------------------------------
+# Container.sort
+# ---------------------------------------------------------------------------
+
+
+def test_sort_leaf_kvs_preserves_leading_and_eol_comments() -> None:
+    src = td("""
+        # preamble
+
+        # above b
+        b = 1  # eol b
+        # above a
+        a = 2  # eol a
+
+        # above c
+        c = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    assert tomlrt.dumps(doc) == td("""
+        # preamble
+
+        # above a
+        a = 2  # eol a
+        # above b
+        b = 1  # eol b
+
+        # above c
+        c = 3
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_reverse_leaf_kvs() -> None:
+    src = td("""
+        a = 1
+        b = 2
+        c = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort(reverse=True)
+    assert tomlrt.dumps(doc) == td("""
+        c = 3
+        b = 2
+        a = 1
+        """)
+
+
+def test_sort_with_custom_key() -> None:
+    src = td("""
+        short = 1
+        longer = 2
+        longest_name = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort(key=len)
+    assert tomlrt.dumps(doc) == td("""
+        short = 1
+        longer = 2
+        longest_name = 3
+        """)
+    doc.sort(key=len, reverse=True)
+    assert tomlrt.dumps(doc) == td("""
+        longest_name = 3
+        longer = 2
+        short = 1
+        """)
+
+
+def test_sort_sections_preserves_above_header_comments() -> None:
+    src = td("""
+        # preamble
+
+        # above b
+        [b]
+        x = 1
+
+        # above a
+        [a]
+        y = 2
+        z = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    assert tomlrt.dumps(doc) == td("""
+        # preamble
+
+        # above a
+        [a]
+        y = 2
+        z = 3
+
+        # above b
+        [b]
+        x = 1
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_aot_at_root_moves_all_entries() -> None:
+    src = td("""
+        # header for b
+        [[b]]
+        x = 1
+        [[b]]
+        x = 2
+
+        # header for a
+        [[a]]
+        y = 1
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    assert tomlrt.dumps(doc) == td("""
+        # header for a
+        [[a]]
+        y = 1
+
+        # header for b
+        [[b]]
+        x = 1
+        [[b]]
+        x = 2
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_dotted_kvs_treated_as_one_block() -> None:
+    src = td("""
+        b = 1
+        a.x = 2
+        a.y = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    assert tomlrt.dumps(doc) == td("""
+        a.x = 2
+        a.y = 3
+        b = 1
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_inside_section() -> None:
+    src = td("""
+        [s]
+        c = 3
+        # above a
+        a = 1
+        b = 2
+        """)
+    doc = tomlrt.loads(src)
+    doc.table("s").sort()
+    assert tomlrt.dumps(doc) == td("""
+        [s]
+        # above a
+        a = 1
+        b = 2
+        c = 3
+        """)
+
+
+def test_sort_rejects_leaf_after_structural() -> None:
+    # Two sections + a leaf. Force an order that interleaves the leaf
+    # between the two structurals: 'leaf' would render after '[a]'
+    # and re-bind as nested under '[a]'.
+    doc = tomlrt.loads(
+        td("""
+        [a]
+        x = 1
+        [b]
+        y = 2
+        """)
+    )
+    doc["leaf"] = "z"
+    order_idx = {"a": 0, "leaf": 1, "b": 2}
+    with pytest.raises(ValueError, match="leaf"):
+        doc.sort(key=order_idx.__getitem__)
+
+
+def test_sort_smart_key_leaves_before_sections() -> None:
+    doc = tomlrt.loads(
+        td("""
+        [a]
+        x = 1
+        [b]
+        y = 2
+        """)
+    )
+    doc["leaf"] = "z"
+
+    def _is_section(k: str) -> bool:
+        v = doc[k]
+        if isinstance(v, AoT):
+            return True
+        return isinstance(v, Table) and not v._inline  # noqa: SLF001
+
+    doc.sort(key=lambda k: (_is_section(k), k))
+    assert tomlrt.dumps(doc) == td("""
+        leaf = "z"
+
+        [a]
+        x = 1
+        [b]
+        y = 2
+        """)
+
+
+def test_sort_handles_non_contiguous_key_blocks() -> None:
+    # Key 'outer' has two runs ([outer.a] and [outer.b]) at root,
+    # with 'other' in between. sort() should collect both runs and
+    # splice them as one contiguous block at 'outer's new position.
+    src = td("""
+        [outer.a]
+        x = 1
+
+        [other]
+        z = 0
+
+        [outer.b]
+        y = 2
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    assert tomlrt.dumps(doc) == td("""
+        [other]
+        z = 0
+
+        [outer.a]
+        x = 1
+
+        [outer.b]
+        y = 2
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_empty_and_single_are_noops() -> None:
+    empty = tomlrt.loads("")
+    empty.sort()
+    assert tomlrt.dumps(empty) == ""
+
+    single = tomlrt.loads("a = 1\n")
+    single.sort()
+    assert tomlrt.dumps(single) == "a = 1\n"
+
+
+def test_sort_already_ordered_is_noop() -> None:
+    src = td("""
+        a = 1
+        b = 2
+        c = 3
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    assert tomlrt.dumps(doc) == src
+
+
+def test_sort_detached_table_reorders_dict_storage() -> None:
+    t = Table()
+    t["c"] = 1
+    t["a"] = 2
+    t["b"] = 3
+    t.sort()
+    assert list(t.keys()) == ["a", "b", "c"]
+
+
+def test_sort_inline_table_simple() -> None:
+    doc = tomlrt.loads("t = {b = 1, a = 2}\n")
+    doc.table("t").sort()
+    assert tomlrt.dumps(doc) == "t = {a = 2, b = 1}\n"
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_inline_table_preserves_no_trailing_comma() -> None:
+    # Sorting must keep the original "no trailing comma" style: the
+    # entry that moves to the last position drops its comma.
+    doc = tomlrt.loads("t = { c = 3, a = 1, b = 2 }\n")
+    doc.table("t").sort()
+    assert tomlrt.dumps(doc) == "t = { a = 1, b = 2, c = 3 }\n"
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_inline_table_with_dotted_keys() -> None:
+    # 'a' is a dotted-key prefix at the inline root: a.x and a.y are
+    # two separate entries grouped under the same direct child.
+    doc = tomlrt.loads("t = {b = 1, a.x = 2, a.y = 3}\n")
+    doc.table("t").sort()
+    # Direct children of t are 'a' and 'b' → sorted: 'a' first.
+    # Both a.x and a.y belong to 'a' and travel together.
+    assert tomlrt.dumps(doc) == "t = {a.x = 2, a.y = 3, b = 1}\n"
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_inline_table_multiline_with_above_comments() -> None:
+    src = td("""
+        t = {
+          # above b
+          b = 2,
+          # above a
+          a = 1,
+        }
+        """)
+    doc = tomlrt.loads(src)
+    doc.table("t").sort()
+    assert tomlrt.dumps(doc) == td("""
+        t = {
+          # above a
+          a = 1,
+          # above b
+          b = 2,
+        }
+        """)
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_inline_dotted_inner_navigator() -> None:
+    # Sort the navigator view for 'a' in {a.p, a.q}; entries outside
+    # 'a' (x, y) keep their absolute positions.
+    doc = tomlrt.loads("t = {x = 0, a.q = 2, a.p = 1, y = 3}\n")
+    doc.table("t").table("a").sort()
+    # Owned positions are 1 and 2 (the a.q and a.p entries). After
+    # sort by ('p','q'): pos 1 ← a.p, pos 2 ← a.q. x and y unchanged.
+    assert tomlrt.dumps(doc) == "t = {x = 0, a.p = 1, a.q = 2, y = 3}\n"
+    assert _reparses(tomlrt.dumps(doc))
+
+
+def test_sort_preserves_lexeme_styles_and_whitespace() -> None:
+    src = td("""
+        b = 'lit'
+        a = "basic"
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    # Each KV keeps its original lexeme style; sort only reorders blocks.
+    assert tomlrt.dumps(doc) == td("""
+        a = "basic"
+        b = 'lit'
+        """)
+
+
+def test_sort_round_trips_for_repeated_sorts() -> None:
+    src = td("""
+        # head
+
+        # above c
+        c = 3
+        # above a
+        a = 1
+
+        # above b
+        b = 2
+        """)
+    doc = tomlrt.loads(src)
+    doc.sort()
+    once = tomlrt.dumps(doc)
+    doc.sort()  # idempotent: already sorted
+    twice = tomlrt.dumps(doc)
+    assert once == twice

--- a/tests/test_synthesise_and_io.py
+++ b/tests/test_synthesise_and_io.py
@@ -18,7 +18,7 @@ import pytest
 
 import tomlrt
 from _helpers import td
-from tomlrt import Document, Table
+from tomlrt import Document, Table, TOMLError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -311,7 +311,7 @@ def test_assign_inline_table_containing_aot_value_rejected() -> None:
     )
     dest = tomlrt.loads("dest = 0\n")
     aot = src.aot("products")
-    with pytest.raises(NotImplementedError, match="AoT"):
+    with pytest.raises(TOMLError, match="array-of-tables"):
         dest["dest"] = {"items": aot}
 
 
@@ -325,8 +325,27 @@ def test_assign_inline_table_containing_section_container_rejected() -> None:
     )
     dest = tomlrt.loads("dest = 0\n")
     section = src.table("sub")
-    with pytest.raises(NotImplementedError, match="section Container"):
+    with pytest.raises(TOMLError, match="section-style table"):
         dest["dest"] = {"nested": section}
+
+
+def test_detached_inline_rejects_section_value_eagerly() -> None:
+    """A detached ``Table.inline()`` used to silently accept a
+    section-typed value, with the error deferred to attach time. The
+    check is now eager: it fires at the actual point of mistake.
+    """
+    sub = Table.section({"y": 1})
+    parent = Table.inline()
+    with pytest.raises(TOMLError, match="section-style table"):
+        parent["x"] = sub
+
+
+def test_detached_inline_rejects_aot_value_eagerly() -> None:
+    """Sibling of the section case: detached inline rejects AoT eagerly."""
+    aot = tomlrt.AoT([{"name": "a"}])
+    parent = Table.inline()
+    with pytest.raises(TOMLError, match="array-of-tables"):
+        parent["x"] = aot
 
 
 def test_assign_aot_over_scalar() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -870,7 +870,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli" },
 ]
 docs = [
     { name = "mkdocstrings", extra = ["python"] },
@@ -886,7 +886,7 @@ dev = [
     { name = "mypy", specifier = ">=1.11" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-cov", specifier = ">=5" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2" },
+    { name = "tomli", specifier = ">=2.2" },
 ]
 docs = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "tomlrt"
-version = "1.4.3"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Addresses a batch of issues filed while migrating `toml-sort` from `tomlkit` to `tomlrt`.

## Issues fixed

| # | Topic |
|---|---|
| 108 | Cross-document clone preserves nested AoTs |
| 109 | Cross-doc table assign preserves header leading comments |
| 110 | `aot[i] = src_entry` preserves nested AoTs |
| 111 | Adding a sub-section to an empty parent preserves `Document.preamble` |
| 112 | Cross-doc `dst[k] = src_section` under empty parent demotes parent to implicit |
| 113 | Reject section / AoT values inside inline tables uniformly |
| 115 | Expose dotted-key comments via the dotted-parent container |
| 117 | Normalise item 0 indent on `Array.sort` / `reverse` |
| 118 | Preserve child trivia on `install("a.b", value)` with synthesised parent |
| 120 | `Array.sort` / `Array.reverse` keep per-item leadings with their items |
| 121 | Drop source preamble on cross-doc clone and AoT sort |
| 122 | Fix `Array.leading_comments` mutation around EOL-comment neighbours |
| 123 | Add `Container.leading_block` / `Table.header_leading_block` |
| 124 | Preserve dotted-key form on per-key clone |
| 125 | Add `Container.sort` for trivia-preserving key reorder |
| 126 | Disjoin `header_leading_block` from `Document.preamble` |
| 127 | Reject detached-comments mutation with a clear `TOMLError` |

Plus `Table.is_inline` (a small API addition asked for during the same review).

## Validation

`pytest -q` (1731 + 18 slow), `mypy`, `ruff check`, `ruff format --check` all clean across Python 3.10–3.14; docs build clean.
