### PR TITLE
Preserve comma-first layout when appending to inline arrays/tables

### DIFF
--- a/src/tomlrt/_array_comments.py
+++ b/src/tomlrt/_array_comments.py
@@ -40,6 +40,7 @@ from tomlrt._trivia import (
     split_above_block,
     split_eol_section,
     split_item_above,
+    trivia_has_newline,
 )
 
 if TYPE_CHECKING:
@@ -70,7 +71,25 @@ def _check_index(arr: Array, key: object) -> int:
 
 
 def _eol_target(item: ArrayItem) -> Trivia:
+    # The EOL comment lives on the value's physical row, ahead of that
+    # row's break. A comma-first layout parks the row break (a newline)
+    # in `trailing`, before the comma, so the comment belongs there; in
+    # the canonical layout the break follows the comma and the comment
+    # sits in `post_comma_trivia`.
+    if trivia_has_newline(item.trailing):
+        return item.trailing
     return item.post_comma_trivia if item.has_comma else item.trailing
+
+
+def _downstream_break_holder(value: ArrayValue, idx: int) -> Trivia:
+    """Return the trivia that owns item ``idx``'s row break.
+
+    When the item's own row carries no EOL section the break lives in the
+    next item's ``leading``, or—for the tail item—the value's
+    ``final_trivia``.
+    """
+    items = value.items
+    return items[idx + 1].leading if idx + 1 < len(items) else value.final_trivia
 
 
 def _raw_eol_text(item: ArrayItem) -> str | None:
@@ -198,8 +217,7 @@ def _set_eol_raw(arr: Array, idx: int, raw_text: str) -> None:
     ]
     target.pieces = [*new_eol, *rest.pieces]
     if not existing_eol.pieces and not stripped:
-        value = arr._value  # noqa: SLF001
-        nxt = items[idx + 1].leading if idx + 1 < len(items) else value.final_trivia
+        nxt = _downstream_break_holder(arr._value, idx)  # noqa: SLF001
         if nxt.pieces and isinstance(nxt.pieces[0], NewlineNode):
             nxt.pieces = list(nxt.pieces[1:])
 
@@ -238,14 +256,18 @@ class ArrayEolView(_ArrayIntKeyedView[str]):
         eol, rest = split_eol_section(target)
         if not eol.pieces:
             raise KeyError(key)
+        nl = self._arr._doc_newline  # noqa: SLF001
+        if item.has_comma and trivia_has_newline(item.trailing):
+            # Comma-first: the eol section's terminating newline is this
+            # row's break and the comma follows it. Keep the break (drop
+            # only the whitespace + comment) and leave the next item alone.
+            item.trailing = Trivia([NewlineNode(nl), *rest.pieces])
+            return
         target.pieces = list(rest.pieces)
         # Canonical model inverse: restore the structural NL onto the
-        # next item's leading (for has-comma non-tail items) or
-        # final_trivia (for the tail item, with or without comma) so
-        # the closing layout still has its row break.
-        value = self._arr._value  # noqa: SLF001
-        nxt = items[idx + 1].leading if idx + 1 < len(items) else value.final_trivia
-        nl = self._arr._doc_newline  # noqa: SLF001
+        # downstream holder (next item's leading, or final_trivia for the
+        # tail item) so the closing layout still has its row break.
+        nxt = _downstream_break_holder(self._arr._value, idx)  # noqa: SLF001
         if not (nxt.pieces and isinstance(nxt.pieces[0], NewlineNode)):
             nxt.pieces = [NewlineNode(nl), *nxt.pieces]
 

--- a/src/tomlrt/_comma_ops.py
+++ b/src/tomlrt/_comma_ops.py
@@ -74,30 +74,32 @@ _CV_ItemT = TypeVar("_CV_ItemT", bound="CommaItem")
 # ---------------------------------------------------------------------------
 
 
-def _item_has_eol(item: CommaItem) -> bool:
-    """True if the item carries an inline EOL comment.
+def _eol_in_post_comma(item: CommaItem) -> bool:
+    """Which channel owns the item's row-attached EOL section.
 
