### PR TITLE
Unify comma-first handling around the row's newline

### DIFF
--- a/src/tomlrt/_array_comments.py
+++ b/src/tomlrt/_array_comments.py
@@ -40,8 +40,8 @@ from tomlrt._trivia import (
     split_above_block,
     split_eol_section,
     split_item_above,
-    trivia_has_newline,
 )
+from tomlrt._values import item_breaks_before_comma, item_eol_channel
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -70,22 +70,6 @@ def _check_index(arr: Array, key: object) -> int:
     return idx
 
 
-def _is_comma_first(item: ArrayItem) -> bool:
-    """True iff ``item`` is laid out comma-first.
-
-    Such an item parks its row break (and any EOL comment) in
-    ``trailing`` ahead of its comma, not in ``post_comma_trivia`` after
-    it. This is the canonical place the comma-first layout is named.
-    """
-    return item.has_comma and trivia_has_newline(item.trailing)
-
-
-def _eol_target(item: ArrayItem) -> Trivia:
-    if _is_comma_first(item):
-        return item.trailing
-    return item.post_comma_trivia if item.has_comma else item.trailing
-
-
 def _downstream_break_holder(value: ArrayValue, idx: int) -> Trivia:
     """Return the trivia that owns item ``idx``'s row break.
 
@@ -99,7 +83,7 @@ def _downstream_break_holder(value: ArrayValue, idx: int) -> Trivia:
 
 def _raw_eol_text(item: ArrayItem) -> str | None:
     """Return the raw (still-encoded) EOL comment text on ``item`` or None."""
-    for p in _eol_target(item).pieces:
+    for p in item_eol_channel(item).pieces:
         if isinstance(p, NewlineNode):
             return None
         if isinstance(p, CommentNode):
@@ -127,7 +111,7 @@ def _above_owner(value: ArrayValue, i: int) -> tuple[Trivia, int]:
     if i == 0:
         return value.header_trivia, 0
     prev = value.items[i - 1]
-    if _is_comma_first(prev):
+    if item_breaks_before_comma(prev):
         eol, _rest = split_eol_section(prev.trailing)
         return prev.trailing, len(eol.pieces)
     return value.items[i].leading, 0
@@ -138,26 +122,19 @@ def _comments_from_lines(pieces: list[TriviaPiece]) -> tuple[str, ...]:
 
 
 def _slot_indent(arr: Array) -> str:
-    """Best-effort indent string for this array's items."""
+    """Best-effort indent string for this array's items.
+
+    The per-item value-indent is the ``tail`` of its above-frame, which
+    :func:`_split_above_frame` already resolves uniformly across the
+    bracket pad (item 0), conventional, and comma-first layouts. Return
+    the first one found.
+    """
     value = arr._value  # noqa: SLF001
-    items = value.items
-    sources: list[Trivia] = []
-    if items and _is_comma_first(items[0]):
-        # Comma-first per-item ``leading`` holds the post-comma gap, not
-        # the line indent; that lives in header_trivia / item trailings.
-        sources.append(value.header_trivia)
-        sources.extend(it.trailing for it in items if _is_comma_first(it))
-    else:
-        if len(items) >= 2:
-            sources.append(items[1].leading)
-        sources.append(value.header_trivia)
-        sources.extend(it.leading for it in items[2:])
-    for src in sources:
-        for p in reversed(src.pieces):
+    for i in range(len(value.items)):
+        _owner, _prefix, _head, tail = _split_above_frame(value, i)
+        for p in reversed(tail.pieces):
             if isinstance(p, WhitespaceNode):
                 return p.text
-            if isinstance(p, NewlineNode):
-                break
     return "  "
 
 
@@ -218,7 +195,7 @@ def _set_eol_raw(arr: Array, idx: int, raw_text: str) -> None:
     items = arr._value.items  # noqa: SLF001
     item = items[idx]
     nl = arr._doc_newline  # noqa: SLF001
