### PR TITLE
Add Container.format() and Array.format()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-05-25
+
 ### Added
 
 - `Container.format(*, comments: bool = True)` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Container.format(*, comments: bool = True)` and
+  `Array.format(*, comments: bool = True)` reformat a section,
+  document, table, or inline array in place. See
+  [docs/formatting.md](docs/formatting.md) for details.
+
 ## [1.5.0] - 2026-05-24
 
 ### Added

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -156,3 +156,17 @@ doc.promote_array("pkgs")                      # → [[pkgs]] … [[pkgs]]
 
 Promotion is rejected if it would lose inner comments; clear them first (see
 [Comments](comments.md)).
+
+## Canonical formatting
+
+Whenever you want to drop format preservation and snap a section, document, or
+array to a canonical layout, call `format()`:
+
+```python
+doc.format()           # whole document
+doc.table("tool").format()
+doc.array("pkgs").format()
+```
+
+See [Formatting](formatting.md) for what `format()` rewrites and what it
+leaves alone.

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -1,0 +1,94 @@
+# Formatting documents
+
+`tomlrt` is format-preserving by design: parsing and dumping a document
+returns exactly the same bytes. When you want to *opt in* to canonical
+formatting — for a single value, a section, or the whole document —
+call `format()`.
+
+## `Container.format(*, comments=True)` / `Array.format(*, comments=True)`
+
+Both methods mutate in place and return `None`, mirroring `list.sort()`.
+
+```python
+import tomlrt
+
+doc = tomlrt.loads("""
+a   =1
+b=2
+arr=[1,2 ,3 ]
+
+
+[bar]
+x={a=1,b=2}
+""")
+
+doc.format()
+print(tomlrt.dumps(doc))
+```
+
+prints
+
+```toml
+a = 1
+b = 2
+arr = [1, 2, 3]
+
+[bar]
+x = { a = 1, b = 2 }
+```
+
+## What gets normalised
+
+- **Whitespace around `=`**: collapsed to one space on each side.
+- **Dotted keys**: separators become bare `.` (no surrounding whitespace).
+  The user's bare-vs-quoted spelling for each key segment is preserved.
+- **Header brackets**: `[  a . b  ]` → `[a.b]`.
+- **Inline arrays and inline tables**: spacing collapses to the
+  canonical form (`[1, 2, 3]`, `{ x = 1, y = 2 }`). The array's
+  overall *shape* is preserved — a multi-line array stays multi-line,
+  and a single-line array stays single-line.
+- **Blank lines between sibling KVs** collapse to none.
+- **Blank lines before structural section / array-of-tables headers**
+  collapse to exactly one.
+- **All newlines** are retargeted to the owning document's newline
+  style (LF or CRLF), including newlines inside multi-line inline
+  values.
+
+## What is preserved
+
+- The document **preamble** (any leading comments above the first
+  section).
+- **Orphan comment blocks** — comment runs separated from a key or
+  header by at least one blank line — are kept verbatim in place.
+- Each key's **attached comment block** (the comments immediately
+  above the key, with no intervening blank line) stays attached.
+- Multi-line inline values keep their multi-line shape.
+- Slots outside the receiver's subtree are not touched: calling
+  `format()` on a single section leaves sibling sections alone.
+
+## The `comments` flag
+
+When `comments=True` (the default), every comment reached by the walk
+is rewritten so that there is exactly one space between `#` and the
+body, and any trailing whitespace inside the comment is stripped:
+
+| Before | After |
+|--------|-------|
+| `#foo` | `# foo` |
+| `#   foo` | `# foo` |
+| `# foo   ` | `# foo` |
+| `#` (empty) | `#` |
+
+Pass `comments=False` to leave comment text untouched. (Trailing
+whitespace on otherwise-blank lines is still cleaned up — that is a
+formatting fix, not a comment fix.)
+
+## Detached views
+
+`format()` works on attached containers and arrays — those reachable
+from a parsed or built `Document`. Calling it on a detached
+`Table.section()` or `Table.inline()` factory raises `TOMLError`:
+there is no document to canonicalise against.
+
+A nested inline `Table` value reached from inside a parsed document
+*is* attached and can be formatted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tomlrt"
-version = "1.5.0"
+version = "1.6.0"
 description = "A format-preserving TOML reader and writer for Python."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -28,6 +28,7 @@ from tomlrt._array_comments import (
     snapshot_comments,
 )
 from tomlrt._errors import TOMLError
