### PR TITLE
Drop dead HeaderSlot aliases; simplify _ArrayStyle

### DIFF
--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -17,6 +17,7 @@ else:  # pragma: no cover -- backport for Python < 3.12
     from typing_extensions import override
 
 from copy import deepcopy
+from dataclasses import dataclass
 
 from tomlrt import _layout_ops
 from tomlrt._array_comments import (
@@ -665,23 +666,14 @@ class Array(list[Any]):
 # ---------------------------------------------------------------------------
 
 
+@dataclass(slots=True, frozen=True)
 class _ArrayStyle:
     """Inferred separator + trailing-comma policy for an Array."""
 
-    __slots__ = ("inter_separator", "is_multiline", "trailing_comma", "trailing_post")
-
-    def __init__(
-        self,
-        *,
-        is_multiline: bool,
-        inter_separator: Trivia,
-        trailing_comma: bool,
-        trailing_post: Trivia,
-    ) -> None:
-        self.is_multiline = is_multiline
-        self.inter_separator = inter_separator
-        self.trailing_comma = trailing_comma
-        self.trailing_post = trailing_post
+    is_multiline: bool
+    inter_separator: Trivia
+    trailing_comma: bool
+    trailing_post: Trivia
 
 
 def _detect_style(value: ArrayValue | None, *, multiline_flag: bool) -> _ArrayStyle:

--- a/src/tomlrt/_slots.py
+++ b/src/tomlrt/_slots.py
@@ -194,11 +194,6 @@ class StructuralHeaderSlot(Slot):
         )
 
 
-# Aliases for readability; not separate types.
-HeaderSlot = StructuralHeaderSlot
-AoTHeaderSlot = StructuralHeaderSlot
-
-
 # ---------------------------------------------------------------------------
 # SlotRef (per-container occurrence)
 # ---------------------------------------------------------------------------
@@ -261,8 +256,6 @@ def retarget_slot_newlines(slot: Slot, target: str) -> None:
 
 __all__ = [
     "AoTEntry",
-    "AoTHeaderSlot",
-    "HeaderSlot",
     "KVSlot",
     "Slot",
     "SlotRef",


### PR DESCRIPTION
* HeaderSlot / AoTHeaderSlot are unused outside their own definition.
* _ArrayStyle was a hand-rolled __slots__ class with a manual __init__ that just stamped four kwargs onto self; a frozen slotted dataclass expresses the same shape in fewer lines.