-    When the item has a comma, the EOL section lives in
-    ``post_comma_trivia``; otherwise it lives in ``trailing``.
+    Canonically the EOL section lives in ``post_comma_trivia`` once the
+    item has a comma — but a comma-first layout parks it in ``trailing``
+    *before* the comma even with ``has_comma`` set, so ``trailing`` wins
+    whenever it carries one.
     """
-    target = item.post_comma_trivia if item.has_comma else item.trailing
-    eol, _rest = split_eol_section(target)
-    return bool(eol.pieces)
+    return item.has_comma and not split_eol_section(item.trailing)[0].pieces
+
+
+def _item_has_eol(item: CommaItem) -> bool:
+    """True if the item carries an inline EOL comment."""
+    channel = item.post_comma_trivia if _eol_in_post_comma(item) else item.trailing
+    return bool(split_eol_section(channel)[0].pieces)
 
 
 def _take_eol(item: CommaItem) -> Trivia:
     """Split out and return the item's row-attached EOL section.
 
-    The EOL section lives in ``post_comma_trivia`` when the item has
-    a comma, and in ``trailing`` otherwise. On return the item holds
-    only the structural rest in that channel.
+    On return the item holds only the structural rest in that channel.
     """
-    if item.has_comma:
-        eol, rest = split_eol_section(item.post_comma_trivia)
-        item.post_comma_trivia = rest
+    if _eol_in_post_comma(item):
+        eol, item.post_comma_trivia = split_eol_section(item.post_comma_trivia)
     else:
-        eol, rest = split_eol_section(item.trailing)
-        item.trailing = rest
+        eol, item.trailing = split_eol_section(item.trailing)
     return eol
 
 

--- a/src/tomlrt/_comma_ops.py
+++ b/src/tomlrt/_comma_ops.py
@@ -34,7 +34,7 @@ paths that need them.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from tomlrt._trivia import (
     NewlineNode,
@@ -47,6 +47,7 @@ from tomlrt._trivia import (
     split_eol_section,
     split_item_above,
     strip_trailing_indent,
+    trivia_has_newline,
 )
 from tomlrt._values import (
     inter_item_separator,
@@ -56,6 +57,7 @@ from tomlrt._values import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from tomlrt._trivia import TriviaPiece
     from tomlrt._values import (
         ArrayValue,
         CommaItem,
@@ -136,16 +138,19 @@ def _normalise_row_breaks(
     """
     if not multiline:
         return
-    # Inter-item: items[i].leading must start with NL iff items[i-1]
-    # carries no EOL.
+    # A comma-first layout parks the row break in items[i].trailing,
+    # before the comma; that boundary already breaks, so don't inject a
+    # second newline there (it would strand the comma on its own line).
     for i in range(1, len(items)):
         pred = items[i - 1]
+        if trivia_has_newline(pred.trailing):
+            continue
         pieces = items[i].leading.pieces
         has_nl = bool(pieces) and isinstance(pieces[0], NewlineNode)
         if _item_has_eol(pred) and has_nl:
             items[i].leading = Trivia(pieces[1:])
         elif not _item_has_eol(pred) and not has_nl:
-            items[i].leading = Trivia([NewlineNode(text=nl), *pieces])
+            items[i].leading = Trivia([*_row_break(value, pieces), *pieces])
     # Closing-bracket gap: final_trivia must start with NL iff the
     # last item carries no EOL.
     if not items:
@@ -229,10 +234,9 @@ def detect_style(
 ) -> CommaStyle:
     """Infer a :class:`CommaStyle` for ``value`` (or for a fresh value).
 
-    For a single-item multi-line value we synthesise the inter-item
-    separator from the bracket-pad indent (no peer to sample from);
-    otherwise the separator is the structural pad portion of
-    ``items[1].leading``.
+    The inter-item separator is sampled from ``items[1].leading``; a
+    multi-line value that can't (single item, or a comma-first peer with
+    an empty leading) falls back to :func:`_canonical_separator`.
     """
     if value is None:
         return CommaStyle(
@@ -243,23 +247,9 @@ def detect_style(
         )
     items = value.items
     is_multiline = multiline_flag or value_is_multiline(value)
-    if is_multiline and len(items) < 2:
-        nl_text = "\n"
-        for p in value.header_trivia.pieces:
-            if isinstance(p, NewlineNode):
-                nl_text = p.text
-                break
-        else:
-            for p in value.final_trivia.pieces:
-                if isinstance(p, NewlineNode):
-                    nl_text = p.text
-                    break
-        indent = _first_indent_after_newline(value.header_trivia)
-        if not indent:
-            indent = indent_from_final_trivia(value.final_trivia) or "    "
-        inter_sep = Trivia([NewlineNode(text=nl_text), WhitespaceNode(text=indent)])
-    else:
-        inter_sep = inter_item_separator(items)
+    inter_sep = inter_item_separator(items)
+    if is_multiline and not trivia_has_newline(inter_sep):
+        inter_sep = _canonical_separator(value)
     trailing_comma = items[-1].has_comma if items else is_multiline
     pad_ft, _above_ft = split_above_block(value.final_trivia)
     trailing_post = pad_ft if pad_ft.pieces else value.final_trivia.copy()
@@ -284,6 +274,35 @@ def _first_indent_after_newline(trivia: Trivia) -> str:
         ):
             return str(pieces[i + 1].text)
     return ""