-    target = _eol_target(item)
+    target = item_eol_channel(item)
     existing_eol, rest = split_eol_section(target)
     stripped = False
     if (
@@ -272,12 +249,12 @@ class ArrayEolView(_ArrayIntKeyedView[str]):
         idx = _check_index(self._arr, key)
         items = self._arr._value.items  # noqa: SLF001
         item = items[idx]
-        target = _eol_target(item)
+        target = item_eol_channel(item)
         eol, rest = split_eol_section(target)
         if not eol.pieces:
             raise KeyError(key)
         nl = self._arr._doc_newline  # noqa: SLF001
-        if _is_comma_first(item):
+        if item_breaks_before_comma(item):
             # The eol section's terminating newline is this row's break
             # and the comma follows it. Keep the break (drop only the
             # whitespace + comment) and leave the next item alone.

--- a/src/tomlrt/_comma_ops.py
+++ b/src/tomlrt/_comma_ops.py
@@ -51,6 +51,7 @@ from tomlrt._trivia import (
 )
 from tomlrt._values import (
     inter_item_separator,
+    item_eol_channel,
     value_is_multiline,
 )
 
@@ -74,21 +75,13 @@ _CV_ItemT = TypeVar("_CV_ItemT", bound="CommaItem")
 # ---------------------------------------------------------------------------
 
 
-def _eol_in_post_comma(item: CommaItem) -> bool:
-    """Which channel owns the item's row-attached EOL section.
+def _row_terminated(item: CommaItem) -> bool:
+    """True if the item's own row already carries its terminating newline.
 
-    Canonically the EOL section lives in ``post_comma_trivia`` once the
-    item has a comma — but a comma-first layout parks it in ``trailing``
-    *before* the comma even with ``has_comma`` set, so ``trailing`` wins
-    whenever it carries one.
+    Otherwise the break is downstream, in the next item's leading (or
+    ``final_trivia`` for the tail). Comma placement never enters into it.
     """
-    return item.has_comma and not split_eol_section(item.trailing)[0].pieces
-
-
-def _item_has_eol(item: CommaItem) -> bool:
-    """True if the item carries an inline EOL comment."""
-    channel = item.post_comma_trivia if _eol_in_post_comma(item) else item.trailing
-    return bool(split_eol_section(channel)[0].pieces)
+    return trivia_has_newline(item_eol_channel(item))
 
 
 def _take_eol(item: CommaItem) -> Trivia:
@@ -96,10 +89,12 @@ def _take_eol(item: CommaItem) -> Trivia:
 
     On return the item holds only the structural rest in that channel.
     """
-    if _eol_in_post_comma(item):
-        eol, item.post_comma_trivia = split_eol_section(item.post_comma_trivia)
+    channel = item_eol_channel(item)
+    eol, rest = split_eol_section(channel)
+    if channel is item.post_comma_trivia:
+        item.post_comma_trivia = rest
     else:
-        eol, item.trailing = split_eol_section(item.trailing)
+        item.trailing = rest
     return eol
 
 
@@ -129,10 +124,10 @@ def _normalise_row_breaks(
 
     In a multi-line inline value each item occupies one physical row;
     each row needs exactly one terminating newline. That newline lives
-    either in the row's EOL section (``items[i].post_comma_trivia`` or
-    ``items[i].trailing``) — or in the next row's leading region
-    (``items[i+1].leading`` for inter-item gaps, ``value.final_trivia``
-    for the gap before the closing bracket).
+    either in the row's own EOL channel (see :func:`_row_terminated`) or
+    downstream in the next row's leading region (``items[i+1].leading``
+    for inter-item gaps, ``value.final_trivia`` before the closing
+    bracket).
 
     This helper restores the invariant after a mutation has touched
     item count, comma state, or EOL state — call it once at the end.
