### PR TITLE
Fix inline replacement of out-of-order subsection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replacing an out-of-order subsection (e.g. `[foo.bar]` defined
+  before `[foo]`) with a dict / inline value no longer emits the
+  new binding outside its parent section.
 - `Array.extend(arr)` / `AoT.extend(aot)` (and the corresponding `+=`
   forms) no longer hang when extending a sequence with itself.
 - A failed out-of-range `Array.comments[i] = ...` no longer silently

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -571,26 +571,6 @@ class Container(dict[str, Any]):
         ) and (is_scalar(value) or _is_synth_inline(value)):
             self._inline_typed_replace(key, value)
             return
-        # Header-bearing → non-header-bearing transition at the
-        # document root cannot preserve the original physical
-        # position: a top-level scalar / inline KV must precede any
-        # section headers, but the existing section sits among (or
-        # after) sibling section headers. Skip the position-preserving
-        # structural overwrite and just delete + reinsert so
-        # `_insert_new` places the new KV before all section headers.
-        #
-        # Only doc-root: nested overwrites synthesise a parent header
-        # (e.g. `[foo]` for `doc["foo"]["bar"] = {...}`) and the new
-        # KV legally lives inside that header, so position-preserving
-        # remains correct there.
-        if (
-            isinstance(self, Document)
-            and (_is_section(current) or isinstance(current, AoT))
-            and (is_scalar(value) or _is_synth_inline(value))
-        ):
-            del self[key]
-            self[key] = value
-            return
         # Structural overwrite: capture position + leading of the
         # existing primary, delete the binding (which detaches the old
         # view into a PrivateRoot), then re-enter __setitem__ at the

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -112,6 +112,12 @@ def reposition_install(parent: Container, key: str, value: Any) -> None:
     rewriting the descendant's leading, ``append_direct_kv``'s
     head-of-doc blank-line guard).
 
+    A header-less new binding (scalar / synth-inline) is left where
+    ``_insert_new`` placed it when the captured anchor lies outside
+    ``parent``'s body region — moving it there would silently
+    re-parent it. (A new binding that brings its own header carries
+    its scope with it and is always safe to reposition.)
+
     Precondition: ``key`` is currently bound under ``parent``.
     """
     primary_ref = parent._index[key][0]  # noqa: SLF001
@@ -122,13 +128,24 @@ def reposition_install(parent: Container, key: str, value: Any) -> None:
     successor_leading = (
         list(successor_slot.leading.pieces) if successor_slot is not None else None
     )
+    # A header-less new binding (scalar / synth-inline) takes its
+    # scope from physical position; check the anchor is in
+    # ``parent``'s body region before del wipes ``old_primary``'s
+    # doc-stream pointers. Same-flavour replacements bring their own
+    # header so the anchor is always safe and the walk is skipped.
+    from tomlrt._array import AoT  # noqa: PLC0415
+    from tomlrt._container import _is_section  # noqa: PLC0415
+
+    anchor_safe = (
+        isinstance(value, AoT)
+        or _is_section(value)
+        or _primary_in_parent_body_region(parent, old_primary)
+    )
     del parent[key]
     doc = parent._attached_doc  # noqa: SLF001
     with _record_install(doc) as new_slots:
         parent[key] = value
-    if not new_slots:
-        # Slotless binding (e.g. an empty AoT) — no physical region
-        # exists to reposition.
+    if not new_slots or not anchor_safe:
         return
     _move_slots_to_anchor(parent, new_slots, saved_anchor_prev, saved_leading_pieces)
     if (
@@ -147,6 +164,33 @@ def _ancestor_chain(c: Container) -> list[Container]:
         out.append(cur)
         cur = cur._parent  # noqa: SLF001
     return out
+
+
+def _primary_in_parent_body_region(parent: Container, primary: Slot) -> bool:
+    """True iff ``primary`` is physically inside ``parent``'s body region.
+
+    Walks the doc-stream backward from ``primary`` to the enclosing
+    boundary: an explicit section needs its own header; a Document
+    root walking past every header without matching one fails; an
+    implicit container has no contiguous body region and is always
+    accepted.
+    """
+    parent_header_ref = parent._header_ref  # noqa: SLF001
+    if parent_header_ref is None and parent._parent is not None:  # noqa: SLF001
+        return True  # implicit container — accept.
+    parent_header = parent_header_ref.slot if parent_header_ref else None
+    parent_path = parent._path  # noqa: SLF001
+    n = len(parent_path)
+    cur: Slot | None = primary
+    while cur is not None:
+        if cur is parent_header:
+            return True
+        if isinstance(cur, StructuralHeaderSlot) and (
+            parent_header is None or cur.path[:n] != parent_path
+        ):
+            return False
+        cur = cur._prev  # noqa: SLF001
+    return False
 
 
 def _file_ref_at_tail(c: Container, ref: SlotRef) -> None:

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -275,6 +275,67 @@ def test_inline_table_rejects_aot_value() -> None:
         obj["bad"] = tomlrt.AoT()
 
 
+def test_inline_replacement_of_out_of_order_subtable() -> None:
+    """Replacing an out-of-order subsection with an inline value must
+    keep the new KV inside its parent's body region.
+
+    ``[foo.bar]`` precedes ``[foo]`` in the source, so the existing
+    primary slot for ``foo['bar']`` sits before ``[foo]``'s own
+    header. Repositioning the synthesised inline KV onto that anchor
+    would land it at top level, silently re-parenting ``bar`` out of
+    ``foo``. The structural-overwrite path must detect this and fall
+    back to delete + reinsert at ``[foo]``'s body tail.
+    """
+    src = td("""
+        [foo.bar]
+        here = true
+
+        [foo]
+        a = 1
+        b = 2
+        """)
+    doc = tomlrt.loads(src)
+    doc["foo"]["bar"] = {"x": 1}
+    assert tomlrt.dumps(doc) == td("""
+        [foo]
+        a = 1
+        b = 2
+        bar = { x = 1 }
+        """)
+
+
+def test_inline_replacement_of_subtable_after_foreign_section() -> None:
+    """Same out-of-order hazard, but the subsection sits *after* a
+    foreign sibling header rather than before parent's own header.
+
+    The structural-overwrite walks backward from ``[foo.sub]`` past
+    ``z = 1`` and hits ``[other]`` — a header whose path is not
+    under ``[foo]`` — so the captured anchor is rejected and the
+    new inline lands at ``[foo]``'s body tail instead of after
+    ``[other]`` (where it would silently reparent under ``other``).
+    """
+    src = td("""
+        [foo]
+        a = 1
+
+        [other]
+        z = 1
+
+        [foo.sub]
+        x = 1
+        """)
+    doc = tomlrt.loads(src)
+    doc["foo"]["sub"] = {"y": 2}
+    assert tomlrt.dumps(doc) == td("""
+        [foo]
+        a = 1
+        sub = { y = 2 }
+
+        [other]
+        z = 1
+        """)
+
+
 # ---------------------------------------------------------------------------
 # Array mutation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replacing `doc["foo"]["bar"] = {...}` where `[foo.bar]` was defined out-of-order (before `[foo]`, or after a foreign sibling header that broke out of `[foo]`'s body) repositioned the new inline KV onto the old subsection header's anchor — landing it outside any section it could legally belong to and silently re-parenting it.

`reposition_install` now validates the captured anchor lies inside the parent's body region before splicing a header-less new binding there. New bindings that bring their own header (section / AoT replacements) skip the check; same-flavour replacements are unaffected.

The Document-root special case previously open-coded in `Container._overwrite_existing` collapses into the same check.