+
+
+def _value_newline(value: CommaValue[Any]) -> str:
+    """The newline text ``value`` uses (sampled from its bracket pads)."""
+    for trivia in (value.header_trivia, value.final_trivia):
+        for p in trivia.pieces:
+            if isinstance(p, NewlineNode):
+                return str(p.text)
+    return "\n"
+
+
+def _canonical_separator(value: CommaValue[Any]) -> Trivia:
+    """Fallback inter-item separator: a newline + the value's own indent."""
+    indent = (
+        _first_indent_after_newline(value.header_trivia)
+        or indent_from_final_trivia(value.final_trivia)
+        or "    "
+    )
+    nl = NewlineNode(text=_value_newline(value))
+    return Trivia([nl, WhitespaceNode(text=indent)])
+
+
+def _row_break(
+    value: CommaValue[Any], existing: Sequence[TriviaPiece]
+) -> list[TriviaPiece]:
+    """Row break to prepend to ``existing``; adds indent only if it has none."""
+    if existing and isinstance(existing[0], WhitespaceNode):
+        return [NewlineNode(text=_value_newline(value))]
+    return list(_canonical_separator(value).pieces)
 
 
 def migrate_bracket_above(bracket: Trivia, separator: Trivia) -> tuple[Trivia, Trivia]:

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1030,6 +1030,32 @@ def test_array_delete_eol_comment() -> None:
     assert list(re.array("arr")) == [1, 2]
 
 
+def test_array_leading_and_trailing_comma_on_one_line_round_trips() -> None:
+    # The physical line ``,2,`` carries item 0's comma (a comma-first
+    # predecessor breaks before it) *and* item 1's own trailing comma.
+    # The two belong to different items, so the dense line needs no
+    # special handling.
+    src = td("""
+        a = [
+          1
+          ,2, # two
+          3
+        ]
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    arr = doc.array("a")
+    assert dict(arr.comments) == {1: "two"}
+    arr.comments[0] = "one"
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+          1 # one
+          ,2, # two
+          3
+        ]
+        """)
+
+
 def test_array_comma_first_eol_comment_read() -> None:
     # A comma-first item carries has_comma=True but parks its EOL comment
     # in `trailing`, before the comma. The view must still find it.

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1030,6 +1030,86 @@ def test_array_delete_eol_comment() -> None:
     assert list(re.array("arr")) == [1, 2]
 
 