@@ -140,29 +135,28 @@ def _normalise_row_breaks(
     """
     if not multiline:
         return
-    # A comma-first layout parks the row break in items[i].trailing,
-    # before the comma; that boundary already breaks, so don't inject a
-    # second newline there (it would strand the comma on its own line).
+    # Each boundary needs exactly one break: it sits downstream, in the
+    # next item's leading, iff the predecessor's own row is not already
+    # terminated. Whether that termination is before or after the comma
+    # is irrelevant here.
     for i in range(1, len(items)):
         pred = items[i - 1]
-        if trivia_has_newline(pred.trailing):
-            continue
         pieces = items[i].leading.pieces
         has_nl = bool(pieces) and isinstance(pieces[0], NewlineNode)
-        if _item_has_eol(pred) and has_nl:
+        if _row_terminated(pred) and has_nl:
             items[i].leading = Trivia(pieces[1:])
-        elif not _item_has_eol(pred) and not has_nl:
+        elif not _row_terminated(pred) and not has_nl:
             items[i].leading = Trivia([*_row_break(value, pieces), *pieces])
-    # Closing-bracket gap: final_trivia must start with NL iff the
-    # last item carries no EOL.
+    # Closing-bracket gap: final_trivia carries the break iff the last
+    # item's own row is not already terminated.
     if not items:
         return
     ft = value.final_trivia
     has_nl = bool(ft.pieces) and isinstance(ft.pieces[0], NewlineNode)
-    last_has_eol = _item_has_eol(items[-1])
-    if last_has_eol and has_nl:
+    last_terminated = _row_terminated(items[-1])
+    if last_terminated and has_nl:
         ft.pieces = list(ft.pieces[1:])
-    elif not last_has_eol and not has_nl:
+    elif not last_terminated and not has_nl:
         ft.pieces = [NewlineNode(text=nl), *ft.pieces]
 
 

--- a/src/tomlrt/_values.py
+++ b/src/tomlrt/_values.py
@@ -301,6 +301,27 @@ Value = (
 )
 
 
+def item_breaks_before_comma(item: CommaItem) -> bool:
+    """True iff the row break (and any EOL comment) precedes the comma.
+
+    The single canonical test for the comma-first / leading-comma
+    layout.
+    """
+    return item.has_comma and trivia_has_newline(item.trailing)
+
+
+def item_eol_channel(item: CommaItem) -> Trivia:
+    """The trivia run that owns the item's row-attached EOL section.
+
+    ``trailing`` for a comma-first or comma-less item, else
+    ``post_comma_trivia``. Picking the channel here lets callers read,
+    write, and normalise the EOL without branching on the comma.
+    """
+    if item_breaks_before_comma(item):
+        return item.trailing
+    return item.post_comma_trivia if item.has_comma else item.trailing
+
+
 def inter_item_separator(items: Sequence[CommaItem]) -> Trivia:
     """Structural-pad portion of ``items[1].leading``; ``" "`` if ``len < 2``.
 
@@ -371,6 +392,8 @@ __all__ = [
     "StringValue",
     "Value",
     "inter_item_separator",
+    "item_breaks_before_comma",
+    "item_eol_channel",
     "retarget_value_newlines",
     "value_is_multiline",
 ]


### PR DESCRIPTION
Inline comma-value layout (comma-first vs conventional) was handled by two separately-defined notions of "comma-first" plus scattered branches. _comma_ops keyed off whether `trailing` carried an EOL *comment*; _array_comments keyed off whether it carried a *newline*; and the EOL-channel selector was duplicated across both.

Lift the model to one home in the value layer: item_breaks_before_comma and item_eol_channel, pure functions of a CommaItem. Both modules now consume them.

The real simplification is in _normalise_row_breaks. It branched on comma-first only because it asked the wrong question — _item_has_eol (does the row carry a comment?) as a proxy for "is this row already broken?", which is false for a comment-less comma-first row. Ask the direct question instead, _row_terminated (does the EOL channel hold the newline?), and the comma-first branch disappears along with two helper functions. The structural mutation core no longer mentions comma-first.

_slot_indent likewise loses its fork: the per-item value-indent is the `tail` of _split_above_frame, already resolved uniformly across the bracket pad, conventional, and comma-first layouts.

What remains is the one genuine model asymmetry — the comma is stored on the previous item, so in comma-first an item's above-block and break physically precede it. That is confined to two accessors (_above_owner, ArrayEolView.__delitem__); reflowing it away would change layout.