+from tomlrt._format import _canon_inline_value
 from tomlrt._trivia import (
     CommentNode,
     NewlineNode,
@@ -224,6 +225,20 @@ class Array(list[Any]):
     def leading_comments(self) -> ArrayLeadingView:
         """Leading-comment view, indexed by item position."""
         return ArrayLeadingView(self)
+
+    def format(self, *, comments: bool = True) -> None:
+        """Canonicalise this array's formatting in place.
+
+        Rewrites whitespace, indentation, separators, and newlines to a
+        canonical layout, while preserving the array's overall shape
+        (single-line stays single-line, multi-line stays multi-line)
+        and the *content* of any orphan comment blocks above items.
+
+        When ``comments`` is true (the default), comment text is also
+        normalised: ``#foo`` and ``#   foo`` both become ``# foo``, and
+        trailing whitespace inside comments is stripped.
+        """
+        _canon_inline_value(self._value, nl=self._doc_newline, comments=comments)
 
     def set_multiline(self, *, multiline: bool, indent: str = "    ") -> Array:
         """Switch this array between flush single-line and multi-line form.

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -39,6 +39,13 @@ from tomlrt._comments import (
     _header_leading_set,
 )
 from tomlrt._errors import TOMLError
+from tomlrt._format import (
+    _canon_header_slot,
+    _canon_inline_value,
+    _canon_kv_slot,
+    _canon_leading,
+    format_subtree,
+)
 from tomlrt._kind import _Kind
 from tomlrt._paths import split_path, validate_path
 from tomlrt._render import render
@@ -245,6 +252,86 @@ class Container(dict[str, Any]):
         r"""The active newline of the owning document, or ``"\n"`` if detached."""
         lr = self._layout_root
         return lr._newline if lr is not None else "\n"  # noqa: SLF001
+
+    def format(self, *, comments: bool = True) -> None:
+        """Canonicalise this container's formatting in place.
+
+        Rewrites whitespace, indentation, separators, and newlines to a
+        canonical layout for every slot in this container's subtree:
+
+        * Keys, ``=`` spacing, and header brackets use canonical
+          whitespace.
+        * Blank lines between sibling key/value slots collapse to none;
+          structural section / array-of-tables headers are preceded by
+          exactly one blank line.
+        * Orphan comment blocks above slots are preserved verbatim.
+        * Inline arrays and inline tables are reformatted in place
+          while preserving their overall shape (single-line stays
+          single-line, multi-line stays multi-line).
+        * All newline characters are retargeted to the owning
+          document's newline style.
+
+        When ``comments`` is true (the default), comment text is also
+        normalised: ``#foo`` and ``#   foo`` both become ``# foo``, and
+        trailing whitespace inside comments is stripped.
+
+        Detached factory-style containers (``Table.section()`` /
+        ``Table.inline()`` not yet assigned anywhere) and inline
+        dotted-navigator views are not supported; calling
+        ``format()`` on one raises `TOMLError`.
+        """
+        kind = self._kind
+        nl = self._doc_newline
+
+        if kind is _Kind.INLINE_ROOT:
+            assert self._value is not None
+            _canon_inline_value(self._value, nl=nl, comments=comments)
+            return
+
+        if kind in (_Kind.INLINE_FACTORY, _Kind.INLINE_DOTTED_INNER):
+            msg = "format() is not supported on detached inline-table views"
+            raise TOMLError(msg)
+
+        if kind is _Kind.DOCUMENT:
+            assert isinstance(self, Document)
+            format_subtree(
+                start=self._head,
+                path=(),
+                nl=nl,
+                comments=comments,
+            )
+            return
+
+        if kind is _Kind.SECTION:
+            assert self._header_ref is not None
+            format_subtree(
+                start=self._header_ref.slot,
+                path=self._path,
+                nl=nl,
+                comments=comments,
+            )
+            return
+
+        # IMPLICIT_SECTION: slots are not contiguous in the doc stream,
+        # so we cannot do a subtree walk with inter-slot blank-line
+        # collapse.  Just canonicalise each owned slot's content and
+        # recurse into nested views via dict storage.
+        if not self._attached:
+            msg = "format() requires the container to be attached to a Document"
+            raise TOMLError(msg)
+        for ref in list(self._refs):
+            slot = ref.slot
+            if isinstance(slot, KVSlot):
+                _canon_kv_slot(slot, nl=nl, comments=comments)
+            elif isinstance(slot, StructuralHeaderSlot):
+                _canon_header_slot(slot, nl=nl, comments=comments)
+            _canon_leading(slot, nl=nl, target_blanks=None, comments=comments)
+        for value in self.values():
+            if isinstance(value, (Container, Array)):
+                value.format(comments=comments)
+            elif isinstance(value, AoT):
+                for entry in value:
+                    entry.format(comments=comments)
 
     @property
     def _attached(self) -> bool:

--- a/src/tomlrt/_format.py
+++ b/src/tomlrt/_format.py
@@ -1,0 +1,521 @@
+"""Container / Array formatter — canonicalise layout without losing comments.
+
+Pure functions over slots / trivia / values. Idempotent and
+shape-preserving for inline values (single-line stays single-line;
+multi-line stays multi-line). Used by the public
+``Container.format`` / ``Array.format`` methods.
+
+Canonical layout enforced here:
+
+KV slot
+    pre_eq=" ", post_eq=" ", key_seps=".", strip column-indent WS,
+    EOL trailing_ws = " " before any comment.
+
+Section / AoT-entry header
+    inner_pre="", inner_post="", strip column-indent WS, EOL as for KV.
+
+Sibling spacing (within the subtree of the container being formatted)
+    Between body KVs of the same container: 0 blank lines.
+    Between sibling sections / AoT entries / between body and next
+    section: exactly 1 blank line.
+
+Inline arrays / inline tables
+    Single-line: ``[a, b, c]`` / ``{ a = 1, b = 2 }``.
+    Multi-line: each item on its own line, last item carries a
+    trailing comma. Indent inherited from the first item if present
+    else two spaces.
+
+Orphan comment blocks (``# …`` runs separated from the slot/header
+by a blank line) and EOL / leading-attached comments are preserved
+in place — comment text is rewritten to ``# body`` form when
+``comments=True``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tomlrt._slots import KVSlot, StructuralHeaderSlot
+from tomlrt._trivia import (
+    CommentNode,
+    NewlineNode,
+    Trivia,
+    WhitespaceNode,
+    join_above_block,
+    retarget_eol_newline,
+    retarget_trivia_newlines,
+    split_above_block,
+    split_item_above,
+    trivia_has_newline,
+)
+from tomlrt._values import (
+    ArrayValue,
+    InlineTableEntry,
+    InlineTableValue,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from tomlrt._slots import Slot
+    from tomlrt._trivia import (
+        EolTrivia,
+        TriviaPiece,
+    )
+    from tomlrt._values import (
+        ArrayItem,
+        Value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comment text + line cleanup
+# ---------------------------------------------------------------------------
+
+
+def _canon_comment_text(text: str) -> str:
+    """Rewrite a comment lexeme to canonical ``# body`` / ``#`` form.
+
+    Input always starts with ``#``.  Normalises any leading whitespace
+    inside the body to exactly one space; strips trailing whitespace.
+    An empty-body comment collapses to a bare ``#``.
+    """
+    assert text.startswith("#"), text
+    body = text[1:].rstrip().lstrip(" \t")
+    return "# " + body if body else "#"
+
+
+def _canon_trivia_text(
+    t: Trivia, *, comments: bool, strip_pre_comment_ws: bool = True
+) -> None:
+    r"""Normalise trivia content in place.
+
+    Always strips trailing whitespace on blank lines (``  \n`` →
+    ``\n``).  When ``strip_pre_comment_ws`` is true (the default),
+    also strips any whitespace that precedes a CommentNode within
+    a trivia line (column indent of orphan / attached comments —
+    canonical column 0).  Pass ``strip_pre_comment_ws=False`` for
+    EOL-style trivia where the space between the previous token and
+    the ``#`` is the structural separator, set by the caller.
+
+    When ``comments`` is true also rewrites each CommentNode's text
+    via :func:`_canon_comment_text`.
+
+    Newline text itself is untouched here; callers run
+    :func:`retarget_trivia_newlines` separately.
+    """
+    pieces = t.pieces
+    new: list[TriviaPiece] = []
+    line: list[TriviaPiece] = []
+    for p in pieces:
+        if isinstance(p, NewlineNode):
+            while line and isinstance(line[-1], WhitespaceNode):
+                line.pop()
+            new.extend(line)
+            new.append(p)
+            line = []
+            continue
+        if isinstance(p, CommentNode):
+            if strip_pre_comment_ws:
+                while line and isinstance(line[-1], WhitespaceNode):
+                    line.pop()
+            if comments:
+                p.text = _canon_comment_text(p.text)
+            new.extend(line)
+            new.append(p)
+            line = []
+            continue
+        line.append(p)
+    new.extend(line)
+    t.pieces = new
+
+
+# ---------------------------------------------------------------------------
+# Leading trivia of slots
+# ---------------------------------------------------------------------------
+
+
+def _split_lines(pieces: list[TriviaPiece]) -> list[list[TriviaPiece]]:
+    """Group pieces into lines terminated by NewlineNode (or the tail)."""
+    out: list[list[TriviaPiece]] = []
+    cur: list[TriviaPiece] = []
+    for p in pieces:
+        cur.append(p)
+        if isinstance(p, NewlineNode):
+            out.append(cur)
+            cur = []
+    if cur:
+        out.append(cur)
+    return out
+
+
+def _line_has_comment(line: list[TriviaPiece]) -> bool:
+    return any(isinstance(p, CommentNode) for p in line)
+
+
+def _line_has_newline(line: list[TriviaPiece]) -> bool:
+    return any(isinstance(p, NewlineNode) for p in line)
+
+
+def _canon_leading(
+    slot: Slot,
+    *,
+    nl: str,
+    target_blanks: int | None,
+    comments: bool,
+) -> None:
+    """Rewrite ``slot.leading`` to canonical form.
+
+    The leading is decomposed into three regions:
+
+    * ``head_blanks`` — leading whitespace-only lines (structural
+      blank gap from the previous slot)
+    * ``middle`` — everything else *except* the slot's own column
+      indent (orphan blank-separated groups + the attached comment
+      run)
+    * ``indent`` — the slot's column-indent line (trailing
+      whitespace-only piece with no terminating newline)
+
+    Canonical form: ``target_blanks`` blank lines at the head,
+    middle preserved verbatim (with newline / comment text
+    normalised), no indent at the tail.
+
+    When ``target_blanks`` is ``None`` the head-blank region is
+    preserved verbatim (used for the first slot in a document /
+    subtree, where the preceding gap is owned by something outside
+    the subtree).
+    """
+    lines = _split_lines(list(slot.leading.pieces))
+
+    # Trailing column-indent line (no newline, no comment).
+    if lines and not _line_has_newline(lines[-1]) and not _line_has_comment(lines[-1]):
+        # Drop it entirely — canonical layout is unindented.
+        lines.pop()
+
+    # Split off the head-blank region (run of newline-only lines at the start).
+    head_count = 0
+    while head_count < len(lines) and not _line_has_comment(lines[head_count]):
+        if not _line_has_newline(lines[head_count]):
+            break
+        head_count += 1
+    middle = lines[head_count:]
+
+    # Normalise newline / comment / blank-line WS in the middle.
+    middle_t = Trivia([p for line in middle for p in line])
+    retarget_trivia_newlines(middle_t, nl)
+    _canon_trivia_text(middle_t, comments=comments)
+
+    # Pick the head-blank count:
+    #
+    # * ``target_blanks is None`` — preamble / subtree boundary,
+    #   preserve the user's count verbatim.
+    # * ``middle`` non-empty — comment block carries the user's
+    #   separation intent; clamp the head blank to 0 or 1 matching
+    #   whether the source had a blank above the comment block.
+    # * otherwise — apply the structural ``target_blanks`` exactly.
+    if target_blanks is None:
+        n_blanks = head_count
+    elif middle:
+        n_blanks = min(head_count, 1)
+    else:
+        n_blanks = target_blanks
+    head_t = Trivia([NewlineNode(nl)] * n_blanks)
+
+    slot.leading.pieces = [*head_t.pieces, *middle_t.pieces]
+
+
+# ---------------------------------------------------------------------------
+# EOL
+# ---------------------------------------------------------------------------
+
+
+def _canon_eol(eol: EolTrivia, *, nl: str, comments: bool) -> None:
+    """Normalise an :class:`EolTrivia`.
+
+    * Newline retargeted to ``nl`` (preserved as ``None`` for the
+      last line of a no-final-newline file).
+    * ``trailing_ws`` → ``None`` when no comment; ``" "`` (one
+      space) before a comment.
+    * Comment text rewritten when ``comments`` is true.
+    """
+    retarget_eol_newline(eol, nl)
+    if eol.comment is None:
+        eol.trailing_ws = None
+        return
+    if comments:
+        eol.comment.text = _canon_comment_text(eol.comment.text)
+    eol.trailing_ws = WhitespaceNode(" ")
+
+
+# ---------------------------------------------------------------------------
+# Key parts
+# ---------------------------------------------------------------------------
+
+
+def _canon_key_equals(node: KVSlot | InlineTableEntry) -> None:
+    """Canonicalise the key / ``=`` body of a KV slot or inline-table entry."""
+    node.pre_eq = " "
+    node.post_eq = " "
+    node.key_seps = ["."] * (len(node.key_parts) - 1)
+
+
+# ---------------------------------------------------------------------------
+# Slots — KV / Header
+# ---------------------------------------------------------------------------
+
+
+def _canon_kv_slot(slot: KVSlot, *, nl: str, comments: bool) -> None:
+    """Normalise a KV slot's body (key/eq/value/eol).
+
+    Leading is handled separately by :func:`_canon_leading` so that
+    the subtree-aware blank-line policy can be applied at the walk
+    level.
+    """
+    _canon_key_equals(slot)
+    _canon_value(slot.value, nl=nl, comments=comments)
+    _canon_eol(slot.eol, nl=nl, comments=comments)
+
+
+def _canon_header_slot(slot: StructuralHeaderSlot, *, nl: str, comments: bool) -> None:
+    slot.inner_pre = ""
+    slot.inner_post = ""
+    slot.key_seps = ["."] * (len(slot.key_parts) - 1)
+    _canon_eol(slot.eol, nl=nl, comments=comments)
+
+
+# ---------------------------------------------------------------------------
+# Inline values
+# ---------------------------------------------------------------------------
+
+
+def _entries_of(
+    v: ArrayValue | InlineTableValue,
+) -> Sequence[ArrayItem | InlineTableEntry]:
+    """Common accessor for the items list of an inline array / table."""
+    return v.items if isinstance(v, ArrayValue) else v.entries
+
+
+def _value_is_multiline(av: ArrayValue | InlineTableValue) -> bool:
+    """Shape detection: any structural NewlineNode inside means multi-line."""
+    if trivia_has_newline(av.header_trivia) or trivia_has_newline(av.final_trivia):
+        return True
+    for it in _entries_of(av):
+        if (
+            trivia_has_newline(it.leading)
+            or trivia_has_newline(it.post_comma_trivia)
+            or trivia_has_newline(it.trailing)
+        ):
+            return True
+    return False
+
+
+def _canon_inline_value(
+    v: ArrayValue | InlineTableValue,
+    *,
+    nl: str,
+    comments: bool,
+    parent_indent: str = "",
+) -> None:
+    """Canonicalise the layout of an inline array or inline table.
+
+    Recurses into nested inline values, then dispatches to the
+    single-line or multi-line shape, then (for multi-line) runs a
+    final text pass over the value's trivia tree.
+    """
+    items = _entries_of(v)
+    multi = _value_is_multiline(v)
+    item_indent = parent_indent + "  " if multi else parent_indent
+
+    for it in items:
+        if isinstance(it, InlineTableEntry):
+            _canon_key_equals(it)
+        _canon_value(it.value, nl=nl, comments=comments, parent_indent=item_indent)
+
+    if not multi:
+        _canon_single_line_inline(v)
+        return
+
+    _canon_multi_line_items(items, nl=nl, indent=item_indent)
+    head_pad = (
+        Trivia([NewlineNode(nl), WhitespaceNode(item_indent)]) if items else Trivia()
+    )
+    final_pad = Trivia(
+        [NewlineNode(nl), WhitespaceNode(parent_indent)]
+        if parent_indent
+        else [NewlineNode(nl)]
+    )
+    v.header_trivia = _replace_pad(v.header_trivia, head_pad)
+    v.final_trivia = _replace_pad(v.final_trivia, final_pad)
+    # Single-line shaping produces only empty / single-space trivia
+    # (no newlines, no comments), so the finalise pass would be a
+    # no-op there.
+    _finalise_inline_trivia(v, nl=nl, comments=comments)
+
+
+def _replace_pad(t: Trivia, new_pad: Trivia) -> Trivia:
+    """Substitute the bracket-pad of ``t`` while preserving its above-block."""
+    _, above = split_above_block(t)
+    return join_above_block(new_pad, above)
+
+
+def _inner_space(v: ArrayValue | InlineTableValue) -> Trivia:
+    """Bracket-inner padding for a single-line inline value.
+
+    Inline tables wear ``{ a = 1 }`` with one space of inner
+    padding; inline arrays wear ``[a, b]`` with none.  Each call
+    produces a fresh ``Trivia`` so callers can assign it to
+    ``header_trivia`` and ``final_trivia`` independently.
+    """
+    if isinstance(v, InlineTableValue) and v.entries:
+        return Trivia([WhitespaceNode(" ")])
+    return Trivia()
+
+
+def _canon_single_line_inline(v: ArrayValue | InlineTableValue) -> None:
+    v.header_trivia = _inner_space(v)
+    v.final_trivia = _inner_space(v)
+    items = _entries_of(v)
+    n = len(items)
+    for k, it in enumerate(items):
+        it.leading = Trivia() if k == 0 else Trivia([WhitespaceNode(" ")])
+        it.trailing = Trivia()
+        it.post_comma_trivia = Trivia()
+        it.has_comma = k < n - 1
+
+
+def _finalise_inline_trivia(
+    v: ArrayValue | InlineTableValue, *, nl: str, comments: bool
+) -> None:
+    """Retarget newlines + canonicalise comment / blank-WS text across ``v``.
+
+    Run after shape canonicalisation; touches the bracket-pad trivia
+    and every per-item trivia channel.
+    """
+    retarget_trivia_newlines(v.header_trivia, nl)
+    retarget_trivia_newlines(v.final_trivia, nl)
+    _canon_trivia_text(v.header_trivia, comments=comments)
+    _canon_trivia_text(v.final_trivia, comments=comments)
+    for it in _entries_of(v):
+        retarget_trivia_newlines(it.leading, nl)
+        retarget_trivia_newlines(it.trailing, nl)
+        retarget_trivia_newlines(it.post_comma_trivia, nl)
+        _canon_trivia_text(it.leading, comments=comments)
+        # ``trailing`` and ``post_comma_trivia`` are EOL contexts:
+        # the space before ``#`` is the structural separator the
+        # callers have already canonicalised to one space.
+        _canon_trivia_text(it.trailing, comments=comments, strip_pre_comment_ws=False)
+        _canon_trivia_text(
+            it.post_comma_trivia, comments=comments, strip_pre_comment_ws=False
+        )
+
+
+def _canon_multi_line_items(
+    items: Sequence[ArrayItem | InlineTableEntry],
+    *,
+    nl: str,
+    indent: str,
+) -> None:
+    r"""Shape-preserving multi-line canonicalisation of per-item trivia.
+
+    For each item k:
+      - k == 0: ``leading`` stays empty (item 0's structural pad
+        lives in ``header_trivia`` per the canonical model).
+      - k >= 1: split into (head_pad, above, tail_pad) via
+        :func:`split_item_above`; replace head/tail with canonical
+        ``\n`` + indent; preserve ``above`` (an above-item comment
+        block, possibly empty).
+
+    All items get ``has_comma=True`` (trailing-comma idiom).
+    ``post_comma_trivia`` shrinks to just an EOL section (`" #
+    comment\n"`) if a comment was attached, otherwise empty.
+    """
+    for k, it in enumerate(items):
+        if k == 0:
+            it.leading = Trivia()
+        else:
+            _, above, _ = split_item_above(it.leading)
+            canon_pad = Trivia([NewlineNode(nl), WhitespaceNode(indent)])
+            it.leading = join_above_block(canon_pad, above)
+        it.trailing = Trivia()
+        it.has_comma = True
+        _canon_post_comma_trivia(it, nl=nl)
+
+
+def _canon_post_comma_trivia(item: ArrayItem | InlineTableEntry, *, nl: str) -> None:
+    # Look at the first non-WS piece: if it's a comment, keep it as an EOL.
+    first = next(
+        (p for p in item.post_comma_trivia.pieces if not isinstance(p, WhitespaceNode)),
+        None,
+    )
+    if isinstance(first, CommentNode):
+        item.post_comma_trivia = Trivia([WhitespaceNode(" "), first, NewlineNode(nl)])
+    else:
+        item.post_comma_trivia = Trivia()
+
+
+# ---------------------------------------------------------------------------
+# Value dispatch
+# ---------------------------------------------------------------------------
+
+
+def _canon_value(v: Value, *, nl: str, comments: bool, parent_indent: str = "") -> None:
+    if isinstance(v, (ArrayValue, InlineTableValue)):
+        _canon_inline_value(v, nl=nl, comments=comments, parent_indent=parent_indent)
+    # Other value kinds carry no formattable trivia.
+
+
+# ---------------------------------------------------------------------------
+# Subtree walk and orchestration
+# ---------------------------------------------------------------------------
+
+
+def _in_subtree(slot: Slot, path: tuple[str, ...]) -> bool:
+    """True iff ``slot`` belongs to the subtree rooted at ``path``."""
+    if isinstance(slot, KVSlot):
+        return slot.host_path[: len(path)] == path
+    assert isinstance(slot, StructuralHeaderSlot)
+    return slot.path[: len(path)] == path
+
+
+def format_subtree(
+    *,
+    start: Slot | None,
+    path: tuple[str, ...],
+    nl: str,
+    comments: bool,
+) -> None:
+    """Canonicalise every slot in the subtree rooted at ``path``.
+
+    Walks the doc-stream linked list starting at ``start`` forward,
+    stopping at the first slot outside the subtree.
+
+    The first slot's leading head-blanks are preserved verbatim
+    (they belong to the document preamble or to the parent of the
+    subtree).  Subsequent slots' leading head-blanks are rewritten
+    to the canonical count: 1 blank line before any structural
+    header, 0 otherwise.
+    """
+    first = True
+    slot = start
+    while slot is not None and _in_subtree(slot, path):
+        if isinstance(slot, KVSlot):
+            _canon_kv_slot(slot, nl=nl, comments=comments)
+        elif isinstance(slot, StructuralHeaderSlot):
+            _canon_header_slot(slot, nl=nl, comments=comments)
+        target: int | None = (
+            None if first else (1 if isinstance(slot, StructuralHeaderSlot) else 0)
+        )
+        _canon_leading(slot, nl=nl, target_blanks=target, comments=comments)
+        first = False
+        slot = slot._next  # noqa: SLF001
+
+
+__all__ = [
+    "_canon_eol",
+    "_canon_header_slot",
+    "_canon_inline_value",
+    "_canon_kv_slot",
+    "_canon_leading",
+    "_canon_value",
+    "format_subtree",
+]

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,421 @@
+"""Tests for `Container.format()` and `Array.format()`."""
+
+from __future__ import annotations
+
+import pytest
+import tomli
+
+import tomlrt
+from _helpers import td
+from tomlrt import TOMLError
+
+
+def _roundtrip(src: str, *, comments: bool = True) -> str:
+    doc = tomlrt.loads(src)
+    doc.format(comments=comments)
+    return tomlrt.dumps(doc)
+
+
+def test_idempotent() -> None:
+    src = td("""
+        [foo]
+        a    =   1
+        b=2
+        arr = [1,2 ,3]
+    """)
+    once = _roundtrip(src)
+    doc = tomlrt.loads(once)
+    doc.format()
+    twice = tomlrt.dumps(doc)
+    assert once == twice
+
+
+def test_kv_spacing() -> None:
+    src = td("""
+        a   =1
+        b=2
+    """)
+    assert _roundtrip(src) == td("""
+        a = 1
+        b = 2
+    """)
+
+
+def test_dotted_key_normalised() -> None:
+    src = "a . b   .  c = 1\n"
+    assert _roundtrip(src) == "a.b.c = 1\n"
+
+
+def test_header_brackets() -> None:
+    src = td("""
+        [  a . b  ]
+        x = 1
+    """)
+    assert _roundtrip(src) == td("""
+        [a.b]
+        x = 1
+    """)
+
+
+def test_inter_kv_blank_collapses() -> None:
+    src = td("""
+        a = 1
+
+
+        b = 2
+    """)
+    assert _roundtrip(src) == td("""
+        a = 1
+        b = 2
+    """)
+
+
+def test_inter_section_blank_canonical() -> None:
+    src = td("""
+        [a]
+        x = 1
+
+
+
+        [b]
+        y = 2
+    """)
+    assert _roundtrip(src) == td("""
+        [a]
+        x = 1
+
+        [b]
+        y = 2
+    """)
+
+
+def test_two_sections_touching_get_blank() -> None:
+    src = td("""
+        [a]
+        x = 1
+        [b]
+        y = 2
+    """)
+    assert _roundtrip(src) == td("""
+        [a]
+        x = 1
+
+        [b]
+        y = 2
+    """)
+
+
+def test_orphan_comment_block_preserved() -> None:
+    src = td("""
+        a = 1
+
+        # orphan one
+        # orphan two
+
+        # attached
+        b = 2
+    """)
+    assert _roundtrip(src) == td("""
+        a = 1
+
+        # orphan one
+        # orphan two
+
+        # attached
+        b = 2
+    """)
+
+
+def test_blank_above_orphan_preserved_when_collapsing() -> None:
+    # The structural blank between sibling KVs normally collapses to
+    # zero, but if there's an orphan / attached comment block above
+    # the next slot the blank stays so the block is visually
+    # separated from the previous slot.
+    src = td("""
+        a = 1
+
+
+        # orphan
+        b = 2
+    """)
+    assert _roundtrip(src) == td("""
+        a = 1
+
+        # orphan
+        b = 2
+    """)
+
+
+def test_single_line_inline_array() -> None:
+    src = "arr = [1,2 ,3 ]\n"
+    assert _roundtrip(src) == "arr = [1, 2, 3]\n"
+
+
+def test_inline_table_single_line() -> None:
+    src = "t = {a=1,b=2}\n"
+    assert _roundtrip(src) == "t = { a = 1, b = 2 }\n"
+
+
+def test_multiline_array_preserved_shape() -> None:
+    src = td("""
+        arr = [
+          1,
+          2,
+          3,
+        ]
+    """)
+    assert _roundtrip(src) == td("""
+        arr = [
+          1,
+          2,
+          3,
+        ]
+    """)
+
+
+def test_nested_multiline_array_indents_per_depth() -> None:
+    src = td("""
+        outer = [
+        [
+        1,
+        2,
+        ],
+        [
+        3,
+        4,
+        ],
+        ]
+    """)
+    assert _roundtrip(src) == td("""
+        outer = [
+          [
+            1,
+            2,
+          ],
+          [
+            3,
+            4,
+          ],
+        ]
+    """)
+
+
+def test_nested_multiline_table_indents_per_depth() -> None:
+    src = td("""
+        outer = {
+        a = {
+        x = 1,
+        y = 2,
+        },
+        b = {
+        x = 3,
+        y = 4,
+        },
+        }
+    """)
+    assert _roundtrip(src) == td("""
+        outer = {
+          a = {
+            x = 1,
+            y = 2,
+          },
+          b = {
+            x = 3,
+            y = 4,
+          },
+        }
+    """)
+
+
+def test_nested_array_in_multiline_table_indents() -> None:
+    src = td("""
+        outer = {
+        items = [
+        1,
+        2,
+        ],
+        }
+    """)
+    assert _roundtrip(src) == td("""
+        outer = {
+          items = [
+            1,
+            2,
+          ],
+        }
+    """)
+
+
+def test_nested_table_in_multiline_array_indents() -> None:
+    src = td("""
+        outer = [
+        {
+        x = 1,
+        y = 2,
+        },
+        {
+        x = 3,
+        y = 4,
+        },
+        ]
+    """)
+    assert _roundtrip(src) == td("""
+        outer = [
+          {
+            x = 1,
+            y = 2,
+          },
+          {
+            x = 3,
+            y = 4,
+          },
+        ]
+    """)
+
+
+def test_aot_recursion() -> None:
+    src = td("""
+        [[a]]
+        x=  1
+
+        [[a]]
+        x=2
+    """)
+    assert _roundtrip(src) == td("""
+        [[a]]
+        x = 1
+
+        [[a]]
+        x = 2
+    """)
+
+
+def test_comments_false_keeps_comment_text() -> None:
+    src = td("""
+        a = 1   #foo
+        b = 2   #   bar
+    """)
+    assert _roundtrip(src, comments=False) == td("""
+        a = 1 #foo
+        b = 2 #   bar
+    """)
+
+
+def test_comments_true_normalises_text() -> None:
+    src = "a = 1 #foo\nb = 2 #   bar\nc = 3 # baz   \n"
+    assert _roundtrip(src, comments=True) == td("""
+        a = 1 # foo
+        b = 2 # bar
+        c = 3 # baz
+    """)
+
+
+def test_bare_hash_comment_stays() -> None:
+    assert _roundtrip("a = 1 #\n", comments=True) == "a = 1 #\n"
+
+
+def test_crlf_newlines_retargeted() -> None:
+    src = "a   =   1\r\nb=2\r\n"
+    out = _roundtrip(src)
+    assert out == "a = 1\r\nb = 2\r\n"
+
+
+def test_preamble_preserved() -> None:
+    src = td("""
+        # preamble line one
+        # preamble line two
+
+        [a]
+        x = 1
+    """)
+    assert _roundtrip(src) == td("""
+        # preamble line one
+        # preamble line two
+
+        [a]
+        x = 1
+    """)
+
+
+def test_detached_section_raises() -> None:
+    t = tomlrt.Table.section()
+    t["x"] = 1
+    with pytest.raises(TOMLError):
+        t.format()
+
+
+def test_detached_inline_factory_raises() -> None:
+    t = tomlrt.Table.inline()
+    t["x"] = 1
+    with pytest.raises(TOMLError):
+        t.format()
+
+
+def test_inline_root_format() -> None:
+    src = "t = {x=1, y=2}\n"
+    doc = tomlrt.loads(src)
+    t = doc.table("t")
+    t.format()
+    assert tomlrt.dumps(doc) == "t = { x = 1, y = 2 }\n"
+
+
+def test_array_format_direct() -> None:
+    src = "arr = [1, 2,3 ]\n"
+    doc = tomlrt.loads(src)
+    arr = doc.array("arr")
+    arr.format()
+    assert tomlrt.dumps(doc) == "arr = [1, 2, 3]\n"
+
+
+def test_section_scoped() -> None:
+    src = td("""
+        [keep]
+        a   =1
+
+
+
+        [target]
+        b   =2
+    """)
+    doc = tomlrt.loads(src)
+    doc.table("target").format()
+    # 'keep' subtree is untouched (raw spacing, blank gap intact);
+    # 'target' subtree is canonicalised, but the gap above its header
+    # is owned by the parent so it stays as-is.
+    assert tomlrt.dumps(doc) == td("""
+        [keep]
+        a   =1
+
+
+
+        [target]
+        b = 2
+    """)
+
+
+def test_format_returns_none() -> None:
+    doc = tomlrt.loads("a = 1\n")
+    assert doc.format() is None  # type: ignore[func-returns-value]
+    arr = tomlrt.loads("a = [1]\n").array("a")
+    assert arr.format() is None  # type: ignore[func-returns-value]
+
+
+def test_roundtrip_through_tomli() -> None:
+    src = td("""
+        # top
+        [section]
+        a = 1
+        b = 2.5
+        c = "hi"
+        arr = [1, 2, 3]
+        inl = { x = 1, y = 2 }
+
+        [[aot]]
+        n = 1
+
+        [[aot]]
+        n = 2
+    """)
+    out = _roundtrip(src)
+
+    assert tomli.loads(out) == tomli.loads(src)

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "tomlrt"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -10,6 +10,7 @@ nav = [
   { "Reading documents" = "reading.md" },
   { "Editing documents" = "editing.md" },
   { Comments = "comments.md" },
+  { Formatting = "formatting.md" },
   { Errors = "errors.md" },
   { "API reference" = "api.md" },
 ]


### PR DESCRIPTION
Introduce format() methods that normalise whitespace, indentation, line endings, separators, and (optionally) comment text in place while preserving the round-trip invariant.

Multi-line inline arrays and tables are re-indented depth-aware: each nesting level adds a two-space step, and every closing bracket sits flush with its surrounding item line.  Orphan and attached comment blocks are preserved verbatim.

See docs/formatting.md for the full specification.