+def test_array_comma_first_eol_comment_read() -> None:
+    # A comma-first item carries has_comma=True but parks its EOL comment
+    # in `trailing`, before the comma. The view must still find it.
+    doc = tomlrt.loads(
+        td("""
+        a = [
+              1 # comma is on the next line
+             ,2
+            ]
+        """)
+    )
+    arr = doc.array("a")
+    assert dict(arr.comments) == {0: "comma is on the next line"}
+
+
+def test_array_comma_first_eol_comment_replace_keeps_layout() -> None:
+    doc = tomlrt.loads(
+        td("""
+        a = [
+              1 # comma is on the next line
+             ,2
+            ]
+        """)
+    )
+    arr = doc.array("a")
+    arr.comments[0] = "changed"
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1 # changed
+             ,2
+            ]
+        """)
+
+
+def test_array_comma_first_eol_comment_add_to_uncommented_row() -> None:
+    # A comma-first row with no comment still parks its row break in
+    # `trailing`, before the comma. Adding a comment must attach it to the
+    # value's row there, not after the comma.
+    doc = tomlrt.loads(
+        td("""
+        a = [
+              1
+             ,2
+            ]
+        """)
+    )
+    arr = doc.array("a")
+    arr.comments[0] = "added"
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1 # added
+             ,2
+            ]
+        """)
+
+
+def test_array_comma_first_eol_comment_delete_keeps_layout() -> None:
+    # Deleting a comma-first EOL must keep the row break (which lives in
+    # the item's own trailing, ahead of the comma) rather than reflowing
+    # the comma and the following item.
+    doc = tomlrt.loads(
+        td("""
+        a = [
+              1 # comma is on the next line
+             ,2
+            ]
+        """)
+    )
+    arr = doc.array("a")
+    del arr.comments[0]
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        a = [
+              1
+             ,2
+            ]
+        """)
+    assert list(tomlrt.loads(out).array("a")) == [1, 2]
+
+
 def test_array_delete_eol_on_multiline_last_item_no_comma_keeps_break() -> None:
     """Deleting an EOL on the last item of a multi-line, no-trailing-comma
     array must keep the structural newline before ``]``.

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -2418,6 +2418,54 @@ def test_append_preserves_leading_comment_in_single_item_array() -> None:
         """)
 
 
+def test_append_preserves_comma_first_boundary_in_array() -> None:
+    # A comma-first multiline array parks its row break *before* the
+    # comma (in the previous item's trailing), leaving the following
+    # item's leading empty. Appending used to renormalise that
+    # already-broken boundary, injecting a second newline that
+    # stranded the comma on its own line and dropped items to column
+    # zero. The existing ",2" row is now left untouched; only the new
+    # item is laid out (in the default comma-attached style).
+    src = td("""
+        a = [
+              1 # comma is on the next line
+             ,2
+            ]
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    doc.array("a").append(99)
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1 # comma is on the next line
+             ,2,
+              99
+            ]
+        """)
+
+
+def test_assign_preserves_comma_first_boundary_in_inline_table() -> None:
+    # Comma-first inline tables share the row-break logic with arrays
+    # (via _comma_ops), so the existing comma-first entry boundary is
+    # preserved the same way.
+    src = td("""
+        t = {
+              a = 1 # comma is on the next line
+             ,b = 2
+            }
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    doc.table("t")["c"] = 3
+    assert tomlrt.dumps(doc) == td("""
+        t = {
+              a = 1 # comma is on the next line
+             ,b = 2,
+              c = 3
+            }
+        """)
+
+
 # ---------------------------------------------------------------------------
 # AoT assignment / Table.promote_array
 # ---------------------------------------------------------------------------

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -173,6 +173,40 @@ def test_multiline_array_preserved_shape() -> None:
     """)
 
 
+def test_comma_first_array_keeps_comment() -> None:
+    # A comma-first layout parks the item's EOL comment in ``trailing``
+    # *before* the comma, even though ``has_comma`` is set. format()
+    # used to look only in ``post_comma_trivia`` and drop the comment;
+    # it is now migrated to the canonical post-comma position.
+    src = td("""
+        a = [
+              1 # comma is on the next line
+             ,2
+            ]
+    """)
+    assert _roundtrip(src) == td("""
+        a = [
+          1, # comma is on the next line
+          2,
+        ]
+    """)
+
+
+def test_comma_first_inline_table_keeps_comment() -> None:
+    src = td("""
+        t = {
+              a = 1 # comma is on the next line
+             ,b = 2
+            }
+    """)
+    assert _roundtrip(src) == td("""
+        t = {
+          a = 1, # comma is on the next line
+          b = 2,
+        }
+    """)
+
+
 def test_nested_multiline_array_indents_per_depth() -> None:
     src = td("""
         outer = [


### PR DESCRIPTION
Appending to a multi-line inline array or table whose row break sits *before* the comma (a comma-first / leading-comma layout) used to mangle the existing rows: _normalise_row_breaks renormalised every boundary, injecting a second newline that stranded the comma on its own line, and the synthesised break carried no indent so items fell to column zero.

A boundary whose predecessor already breaks its row in `trailing` is now left untouched, so the existing comma-first rows survive; only the genuinely new boundary is laid out, in the default style, at the array's own indent.

While here, fold detect_style's single-item separator special case and the new row-break indent logic into one _canonical_separator helper, so the "what separator does this value use" question has a single home.