### PR TITLE
Preserve trivia when grafting a parsed document or table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   match synthesis and `.format()`.
 - Assigning a parsed document or table into another document now keeps its
   comments and formatting, instead of dropping them.
+- Overwriting a section that has array-of-tables children now keeps those
+  children under the section, instead of moving them to the end of the
+  document.
 
 ## [1.7.5] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the wrong table.
 - Filling a previously-empty inline table now pads the braces (`{ a = 1 }`) to
   match synthesis and `.format()`.
+- Assigning a parsed document or table into another document now keeps its
+  comments and formatting, instead of dropping them.
 
 ## [1.7.5] - 2026-06-11
 

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -65,6 +65,20 @@ A container that is already attached somewhere is deep-cloned on assignment, so
 two slots never share state.
 This applies whether the source and destination are in the same document
 (`doc["b"] = doc["a"]`) or different ones (`d2["x"] = d1["x"]`).
+The clone is byte-faithful: comments, whitespace, and string / number style on
+the bytes you didn't touch survive the move.
+
+Assigning a whole parsed `Document` as a value lifts its body into a section,
+preserving the comments and layout that were in the source — handy for dropping
+a versioned standalone template into a larger file:
+
+```python
+template = tomlrt.loads(template_text)   # a standalone file, no [header]
+doc["tool"]["bumpversion"] = template    # becomes [tool.bumpversion], trivia intact
+```
+
+The document's own file-level preamble / epilogue (comment blocks separated from
+the body by a blank line) belong to no key and are not carried across.
 
 ## Removal and orphaning
 

--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -1,8 +1,7 @@
 """Array views.
 
-`Array(list)` backs an inline-array TOML value (`[1, 2, 3]`). `AoT`
-(array-of-tables) is a `list[Table]` whose entries are individually
-backed by `AoTEntry` records and whose elements are `Table` views.
+`Array(list)` backs inline TOML arrays. `AoT(list[Table])` backs
+array-of-tables entries via `AoTEntry` records.
 """
 
 from __future__ import annotations
@@ -80,8 +79,8 @@ _T = TypeVar("_T")
 class Array(list[Any]):
     """An inline TOML array.
 
-    `Array` is a `list` subclass, so ``isinstance(arr, list)`` holds
-    and it can be passed wherever a `list` or `Sequence` is expected.
+    `Array` is a `list` subclass, so ``isinstance(arr, list)`` holds and
+    it can be passed wherever a `list` or `Sequence` is expected.
     """
 
     __slots__ = ("_layout_root", "_multiline", "_value")
@@ -95,9 +94,8 @@ class Array(list[Any]):
     ) -> None:
         """Construct a standalone inline array.
 
-        ``Array([1, 2, 3])`` builds an inline array;
-        ``Array([1, 2, 3], multiline=True)`` lays it out one item per
-        line with ``indent`` indentation.
+        ``Array([1, 2, 3])`` builds an inline array; ``multiline=True``
+        lays items out one per line with ``indent``.
         """
         super().__init__()
 
@@ -130,9 +128,8 @@ class Array(list[Any]):
                 it.trailing = Trivia()
                 it.has_comma = True
         elif multiline and not val.items:
-            # Empty multiline factory: header_trivia stays empty;
-            # final_trivia carries the pre-`]` line break + indent so
-            # that a subsequent first append slots in correctly.
+            # Empty multiline factory: final_trivia carries the pre-`]`
+            # break + indent so a later first append slots in correctly.
             val.final_trivia = Trivia(
                 [NewlineNode(text="\n"), WhitespaceNode(text=indent)]
             )
@@ -188,8 +185,6 @@ class Array(list[Any]):
             raise TypeError(msg)
         return v
 
-    # ---- mutation -----------------------------------------------------
-
     @property
     def _attached(self) -> bool:
         """True iff this array is wired to a user-visible document.
@@ -235,10 +230,9 @@ class Array(list[Any]):
     def format(self, *, comments: bool = True) -> None:
         """Canonicalise this array's formatting in place.
 
-        Rewrites whitespace, indentation, separators, and newlines to a
-        canonical layout, while preserving the array's overall shape
-        (single-line stays single-line, multi-line stays multi-line)
-        and the *content* of any orphan comment blocks above items.
+        Rewrites whitespace, indentation, separators, and newlines
+        while preserving shape (single-line stays single-line, multi-line
+        stays multi-line) and orphan comment text.
 
         When ``comments`` is true (the default), comment text is also
         normalised: ``#foo`` and ``#   foo`` both become ``# foo``, and
@@ -250,9 +244,8 @@ class Array(list[Any]):
         """Switch this array between flush single-line and multi-line form.
 
         Raises ``TOMLError`` when collapsing a multi-line array that
-        carries comments (anywhere in per-item trivia, header_trivia
-        or final_trivia, or in nested inline values), since those
-        would have nowhere to live on a single line.
+        carries comments anywhere in it, including inside nested values,
+        since they would have nowhere to live on one line.
 
         Returns ``self`` for chaining.
         """
@@ -321,10 +314,8 @@ class Array(list[Any]):
     def _append_with_style(self, cst: Value, decoded: Any, style: CommaStyle) -> None:
         """Append ``cst`` / ``decoded`` using a precomputed ``style``.
 
-        Shared between `append` (which derives style fresh) and
-        `__imul__` (which must snapshot style before mutating, so
-        the closing trailing-comma decision reflects the array's
-        original layout — not the half-mutated state).
+        `__imul__` snapshots style before mutating so trailing-comma
+        decisions reflect the original layout, not a half-mutated one.
         """
         new_item = _make_item(cst, has_comma=False)
         splice_in(self._value, new_item, style, self._doc_newline)
@@ -332,17 +323,14 @@ class Array(list[Any]):
 
     @override
     def extend(self, values: Iterable[Any]) -> None:
-        # Snapshot first so ``arr.extend(arr)`` (and ``arr += arr``)
-        # match list semantics — duplicate once — rather than
-        # iterating forever as ``self`` grows.
+        # Snapshot so ``arr.extend(arr)`` duplicates once like list does.
         for v in list(values):
             self.append(v)
 
     @override
     def clear(self) -> None:
         self._value.items.clear()
-        # Drop any inter-item trivia clutter; preserve the bracket
-        # leading captured in final_trivia.
+        # Drop inter-item trivia; preserve bracket leading in final_trivia.
         strip_trailing_indent(self._value.header_trivia, self._value.final_trivia)
         list.clear(self)
 
@@ -382,22 +370,17 @@ class Array(list[Any]):
             return
         style = self._style()
         if i == 0:
-            # Item-owned semantics: any above-block currently inside
-            # header_trivia conceptually belongs to *the item that
-            # appears below it*. On insert(0), that item becomes
-            # items[1]; the above-block migrates to its leading. The
-            # new item gets bare leading; header_trivia retains only
-            # its structural pad.
+            # Item-owned semantics: an above-block in header_trivia
+            # belongs to the item below it, so insert(0) migrates that
+            # block to items[1].leading and leaves structural pad behind.
             new_item = _make_item(cst, has_comma=True)
             self._value.header_trivia, items[0].leading = migrate_bracket_above(
                 self._value.header_trivia, style.inter_separator
             )
             items.insert(0, new_item)
         else:
-            # Internal insert: new item with leading = inter_sep; the
-            # item that was at position i (now at i+1) keeps its old
-            # leading (which already carries inter_sep + its own
-            # above-block).
+            # Internal insert: the displaced item keeps its existing
+            # leading (inter_sep plus any above-block).
             new_item = _make_item(
                 cst, leading=style.inter_separator.copy(), has_comma=True
             )
@@ -469,14 +452,11 @@ class Array(list[Any]):
                         f"to extended slice of size {len(indices)}"
                     )
                     raise ValueError(msg)
-                # Extended slice: positions are unchanged, only values
-                # change. Delegate to the int-index path per slot.
+                # Extended slice positions are unchanged; replace per slot.
                 for k, v in zip(indices, values, strict=True):
                     self[k] = v
                 return
-            # Contiguous slice: realise as delete + insert so the
-            # boundary-handling that ``__delitem__`` and ``insert``
-            # already encode is reused, rather than duplicated here.
+            # Reuse delete/insert boundary handling for contiguous slices.
             start, stop, _ = index.indices(len(self))
             del self[start:stop]
             for offset, v in enumerate(values):
@@ -497,8 +477,7 @@ class Array(list[Any]):
         if not items:
             list.__delitem__(self, index)  # propagate IndexError
             return
-        # Normalise to a list of removed positions so the shared
-        # comma-list orchestration can run uniformly.
+        # Normalise removed positions for shared comma-list orchestration.
         if isinstance(index, slice):
             removed = list(range(*index.indices(len(items))))
         else:
@@ -534,16 +513,9 @@ class Array(list[Any]):
             return self
         if n == 1:
             return self
-        # Snapshot style and the source-item list before any append:
-        # ``_append_with_style`` flips the previous-last item's
-        # ``has_comma``, so re-detecting style on a half-mutated array
-        # would spuriously promote a no-trailing-comma array to one with
-        # a trailing comma. The items list is snapshot because we append
-        # to it inside the loop. Each iteration deepcopies the source
-        # ``Value`` and re-decodes so the appended logical view is wired
-        # to its own CST clone (``deepcopy`` of the decoded view for an
-        # inline ``Table`` / ``Array`` yields a detached object not wired
-        # to any CST).
+        # Snapshot style and items before appending: `_append_with_style`
+        # flips the previous last comma, and decoded inline views must be
+        # re-built from cloned CST so they stay wired to their own nodes.
         from tomlrt._build import _decode_value  # noqa: PLC0415
 
         style = self._style()
@@ -562,18 +534,12 @@ class Array(list[Any]):
         return self
 
 
-# ---------------------------------------------------------------------------
-# Array-specific helpers (style detection + canonical pads live in _format)
-# ---------------------------------------------------------------------------
-
-
 def _make_item(
     cst: Value, *, leading: Trivia | None = None, has_comma: bool
 ) -> ArrayItem:
     """Build a fresh ``ArrayItem`` with empty trailing/post_comma.
 
-    Most call-sites only vary ``leading`` and ``has_comma``; this helper
-    centralises the boilerplate so the policy stays in one place.
+    Most call sites only vary ``leading`` and ``has_comma``.
     """
     return ArrayItem(
         leading=leading if leading is not None else Trivia(),
@@ -614,9 +580,8 @@ def _renormalise_commas(items: list[ArrayItem], style: CommaStyle) -> None:
 class AoT(list["Table"]):
     """An Array-of-tables, e.g. ``[[products]]`` repeated.
 
-    `AoT` is a `list[Table]` subclass, so ``isinstance(aot, list)``
-    holds and it can be passed wherever a `list` or `Sequence` is
-    expected.
+    `AoT` is a `list[Table]` subclass, so ``isinstance(aot, list)`` holds
+    and it can be passed wherever a `list` or `Sequence` is expected.
     """
 
     __slots__ = ("_layout_root", "_parent", "_path")
@@ -633,10 +598,7 @@ class AoT(list["Table"]):
 
     @property
     def _attached_doc(self) -> Document:
-        """The owning ``Document``, asserting this AoT is attached.
-
-        Mirror of :attr:`Container._attached_doc` — see that docstring.
-        """
+        """The owning ``Document``, asserting this AoT is attached."""
         lr = self._layout_root
         assert lr is not None, "AoT is not attached to a document"
         return lr
@@ -654,8 +616,8 @@ class AoT(list["Table"]):
     def add(self, entry: Mapping[str, TomlInput] | None = None) -> Table:
         """Append a fresh ``[[path]]`` entry and return its `Table` view.
 
-        ``entry`` may be a Mapping (initial body content) or ``None``
-        (empty entry). The AoT must be attached to a document.
+        ``entry`` may be initial body content or ``None``. Attached AoTs
+        append to the owning document.
         """
         if entry is not None:
             entry = _validate_mapping(entry, label="AoT entry")
@@ -667,10 +629,8 @@ class AoT(list["Table"]):
     def _add_entry_attached(self, value: Mapping[str, Any]) -> Table:
         """Dispatch a new attached AoT entry from ``value``.
 
-        Pre: ``self._layout_root is not None``. Selects the trivia-
-        preserving clone path when ``value`` is itself an attached
-        AoT entry or attached standard section, otherwise falls
-        through to ``add_aot_entry``.
+        Pre: attached AoT. Selects the trivia-preserving clone path for
+        attached AoT entries or sections.
         """
         from tomlrt._container import Table as TableType  # noqa: PLC0415
 
@@ -696,8 +656,7 @@ class AoT(list["Table"]):
             return
         _layout_ops.replace_aot_entry(self, index, value)
 
-    # Supported list-mutator surface. Anything not implemented here
-    # is overridden below to fail closed rather than corrupt the
+    # Unsupported list mutators fail closed rather than corrupt the
     # doc-stream via inherited `list` behaviour.
 
     @override
@@ -766,18 +725,15 @@ class AoT(list["Table"]):
                     f"to extended slice of size {len(indices)}"
                 )
                 raise ValueError(msg)
-            # Validate every assigned value is a Mapping/Table BEFORE
-            # mutating the AoT (atomicity preflight).
+            # Atomicity preflight: validate everything before mutating.
             typed_values = [_validate_mapping(v, label="AoT entry") for v in values]
             if self._layout_root is None:
                 list.__setitem__(
                     self, index, [_make_unattached_entry(v) for v in typed_values]
                 )
                 return
-            # For contiguous step == 1: replace by delete-range then
-            # insert at the start index. Order matters: build new
-            # entries via the dispatcher (appended to end), then
-            # renormalise.
+            # Contiguous replacement: delete, append via dispatcher,
+            # then renormalise to the requested order.
             if index.step is None or index.step == 1:
                 start = index.indices(len(self))[0]
                 for i in sorted(indices, reverse=True):
@@ -790,8 +746,7 @@ class AoT(list["Table"]):
                 if cur != list(self):
                     _layout_ops.renormalise_aot_order(self, cur)
                 return
-            # Extended slice with step != 1 and matching length:
-            # replace each entry in place.
+            # Extended slice with matching length: replace in place.
             for i, v in zip(indices, typed_values, strict=True):
                 self._replace_entry_attached(i, v)
             return
@@ -812,9 +767,7 @@ class AoT(list["Table"]):
 
     @override
     def extend(self, values: Iterable[Table | Mapping[str, TomlInput]]) -> None:
-        # Snapshot first so ``aot.extend(aot)`` (and ``aot += aot``)
-        # match list semantics — duplicate once — rather than
-        # iterating forever as ``self`` grows.
+        # Snapshot so ``aot.extend(aot)`` duplicates once like list does.
         for v in list(values):
             self.append(v)
 
@@ -826,9 +779,7 @@ class AoT(list["Table"]):
         if self._layout_root is None:
             list.insert(self, index, _make_unattached_entry(entry))
             return
-        # Normalise against the pre-append length so semantics match
-        # list.insert (e.g. insert(-1, x) inserts BEFORE the last entry,
-        # not in place of it).
+        # Normalise against the pre-append length to match list.insert.
         n_before = len(self)
         new_entry = self._add_entry_attached(entry)
         idx = int(index)
@@ -885,10 +836,8 @@ class AoT(list["Table"]):
         if n == 1:
             return self
         if self._layout_root is None:
-            # Detached AoT: replicate entries through `extend`, so the
-            # detached append path (`_make_unattached_entry`) is the
-            # one source of truth for "how do we add an entry without
-            # touching the document".
+            # Detached AoT: replicate via `extend` so `_make_unattached_entry`
+            # stays the source of truth for document-free entries.
             bodies = self.to_list()
             for _ in range(n - 1):
                 self.extend(bodies)

--- a/src/tomlrt/_array_comments.py
+++ b/src/tomlrt/_array_comments.py
@@ -1,11 +1,9 @@
-"""Comment side-channel views for ``Array``.
+"""Expose comment side-channel views for ``Array``.
 
-``Array.comments`` (EOL comments per item) and
-``Array.leading_comments`` (tuple of comment lines above each item)
-are implemented here.  Both are indexed by item position and share
-the encode/decode helpers and validation rules from ``_comments``.
+``Array.comments`` and ``Array.leading_comments`` are indexed by item
+position and share the encode/decode rules from ``_comments``.
 
-Per-item trivia ownership (canonical model — see ``ArrayValue``):
+Per-item trivia ownership (see ``ArrayValue``):
 
   - Above-item region for item ``i``:
       ``header_trivia``       if i == 0
@@ -73,9 +71,8 @@ def _check_index(arr: Array, key: object) -> int:
 def _downstream_break_holder(value: ArrayValue, idx: int) -> Trivia:
     """Return the trivia that owns item ``idx``'s row break.
 
-    When the item's own row carries no EOL section the break lives in the
-    next item's ``leading``, or—for the tail item—the value's
-    ``final_trivia``.
+    If the item has no EOL section, the break lives in the next item's
+    ``leading`` or, for the tail item, in ``final_trivia``.
     """
     items = value.items
     return items[idx + 1].leading if idx + 1 < len(items) else value.final_trivia
@@ -104,9 +101,8 @@ def _ensure_multiline(arr: Array) -> None:
 def _above_owner(value: ArrayValue, i: int) -> tuple[Trivia, int]:
     """Return ``(owner, prefix_len)`` for item ``i``'s above-region.
 
-    ``owner`` carries item ``i``'s above-block; its first ``prefix_len``
-    pieces precede the region and must be preserved. Comma-first parks
-    the block in ``items[i-1].trailing`` after that item's EOL section.
+    The first ``prefix_len`` owner pieces must be preserved. Comma-first
+    parks the block in ``items[i-1].trailing`` after that item's EOL.
     """
     if i == 0:
         return value.header_trivia, 0
@@ -124,10 +120,8 @@ def _comments_from_lines(pieces: list[TriviaPiece]) -> tuple[str, ...]:
 def _slot_indent(arr: Array) -> str:
     """Best-effort indent string for this array's items.
 
-    The per-item value-indent is the ``tail`` of its above-frame, which
-    :func:`_split_above_frame` already resolves uniformly across the
-    bracket pad (item 0), conventional, and comma-first layouts. Return
-    the first one found.
+    ``_split_above_frame`` resolves the value-indent uniformly across
+    bracket-pad, conventional, and comma-first layouts.
     """
     value = arr._value  # noqa: SLF001
     for i in range(len(value.items)):
@@ -182,12 +176,9 @@ def _set_eol_raw(arr: Array, idx: int, raw_text: str) -> None:
 
     The synthesised EOL section ends with its own newline, so the
     structural newline that previously terminated the item's line must
-    be removed to avoid duplication. That structural newline lives in
-    one of three places, depending on layout:
+    be removed to avoid duplication. Depending on layout, it lives:
 
-    * inside ``target`` (the item's ``post_comma_trivia`` for
-      has-comma items, or ``trailing`` for no-comma items) — handled
-      by the ``rest`` strip below;
+    * inside ``target`` — handled by the ``rest`` strip below;
     * on the next item's ``leading`` — has-comma, non-tail item;
     * in the value's ``final_trivia`` — tail item (with or without
       a trailing comma).
@@ -203,8 +194,7 @@ def _set_eol_raw(arr: Array, idx: int, raw_text: str) -> None:
         and rest.pieces
         and isinstance(rest.pieces[0], NewlineNode)
     ):
-        # Replace the structural newline; our synthesised EOL
-        # provides its own.
+        # Replace the structural newline; our synthesised EOL has one.
         rest = Trivia(list(rest.pieces[1:]))
         stripped = True
     new_eol: list[TriviaPiece] = [
@@ -296,12 +286,10 @@ def _split_above_frame(
 ) -> tuple[Trivia, Trivia, Trivia, Trivia]:
     """Decompose item ``i``'s above-region into ``(owner, prefix, head, tail)``.
 
-    Rewrites assign ``owner.pieces``; the existing comment block is
-    discarded. ``prefix`` precedes the region and is re-emitted verbatim
-    (a comma-first predecessor's EOL section, else empty); ``head`` /
-    ``tail`` are the framing NL / value-indent. For ``i == 0`` the owner
-    is the bracket pad, where a pre-NL comment is a ``[``-EOL kept in
-    ``head`` rather than an above-block.
+    Rewrites assign ``owner.pieces``. ``prefix`` is preserved verbatim
+    (comma-first predecessor EOL, else empty); ``head`` / ``tail`` frame
+    the comment block. For item 0, pre-NL bracket comments stay in
+    ``head`` rather than becoming above-blocks.
     """
     if i == 0:
         owner = value.header_trivia
@@ -331,9 +319,8 @@ def _set_above_pieces(
 ) -> None:
     """Replace the comment block in item ``i``'s above-region.
 
-    Preserves any structural framing already present (preserved
-    prefix, leading NL, trailing value-indent WS) and only rewrites
-    the comment block between.
+    Preserve structural framing and rewrite only the comment block
+    between it.
     """
     owner, prefix, head, tail = _split_above_frame(value, i)
     if not head.pieces and not tail.pieces:
@@ -378,8 +365,8 @@ class ArrayLeadingView(_ArrayIntKeyedView[tuple[str, ...]]):
         idx = _check_index(self._arr, key)
         if not seq:
             # Empty assignment means "no leading comments" — semantically
-            # a delete-if-present. Don't auto-promote to multi-line: the
-            # array doesn't need newlines to carry zero comments.
+            # a delete-if-present. Don't promote: zero comments need no
+            # newlines.
             self._delete(idx, allow_missing=True)
             return
         _ensure_multiline(self._arr)

--- a/src/tomlrt/_build.py
+++ b/src/tomlrt/_build.py
@@ -1,11 +1,8 @@
 """Initial logical-container build.
 
-Single linear pass over a `ParseResult`'s slot stream that
-constructs the `Document` body and all nested `Table` / `Array` /
-`AoT` views, populating dict storage in doc-stream-first-occurrence
-order. This is the *one* place that derives implicit containers from
-slot paths; the parser does not build logical containers and
-`_container.py` does not duplicate the derivation.
+Builds `Document`, `Table`, `Array`, and `AoT` views from a parsed
+slot stream in doc-stream first-occurrence order. This is the one place
+that derives implicit containers from slot paths.
 """
 
 from __future__ import annotations
@@ -35,9 +32,8 @@ def build_initial_containers(doc: Document, slots: list[Slot]) -> None:
     """Walk the slot stream and populate ``doc`` and its descendants.
 
     Threads the current header's host container through the loop so
-    each KV skips the doc-root re-walk in ``_resolve_chain``. The
-    validator guarantees ``slot.host_path`` equals the most recent
-    header's ``path`` (or ``()`` if none) — asserted below.
+    each KV skips a doc-root re-walk. The validator guarantees
+    ``slot.host_path`` equals the most recent header path (or ``()``).
     """
     current_host: Container = doc
     for slot in slots:
@@ -57,9 +53,8 @@ def build_initial_containers(doc: Document, slots: list[Slot]) -> None:
 # ---------------------------------------------------------------------------
 
 
-# ``record_ref`` and ``maybe_advance_body_tail`` are imported from
-# _layout_ops and shared with the mutation paths, so cache maintenance
-# has one canonical source.
+# ``record_ref`` and ``maybe_advance_body_tail`` are shared with
+# mutation paths, keeping cache maintenance in one place.
 
 
 # ---------------------------------------------------------------------------
@@ -77,10 +72,8 @@ def _apply_header(doc: Document, slot: StructuralHeaderSlot) -> Table:
 def _open_table(doc: Document, header: StructuralHeaderSlot) -> Table:
     """Open ``[a.b.c]`` — return the `Table` view for ``path``.
 
-    Walks (and creates as needed) all implicit ancestors. Raises if an
-    intermediate name is bound to a non-table value (the validator
-    should have already rejected this; the assertion guards against
-    drift).
+    Creates implicit ancestors as needed. A non-table intermediate is
+    validator drift and raises.
     """
     path = header.path
     parent_chain = _resolve_chain(doc, path[:-1])
@@ -141,9 +134,9 @@ def _open_aot_entry(
 def _resolve_chain(doc: Document, prefix: tuple[str, ...]) -> list[Container]:
     """Return the container chain ``[doc, doc.a, doc.a.b, ...]`` for prefix.
 
-    Creates implicit containers as needed (these are reachable from
-    later headers). For an AoT prefix, descends into the most recent
-    entry. The returned list always has length ``len(prefix) + 1``.
+    Creates implicit containers as needed. For an AoT prefix, descends
+    into the most recent entry. The returned list always has length
+    ``len(prefix) + 1``.
     """
     chain: list[Container] = [doc]
     cur: Container = doc
@@ -191,19 +184,15 @@ def _apply_kv(slot: KVSlot, *, host: Container) -> None:
     """Bind a `key = value` slot into its host container.
 
     Refs propagate **only** along the slot's logical path starting at
-    the host container `H`, NOT from the document root. So a KV with
-    `host_path = ("a",)` and `key = ("x",)` generates exactly one ref,
-    in `a._index["x"]`; it does NOT contribute a ref to
-    `doc._index["a"]`.
+    the host container, not from the document root. A KV under ``[a]``
+    contributes to ``a._index["x"]``, not ``doc._index["a"]``.
 
     ``host`` is the pre-resolved container for ``slot.host_path``,
-    threaded by ``build_initial_containers`` from the most recent
-    header. Everything else (layout root for dotted intermediates,
-    decoded value attachment) cascades through ``host._layout_root``.
+    threaded from the most recent header; decoded value attachment
+    cascades through ``host._layout_root``.
     """
     decoded = slot.key
-    # Logical container chain along the dotted-KV intermediate steps:
-    # host -> host.k0 -> host.k0.k1 -> ... -> host.k[:-1].
+    # Logical chain for dotted-KV intermediates: host -> ... -> leaf parent.
     leaf_chain: list[Container] = [host]
     cur = host
     for step in decoded[:-1]:
@@ -319,9 +308,7 @@ def _decode_inline_table(
                     owner=owner,
                 )
                 inner._inline = True  # noqa: SLF001
-                # Inner inline-tables created from a dotted inline-table
-                # entry don't have their own backing InlineTableValue;
-                # `_value` stays None.
+                # Dotted inline-table navigators have no backing value.
                 dict.__setitem__(cur, step, inner)
                 cur = inner
             else:
@@ -360,9 +347,8 @@ def build_from_parse(result: ParseResult) -> Document:
     doc._displaced_recorder = None  # noqa: SLF001
     doc._layout_root = doc  # noqa: SLF001
     if result.slots:
-        # Migrate the head slot's positional-prefix (preamble +
-        # archived above-blocks) onto the document. The head slot's
-        # leading retains only its own attached comments + indent.
+        # Move the head slot's above-blank prefix onto the document
+        # preamble; leave only attached comments + indent on the slot.
         head = result.slots[0]
         above, attached, indent = _split_attached_block(head.leading)
         if above:

--- a/src/tomlrt/_comma_ops.py
+++ b/src/tomlrt/_comma_ops.py
@@ -1,34 +1,18 @@
-"""Structural mutation primitives for inline-array / inline-table values.
+"""Mutate inline-array / inline-table item lists structurally.
 
-This module owns the operations that splice items into or out of a
-:class:`tomlrt._values.CommaValue` while keeping the canonical layout
-invariants (per-item trivia ownership, one-row-break-per-row, EOL
-section attachment, trailing-comma policy). It is the structural
-counterpart to :mod:`tomlrt._format`, which owns the *canonicalisation*
-of an existing layout to a chosen shape.
+All structural changes to a :class:`tomlrt._values.CommaValue` pass
+through this module so the canonical model stays central: per-item
+trivia ownership, ``header_trivia`` / ``final_trivia`` bracket-pad
+attachment, one-row-break-per-row, EOL section placement, and
+trailing-comma policy. :mod:`tomlrt._format` is the counterpart that
+canonicalises an existing layout without changing structure.
 
-The public surface is intentionally small:
+The small public surface covers append, removal, reorder, comma-state
+flips, and EOL-section helpers for arrays and inline tables.
 
-* :func:`splice_in` — append one item.
-* :func:`splice_out_tail` — promote a previously-internal
-  item to terminal after its successor has been spliced out.
-* :func:`splice_out_head` — promote a previously-internal
-  item to head after the original head has been spliced out.
-* :func:`splice_out` — splice out a set of owned
-  indices and run the head / tail / inter-item fix-ups.
-* :func:`reorder_owned` — permute a set of owned indices
-  in place.
-
-Inline-array (`tomlrt._array.Array`) and inline-table
-(`tomlrt._inline_ops`) mutation both drive every structural change
-through these helpers, so a future change to the canonical model only
+Inline-array and inline-table mutation both drive structural changes
+through these helpers, so a future change to the comma-value model only
 needs to land here.
-
-Supporting primitives — :func:`flip_to_internal` / :func:`flip_to_terminal`
-and the EOL section helpers :func:`_take_eol` / :func:`_put_eol` /
-:func:`_item_has_eol` / :func:`_normalise_row_breaks` — also live here
-and are exported for the few :mod:`tomlrt._format` canonicalisation
-paths that need them.
 """
 
 from __future__ import annotations
@@ -76,7 +60,7 @@ _CV_ItemT = TypeVar("_CV_ItemT", bound="CommaItem")
 
 
 def _row_terminated(item: CommaItem) -> bool:
-    """True if the item's own row already carries its terminating newline.
+    """Return whether the item's own row carries its terminating newline.
 
     Otherwise the break is downstream, in the next item's leading (or
     ``final_trivia`` for the tail). Comma placement never enters into it.
@@ -87,7 +71,7 @@ def _row_terminated(item: CommaItem) -> bool:
 def _take_eol(item: CommaItem) -> Trivia:
     """Split out and return the item's row-attached EOL section.
 
-    On return the item holds only the structural rest in that channel.
+    The item keeps only the structural rest in that channel.
     """
     channel = item_eol_channel(item)
     eol, rest = split_eol_section(channel)
@@ -168,16 +152,10 @@ def _normalise_row_breaks(
 def flip_to_internal(item: CommaItem) -> None:
     """Make ``item`` look like an internal (non-last) item.
 
-    Under the canonical model the inter-item separator lives in the
-    NEXT item's leading; this function only ensures the comma is set
-    and carries any EOL comment across the channel flip (trailing →
-    post_comma_trivia) so the comma stays immediately after the
-    value and the comment after the comma. No-op if the item already
-    has a comma.
-
-    Shared between the inline-array append path and the inline-table
-    append path, both of which transition a previously-terminal item
-    into an internal item when a new item is being appended.
+    The inter-item separator belongs to the next item's leading; this
+    only sets comma state and carries any EOL comment across the
+    ``trailing`` → ``post_comma_trivia`` channel flip so the comma renders
+    before the comment. No-op if the item already has a comma.
     """
     if item.has_comma:
         return
@@ -187,7 +165,11 @@ def flip_to_internal(item: CommaItem) -> None:
 
 
 def flip_to_terminal(item: CommaItem, style: CommaStyle) -> None:
-    """Make ``item`` look like the terminal (last) item per style."""
+    """Make ``item`` look like the terminal item for ``style``.
+
+    Trailing-comma style keeps existing ``post_comma_trivia`` intact;
+    no-trailing style moves any EOL section back to ``trailing``.
+    """
     if style.trailing_comma:
         if not item.has_comma:
             eol = _take_eol(item)
@@ -212,11 +194,10 @@ def flip_to_terminal(item: CommaItem, style: CommaStyle) -> None:
 
 @dataclass(slots=True, frozen=True)
 class CommaStyle:
-    """Inferred layout policy for an inline array or inline table.
+    """Hold inferred layout policy for inline array/table append paths.
 
-    Used by both the inline-array and inline-table append paths to
-    decide where the new item goes, how the previous-last is flipped
-    to internal, and whether the new last carries a trailing comma.
+    Carries the inter-item separator, whether the value is multi-line,
+    and whether the terminal item should keep a trailing comma.
     """
 
     is_multiline: bool
@@ -230,9 +211,9 @@ def detect_style(
 ) -> CommaStyle:
     """Infer a :class:`CommaStyle` for ``value`` (or for a fresh value).
 
-    The inter-item separator is sampled from ``items[1].leading``; a
-    multi-line value that can't (single item, or a comma-first peer with
-    an empty leading) falls back to :func:`_canonical_separator`.
+    The inter-item separator is sampled from ``items[1].leading``. A
+    multi-line value that cannot sample one (single item, or a comma-first
+    peer with empty leading) falls back to :func:`_canonical_separator`.
     """
     if value is None:
         return CommaStyle(
@@ -273,7 +254,7 @@ def _first_indent_after_newline(trivia: Trivia) -> str:
 
 
 def _value_newline(value: CommaValue[Any]) -> str:
-    """The newline text ``value`` uses (sampled from its bracket pads)."""
+    """Return the newline text sampled from ``value`` bracket pads."""
     for trivia in (value.header_trivia, value.final_trivia):
         for p in trivia.pieces:
             if isinstance(p, NewlineNode):
@@ -282,7 +263,7 @@ def _value_newline(value: CommaValue[Any]) -> str:
 
 
 def _canonical_separator(value: CommaValue[Any]) -> Trivia:
-    """Fallback inter-item separator: a newline + the value's own indent."""
+    """Return the fallback inter-item newline plus value indent."""
     indent = (
         _first_indent_after_newline(value.header_trivia)
         or indent_from_final_trivia(value.final_trivia)
@@ -295,7 +276,7 @@ def _canonical_separator(value: CommaValue[Any]) -> Trivia:
 def _row_break(
     value: CommaValue[Any], existing: Sequence[TriviaPiece]
 ) -> list[TriviaPiece]:
-    """Row break to prepend to ``existing``; adds indent only if it has none."""
+    """Return a row break to prepend, adding indent only if none exists."""
     if existing and isinstance(existing[0], WhitespaceNode):
         return [NewlineNode(text=_value_newline(value))]
     return list(_canonical_separator(value).pieces)
@@ -304,11 +285,9 @@ def _row_break(
 def migrate_bracket_above(bracket: Trivia, separator: Trivia) -> tuple[Trivia, Trivia]:
     """Migrate any above-bracket comment block onto a new item's leading.
 
-    An above-block in ``header_trivia`` / ``final_trivia`` (the
-    structural row(s) between the bracket and the next/last item)
-    conceptually belongs to the item below it. When a new boundary
-    item is being inserted or appended, the block migrates from the
-    bracket pad onto that item's leading.
+    An above-block in ``header_trivia`` / ``final_trivia`` conceptually
+    belongs to the item below it. Inserting a boundary item moves that
+    block from the bracket pad onto the item's leading.
 
     Returns ``(new_bracket, new_leading)``.
     """
@@ -329,21 +308,12 @@ def splice_in(
 ) -> None:
     """Append ``new_item`` to ``cv`` honouring ``style``.
 
-    Shared orchestration for inline arrays and inline tables. The
-    caller is responsible for constructing ``new_item`` of the
-    appropriate concrete type (``ArrayItem`` for an array,
-    ``InlineTableEntry`` for an inline table) and for computing the
-    appropriate ``style`` (typically via :func:`detect_style`).
-
-    Empty case: reframes the bracket pad so the new item sits on its
-    own canonical row, stamping the value's canonical single-line pad
-    (one space for inline tables, none for arrays) when no pad survives,
-    then flips it to terminal-per-style.
-
-    Non-empty case: migrates any above-bracket comment block onto the
-    new item's leading, flips the previous-last to internal, appends,
-    flips the new item to terminal-per-style, and renormalises the
-    row-break invariant.
+    The caller supplies the concrete item (``ArrayItem`` or
+    ``InlineTableEntry``) and style. Empty values reframe bracket pads for
+    the first item, preserving canonical single-line inner pad when no
+    authored pad survives. Non-empty values migrate above-bracket comments
+    to the new item's leading, flip the old tail internal, make the new
+    item terminal, and restore row-break invariants.
     """
     items = cv.items
     if not items:
@@ -373,23 +343,14 @@ def splice_out_tail(
 ) -> None:
     """Re-terminalise the new last item after a tail removal.
 
-    Both inline-array tail-delete and inline-table tail-delete face
-    the same transition: the previous tail has been spliced out, and
-    the item that was internal is now the new tail.
+    The former internal tail adopts the removed tail's comma policy while
+    its row-attached EOL section survives the
+    ``post_comma_trivia``/``trailing`` channel flip. No-op when empty;
+    caller owns empty bracket-pad cleanup.
 
-    Steps (mirroring :func:`splice_in` in reverse):
-      * take the entry-attached EOL section off the new tail (it
-        currently lives in ``post_comma_trivia`` because the entry
-        was internal);
-      * adopt the removed entry's trailing-comma policy on the new
-        tail and clear its now-stale ``post_comma_trivia``;
-      * put the EOL section back, routed to ``trailing`` or
-        ``post_comma_trivia`` per the new ``has_comma`` state;
-      * renormalise the row-break invariant.
-
-    No-ops when ``cv.items`` is empty (the caller's
-    ``strip_trailing_indent`` or equivalent handles the no-item
-    canonical form).
+    This mirrors ``splice_in`` in reverse: the item was internal, so its
+    EOL section may currently live after its comma; terminalising may move
+    that section back before the (now absent) comma.
     """
     items = cv.items
     if not items:
@@ -408,16 +369,10 @@ def splice_out_head(
 ) -> None:
     """Migrate the above-block of the new first item into ``header_trivia``.
 
-    After deleting the original head item(s), the item that is now
-    ``items[0]`` was previously internal; its ``leading`` still
-    carries the inter-item separator plus any above-item comment
-    block that conceptually belonged above it. Under the canonical
-    model ``items[0].leading`` is always empty and the above-block
-    above the first item lives in ``header_trivia``. This helper
-    completes the migration: the caller has already extracted the
-    above-block (before deletion, via :func:`split_item_above` on
-    the soon-to-be-new-first item's leading); we splice it into
-    ``header_trivia`` and reset ``items[0].leading``.
+    After head deletion, new item 0 was internal and still has separator
+    plus above-item comments in leading. The canonical model keeps item 0
+    leading empty and stores the above-block in ``header_trivia``; caller
+    passes the pre-extracted block.
     """
     if not cv.items:
         return
@@ -436,29 +391,14 @@ def splice_out(
 ) -> None:
     """Splice out ``removed_indices`` and run the boundary fixups.
 
-    Shared orchestration for inline-array tail/head/internal removal
-    (``Array.__delitem__``) and inline-table key / dotted-prefix
-    removal (``_inline_ops.delete_entry``). The caller is responsible
-    for the kind-specific logic that *finds* the indices to remove
-    (slice-vs-int normalisation for arrays, key / prefix lookup for
-    inline tables) and for any associated logical-view bookkeeping
-    (decoded ``list`` / ``dict`` removal).
-
-    Steps:
-      * snapshot the above-block of the soon-to-be-new-first item
-        when position 0 is among ``removed_indices`` (so the
-        canonical "above-block of item 0 lives in header_trivia"
-        invariant can be restored after the splice);
-      * capture the about-to-be-removed tail's ``has_comma`` policy
-        (so the new tail can adopt it);
-      * pop the removed indices from ``cv.items`` in reverse order;
-      * if no items remain, call :func:`strip_trailing_indent` to
-        canonicalise the empty bracket pad (unless
-        ``strip_when_empty`` is False — used by callers that own a
-        different empty-canonicalisation policy);
-      * else dispatch to :func:`splice_out_head` /
-        :func:`splice_out_tail` /
-        :func:`_normalise_row_breaks` as appropriate.
+    Shared removal orchestration for inline arrays and inline-table
+    entries; callers own index discovery (slice/int normalisation for
+    arrays, key/prefix lookup for inline tables) and logical-view updates.
+    Head removal snapshots the new-first above-block so the "item 0
+    above-block lives in ``header_trivia``" invariant is restored. Tail
+    removal transfers the removed tail's comma policy to the new tail.
+    Empty values use :func:`strip_trailing_indent` unless the caller
+    supplies a different policy.
 
     ``removed_indices`` must be a list of valid distinct indices into
     ``cv.items`` (not necessarily sorted on input; sorted internally).
@@ -512,30 +452,19 @@ def reorder_owned(
 ) -> None:
     """Reorder ``owned_positions`` within ``cv.items`` in place.
 
-    Positional-preserve strategy shared by inline arrays (where every
-    position is owned) and inline tables (where the caller may be a
-    dotted-inner navigator with foreign entries interspersed). The
-    split between positional state (stays at the position) and
-    entry-attached state (travels with the entry) is:
+    Shared positional-preserve strategy for arrays and dotted-inner
+    inline-table navigators. State splits as follows:
 
-      * **Positional**: structural pad (the part of ``leading`` —
-        or ``header_trivia`` for position 0 — before any above-item
-        comment block), ``has_comma``, ``post_comma_trivia``,
-        ``trailing``.
-      * **Entry-attached**: above-item comment block, row-attached
-        EOL section.
+    * positional: structural pad, comma state, post-comma trivia, trailing
+      trivia;
+    * entry-attached: above-item comment blocks and row-attached EOL
+      sections.
 
-    ``owned_positions`` is a strictly ascending list of indices into
-    ``cv.items`` that are subject to reordering; non-owned positions
-    are left untouched. ``new_owned`` is the permutation: the entry
-    to place at each owned position, in the same order. Both lists
-    must have equal length, and ``new_owned`` must be a permutation
-    of ``cv.items[i]`` for ``i in owned_positions``.
-
-    Bracket trivia (``header_trivia`` / ``final_trivia``) is
-    untouched, so above-bracket comment blocks survive the reorder
-    at their structural position. No-op for fewer than two owned
-    positions.
+    ``owned_positions`` is strictly ascending and foreign positions stay
+    untouched. ``new_owned`` is the matching permutation. Bracket trivia
+    (``header_trivia`` / ``final_trivia``) is untouched, so above-bracket
+    comments stay at their structural position. No-op for fewer than two
+    owned positions.
     """
     if len(owned_positions) <= 1:
         return

--- a/src/tomlrt/_comments.py
+++ b/src/tomlrt/_comments.py
@@ -1,23 +1,10 @@
-"""Comment side-channel views over slot trivia.
+"""Expose comment side-channel views over slot trivia.
 
-Two primary views per `Container`:
-
-- `Container.comments` — `MutableMapping[str, str]` over the *EOL*
-  comment of the direct-KV slot for each key.  Reading returns the
-  decoded comment text (the leading ``#`` and one optional space
-  are stripped); writing accepts the same shape and re-encodes.
-- `Container.leading_comments` — `MutableMapping[str, tuple[str, ...]]`
-  over the *leading* comment block on the direct-KV slot for each
-  key.  Empty tuple means "no comments above this key".
-
-Implementation notes:
-
-- A slot is exposed under its leaf key on whichever container is its
-  immediate parent. For a plain ``key = value``, that's the explicit
-  section it sits in; for a dotted KV like ``b.c = 1`` under ``[a]``,
-  that's ``a["b"]`` (not ``a``).
-- Inline-table containers do not expose a comment view (TOML
-  forbids comments inside an inline table).
+`Container.comments` maps direct keys to decoded EOL comments;
+`Container.leading_comments` maps them to attached leading comment
+blocks. A slot is exposed under its leaf key on its immediate parent
+(``b.c = 1`` under ``[a]`` appears on ``a["b"]``). Inline tables have
+no comment view because TOML forbids comments inside them.
 """
 
 from __future__ import annotations
@@ -61,8 +48,8 @@ def _validate_comment_text(text: str) -> None:
         raise TOMLError(msg)
     for ch in text:
         cp = ord(ch)
-        # TOML comments allow TAB plus any printable Unicode; reject
-        # other ASCII control chars and DEL.
+        # TOML comments allow TAB plus printable Unicode; reject other
+        # ASCII controls and DEL.
         if cp == 0x09:
             continue
         if cp < 0x20 or cp == 0x7F:
@@ -107,11 +94,8 @@ def _direct_kv_slot(c: Container, key: str) -> KVSlot | None:
 def _require_attached(c: Container) -> None:
     """Reject comment-view mutation on a container with no slot stream.
 
-    Detached containers (e.g. ``Table.section()`` before assignment into
-    a `Document`) have no slot stream, so the comment views have nowhere
-    to store the mutation. Raise a clear `TOMLError` pointing at the
-    fix instead of a misleading ``KeyError`` from the internal slot
-    lookup.
+    Detached containers have nowhere to store comment mutations, so
+    raise a clear `TOMLError` instead of an internal ``KeyError``.
     """
     if c._layout_root is None:  # noqa: SLF001
         msg = (
@@ -128,9 +112,8 @@ _T = TypeVar("_T")
 class _SlotKeyedView(MutableMapping[str, _T]):
     """Mapping over Container keys whose direct-KV slot satisfies a predicate.
 
-    Subclasses provide ``_present(slot)`` plus the read/write/delete
-    item methods. The base supplies ``__init__``, ``__contains__``,
-    ``__iter__``, ``__len__`` and ``__repr__``.
+    Subclasses provide ``_present(slot)`` and item methods; the base
+    supplies the shared mapping plumbing.
     """
 
     __slots__ = ("_c",)
@@ -214,20 +197,15 @@ def _split_attached_block(
 ) -> tuple[list[list[TriviaPiece]], list[list[TriviaPiece]], list[TriviaPiece]]:
     """Split the leading into (above_blank, attached_comment_lines, slot_indent).
 
-    The "attached" group is the contiguous run of comment lines
-    immediately preceding the slot — i.e. with no blank line
-    between the run and the slot itself.  Everything before the
-    last blank-separator-or-start is "above_blank" (preamble +
-    archived blocks).  ``slot_indent`` is any trailing whitespace-
-    only, newline-less "indent" line (the slot's own column
-    offset) — preserved separately so callers can reapply it
-    when rebuilding the leading.
+    The attached group is the contiguous comment run immediately before
+    the slot. Earlier lines are preamble/archived blocks. ``slot_indent``
+    is the trailing whitespace-only, newline-less column offset that
+    rebuilders must reapply.
     """
     lines = split_lines(leading.pieces)
     indent: list[TriviaPiece] = []
     if lines and not any(isinstance(p, NewlineNode) for p in lines[-1]):
         last = lines[-1]
-        # Only treat as indent if it has no comment.
         if not any(isinstance(p, CommentNode) for p in last):
             indent = last
             lines = lines[:-1]
@@ -242,9 +220,8 @@ def _split_attached_block(
 def _read_leading_block(c: Container, slot: Slot) -> tuple[str | None, ...]:
     """Decoded leading block of ``slot``.
 
-    Comment-bearing lines decode to their text; blank or whitespace-only
-    lines become ``None``.  The slot's own trailing indent line (if any)
-    is excluded.
+    Comment lines decode to text, blank/whitespace-only lines become
+    ``None``, and the slot's own trailing indent is excluded.
     """
     del c
     above, attached, _indent = _split_attached_block(slot.leading)
@@ -257,9 +234,8 @@ def _write_leading_block(
 ) -> None:
     """Replace ``slot``'s leading with ``block``.
 
-    The slot's own trailing indent (column offset) is preserved.  Comment
-    lines re-use that indent as their prefix; blank lines are emitted as
-    a bare newline with no trailing whitespace.
+    Preserve the slot's column indent; comment lines reuse it and blank
+    lines emit a bare newline.
     """
     _above, _attached, indent = _split_attached_block(slot.leading)
     new_pieces: list[TriviaPiece] = []
@@ -298,9 +274,8 @@ def _validate_block_seq(value: object, name: str) -> tuple[str | None, ...]:
 def _extract_leading_comments(leading: Trivia) -> tuple[str, ...]:
     """Return only the *attached* run of comment-bearing lines.
 
-    The "attached" run is the contiguous block immediately above
-    the slot — comments separated by a blank line are considered
-    preamble or archived blocks and are excluded.
+    Comments separated by a blank line are preamble or archived blocks
+    and are excluded.
     """
     _above, attached, _indent = _split_attached_block(leading)
     return _lines_to_comments(attached)
@@ -355,16 +330,12 @@ class LeadingCommentView(_SlotKeyedView[tuple[str, ...]]):
 class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
     """Mapping view over the full leading-trivia block of each direct key.
 
-    Entries are tuples of comment strings and ``None`` (one ``None`` per
-    blank line), in source order; the slot's own column indent is not
-    included.  This is the full-fidelity peer of
-    :class:`LeadingCommentView`, which only exposes the trailing attached
-    block.  Writing replaces the entire leading; the slot's indent is
-    re-applied to each comment line and to the slot itself.
+    Entries are source-order comment strings and ``None`` for blank
+    lines; the slot's own column indent is excluded and re-applied on
+    write. This is the full-fidelity peer of :class:`LeadingCommentView`.
 
-    For the document's head slot the above-blank region (preamble) is
-    disjoint from this view: it is exposed and mutated via
-    :attr:`Document.preamble` instead.
+    The document head preamble is disjoint and lives on
+    :attr:`Document.preamble`.
     """
 
     __slots__ = ()
@@ -407,9 +378,8 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
 def _header_slot(c: Container) -> StructuralHeaderSlot | None:
     """Return the StructuralHeaderSlot for a section container, or raise.
 
-    Raises TOMLError on inline tables (no header to attach a comment to).
-    Returns None if this container has no own header (document root /
-    purely-implicit container).
+    Inline tables raise because they have no header; document roots and
+    purely implicit containers return ``None``.
     """
     if c._inline:  # noqa: SLF001
         msg = "header comment API is not available on inline tables"
@@ -427,9 +397,8 @@ def _header_comment_get(c: Container) -> str | None:
     h = _header_slot(c)
     if h is None:
         # No header line means no header comment; mirror the empty
-        # state of an explicit section that simply has no comment.
-        # Setters still raise — silently dropping a write would be a
-        # footgun.
+        # state of an explicit section. Setters still raise; silently
+        # dropping a write would be a footgun.
         return None
     eol = h.eol
     if eol.comment is None:
@@ -520,9 +489,8 @@ def _lines_to_comments(lines: Iterable[Iterable[TriviaPiece]]) -> tuple[str, ...
 def _set_attached_block(leading: Trivia, comments: tuple[str, ...], nl: str) -> None:
     """Replace the attached comment block on ``leading`` with ``comments``.
 
-    Preserves any preamble / archived blocks above any blank-line
-    separator and re-applies the slot's own indent before each new
-    comment line and the slot itself.
+    Preserve preamble/archived blocks and reapply the slot's indent to
+    each new comment line and the slot itself.
     """
     above, _attached, indent = _split_attached_block(leading)
     kept: list[TriviaPiece] = []

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -56,6 +56,7 @@ from tomlrt._trivia import (
     NewlineNode,
     Trivia,
     WhitespaceNode,
+    retarget_trivia_newlines,
     trivia_has_comment,
 )
 from tomlrt._typecheck import _validate_key, _validate_mapping
@@ -638,7 +639,9 @@ class Container(dict[str, Any]):
 
         AoT-entry sources clone as a table so trivia survives and the
         head normalises from ``[[..]]`` to ``[..]``. Attached
-        header-bearing sections clone slots; attached implicit sources
+        header-bearing sections clone slots; a whole attached
+        ``Document`` clones its body under a synthesised header (so body
+        comments and inline pad survive); attached implicit sources
         recurse via ``_install_attached_subtree``; detached/private
         sources rehome in place.
         """
@@ -651,9 +654,11 @@ class Container(dict[str, Any]):
                 _layout_ops.clone_aot_entry_as_table(self, key, value)
             elif value._header_ref is not None:
                 _layout_ops.clone_section_as_section(self, key, value)
+            elif isinstance(value, Document):
+                _layout_ops.clone_document_as_section(self, key, value)
             else:
-                # Implicit source / whole Document: tuple-path install
-                # preserves structural children and implicit chains.
+                # Implicit source: tuple-path install preserves structural
+                # children and implicit chains.
                 _install_attached_subtree(self, (key,), value)
             return
         if src_root is not None and src_root._is_private:  # noqa: SLF001
@@ -1514,7 +1519,7 @@ def _install_attached_subtree(
             direct_kvs.append((k, v))
 
     if direct_kvs:
-        _install_dotted_direct_kvs(dst_parent, dst_path, direct_kvs)
+        _install_dotted_direct_kvs(dst_parent, dst_path, direct_kvs, src_table)
 
     for k, v in structural:
         sub_path = (*dst_path, k)
@@ -1530,33 +1535,43 @@ def _install_dotted_direct_kvs(
     dst_parent: Container,
     dst_path: tuple[str, ...],
     direct_kvs: list[tuple[str, object]],
+    src_table: Container,
 ) -> None:
     """Emit each ``(k, v)`` in ``direct_kvs`` as a dotted KV under host.
 
     ``host`` is the nearest header-bearing ancestor at-or-above
     ``dst_parent`` (or the doc / AoT-entry root). Creates implicit
-    intermediates as needed. Values are deep-cloned through
-    ``_to_python`` + ``_synth_value`` so the source CST is not disturbed.
+    intermediates as needed. Each value's CST and leading trivia are
+    deep-cloned from the corresponding source slot so string/number
+    style, inline-array pad, and standalone comments survive — a
+    re-synthesis from the logical value would drop all of those.
     """
+    from tomlrt._build import _decode_value  # noqa: PLC0415
+
+    doc = dst_parent._attached_doc  # noqa: SLF001
     host: Container = dst_parent
     while host._header_ref is None and host._parent is not None:  # noqa: SLF001
         host = host._parent  # noqa: SLF001
     parent_to_host = dst_parent._path[len(host._path) :]  # noqa: SLF001
-    layout_root = dst_parent._layout_root  # noqa: SLF001
     owner = host._owner_aot_entry  # noqa: SLF001
-    for k, v in direct_kvs:
+    for k, _v in direct_kvs:
         leaf_keypath = (*parent_to_host, *dst_path, k)
         leaf_parent = _layout_ops.ensure_implicit_chain(host, leaf_keypath[:-1])
-        py = _to_python(v)
-        cst, decoded = _synth_value(
-            py,
-            layout_root=layout_root,
-            parent=leaf_parent,
-            path=(*host._path, *leaf_keypath),  # noqa: SLF001
-            owner=owner,
+        path = (*host._path, *leaf_keypath)  # noqa: SLF001
+        # A direct (non-structural) key of an attached source is always
+        # backed by a single KVSlot; clone its value + leading so style
+        # and standalone comments survive (re-synthesis would drop them).
+        src_slot = src_table._index[k][0].slot  # noqa: SLF001
+        assert isinstance(src_slot, KVSlot)
+        cst = copy.deepcopy(src_slot.value)
+        _retarget_to_doc(cst, doc)
+        leading = copy.deepcopy(src_slot.leading)
+        retarget_trivia_newlines(leading, doc._newline)  # noqa: SLF001
+        decoded = _decode_value(
+            cst, layout_root=doc, parent=leaf_parent, path=path, owner=owner
         )
         _layout_ops.install_dotted_kv_slot(
-            host, leaf_keypath, cst, leaf_parent=leaf_parent
+            host, leaf_keypath, cst, leaf_parent=leaf_parent, leading=leading
         )
         dict.__setitem__(leaf_parent, k, decoded)
 

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -1,11 +1,8 @@
 """Logical container layer.
 
-`Container(dict)` is the dict-typed base for both `Document` (the
-root) and `Table` (sections + inline tables). Reads come straight
-from dict storage populated in doc-stream first-occurrence order;
-mutations write to the slot stream via the per-container caches
-(`_index`, `_refs`, `_header_ref`, `_body_tail`) and refresh the
-dict from there.
+`Container(dict)` backs `Document` and `Table`. Dict storage follows
+doc-stream first-occurrence order; mutations update the slot stream
+through `_index`, `_refs`, `_header_ref`, and `_body_tail`.
 """
 
 from __future__ import annotations
@@ -95,12 +92,10 @@ _MISSING: Any = object()
 class Container(dict[str, Any]):
     """Dict-typed base for `Document` and `Table` views.
 
-    Reads are pure dict operations. Mutation paths use the per-container
-    cache (`_index` / `_refs` / `_header_ref` / `_body_tail`)
-    maintained alongside the dict storage. For inline tables
-    (`_inline=True`) the slot-stream caches stay empty and `_value`
-    points at the backing `InlineTableValue` instead — inline mutation
-    lives in a separate code path.
+    Reads are pure dict operations. Section mutations use the
+    per-container cache (`_index`, `_refs`, `_header_ref`,
+    `_body_tail`). Inline tables keep those caches empty and mutate
+    the backing `InlineTableValue` in `_value`.
     """
 
     __slots__ = (
@@ -160,8 +155,8 @@ class Container(dict[str, Any]):
         """Mapping view of leading-comment blocks on this container's direct keys.
 
         Returns only the *attached* comment run immediately above each key
-        (no blank line between).  For the full block — including any
-        above-blank groups and the blank-line structure between them — see
+        (no blank line between). For the full block, including any
+        above-blank groups and the blank-line structure between them, see
         [`leading_block`][tomlrt.Table.leading_block].
 
         Mutating the view requires the container to be attached to a
@@ -179,9 +174,6 @@ class Container(dict[str, Any]):
         Each entry is a ``tuple[str | None, ...]`` of comment strings
         interleaved with ``None`` (one per blank line), in source order;
         the slot's own column indent is implicit and re-applied on write.
-        Full-fidelity peer of
-        [`leading_comments`][tomlrt.Table.leading_comments], which exposes
-        only the trailing attached run.
 
         At the document's head slot,
         [`Document.preamble`][tomlrt.Document.preamble] is disjoint from
@@ -200,11 +192,10 @@ class Container(dict[str, Any]):
     def header_comment(self) -> str | None:
         """The EOL comment on this container's section header, or None.
 
-        Returns ``None`` for containers that have no header line
-        (the document root, implicit sections opened only by a
-        nested ``[a.b]`` header).  Setting on such a container
-        raises [`TOMLError`][tomlrt.TOMLError]; raises on inline
-        tables.
+        Containers without a header line (the document root, or implicit
+        sections opened only by a nested ``[a.b]`` header) read as
+        ``None``. Setting on such a container raises
+        [`TOMLError`][tomlrt.TOMLError]; inline tables also raise.
         """
         return _header_comment_get(self)
 
@@ -220,11 +211,10 @@ class Container(dict[str, Any]):
     def header_leading_comments(self) -> tuple[str, ...]:
         """The attached comment block immediately above this container's header.
 
-        Returns ``()`` for containers that have no header line
-        (the document root, implicit sections opened only by a
-        nested ``[a.b]`` header).  Setting on such a container
-        raises [`TOMLError`][tomlrt.TOMLError]; raises on inline
-        tables.
+        Containers without a header line (the document root, or implicit
+        sections opened only by a nested ``[a.b]`` header) read as ``()``.
+        Setting on such a container raises [`TOMLError`][tomlrt.TOMLError];
+        inline tables also raise.
 
         Excludes any above-blank groups — those are visible via
         [`header_leading_block`][tomlrt.Table.header_leading_block].
@@ -244,16 +234,11 @@ class Container(dict[str, Any]):
         """The full leading-trivia block above this container's header.
 
         A ``tuple[str | None, ...]`` of comment strings interleaved with
-        ``None`` (one per blank line), in source order.  Full-fidelity
-        peer of
-        [`header_leading_comments`][tomlrt.Table.header_leading_comments],
-        which exposes only the trailing attached run.
-
-        Returns ``()`` for containers that have no header line
-        (the document root, implicit sections opened only by a
-        nested ``[a.b]`` header).  Setting on such a container
-        raises [`TOMLError`][tomlrt.TOMLError]; raises on inline
-        tables.
+        ``None`` (one per blank line), in source order. Containers without
+        a header line (the document root, or implicit sections opened only
+        by a nested ``[a.b]`` header) read as ``()``. Setting on such a
+        container raises [`TOMLError`][tomlrt.TOMLError]; inline tables
+        also raise.
 
         For the first section in a document,
         [`Document.preamble`][tomlrt.Document.preamble] is disjoint from
@@ -279,29 +264,23 @@ class Container(dict[str, Any]):
     def format(self, *, comments: bool = True) -> None:
         """Canonicalise this container's formatting in place.
 
-        Rewrites whitespace, indentation, separators, and newlines to a
-        canonical layout for every slot in this container's subtree:
+        Rewrites this subtree to the canonical layout:
 
         * Keys, ``=`` spacing, and header brackets use canonical
           whitespace.
-        * Blank lines between sibling key/value slots collapse to none;
-          structural section / array-of-tables headers are preceded by
-          exactly one blank line.
+        * Sibling key/value slots have no blank line between them;
+          section / array-of-tables headers get one.
         * Orphan comment blocks above slots are preserved verbatim.
-        * Inline arrays and inline tables are reformatted in place
-          while preserving their overall shape (single-line stays
-          single-line, multi-line stays multi-line).
-        * All newline characters are retargeted to the owning
-          document's newline style.
+        * Inline values keep their shape (single-line stays single-line,
+          multi-line stays multi-line).
+        * Newlines use the owning document's style.
 
-        When ``comments`` is true (the default), comment text is also
-        normalised: ``#foo`` and ``#   foo`` both become ``# foo``, and
-        trailing whitespace inside comments is stripped.
+        With ``comments=True``, ``#foo`` and ``#   foo`` both become
+        ``# foo`` and trailing comment whitespace is stripped.
 
         Detached factory-style containers (``Table.section()`` /
-        ``Table.inline()`` not yet assigned anywhere) and inline
-        dotted-navigator views are not supported; calling
-        ``format()`` on one raises `TOMLError`.
+        ``Table.inline()`` not yet assigned anywhere) and inline dotted
+        navigators are unsupported and raise `TOMLError`.
         """
         kind = self._kind
         nl = self._doc_newline
@@ -339,10 +318,8 @@ class Container(dict[str, Any]):
             )
             return
 
-        # IMPLICIT_SECTION: slots are not contiguous in the doc stream,
-        # so we cannot do a subtree walk with inter-slot blank-line
-        # collapse.  Just canonicalise each owned slot's content and
-        # recurse into nested views via dict storage.
+        # IMPLICIT_SECTION slots are not contiguous, so canonicalise each
+        # owned slot and recurse through dict storage.
         if not self._attached:
             msg = "format() requires the container to be attached to a Document"
             raise TOMLError(msg)
@@ -364,11 +341,9 @@ class Container(dict[str, Any]):
     def _attached(self) -> bool:
         """True iff this container is attached to a live document root.
 
-        A container is "attached" when its layout root is a real,
-        user-visible document — not ``None`` (factory mode) and not a
-        private orphan root used to hold a recently-displaced subtree.
-        Mirrors :attr:`Array._attached` so cross-document live-attach
-        dispatch can read one predicate over both view kinds.
+        Attached means the layout root is a user-visible document: not
+        ``None`` (factory mode) and not a private orphan root. Mirrors
+        :attr:`Array._attached` for cross-document live-attach dispatch.
         """
         lr = self._layout_root
         return lr is not None and not lr._is_private  # noqa: SLF001
@@ -377,13 +352,9 @@ class Container(dict[str, Any]):
     def _attached_doc(self) -> Document:
         """The owning ``Document``, asserting the container is attached.
 
-        Most ``_layout_ops`` mutation primitives only run when the
-        target container is already wired into a document — they
-        operate on the doc-stream linked list, allocate slots, etc.
-        Reading ``_layout_root`` directly returns ``Document | None``;
-        this accessor narrows the type (and asserts in debug builds)
-        so call sites don't all need ``layout_root = c._layout_root;
-        assert layout_root is not None; doc = layout_root``.
+        Most ``_layout_ops`` primitives require an attached target
+        because they mutate the doc-stream linked list. This accessor
+        narrows ``_layout_root`` from ``Document | None``.
         """
         lr = self._layout_root
         assert lr is not None, "container is not attached to a document"
@@ -508,26 +479,20 @@ class Container(dict[str, Any]):
 
     @override
     def __setitem__(self, key: str, value: Any) -> None:
-        # Reject non-str keys explicitly: TOML keys are strings, and
-        # without this guard a mistyped key (e.g. ``obj[a, b] = v``,
-        # which is Python sugar for a tuple key) propagates deep into
-        # the layout pipeline before crashing in ``make_keypart``
-        # with an opaque TypeError.
+        # Reject non-str keys before they reach the layout pipeline and
+        # fail later with an opaque TypeError.
         _validate_key(key)
         if key in self and self[key] is value:
             return
-        # Reject types we explicitly do not coerce (clear error rather
-        # than a confusing NIE later in the dispatch).
+        # Reject types we explicitly do not coerce.
         if isinstance(value, tuple):
             msg = f"cannot assign tuple to TOML key {key!r}; use a list"
             raise TypeError(msg)
         if isinstance(value, (bytes, bytearray)):
             msg = f"cannot assign bytes to TOML key {key!r}; use a string"
             raise TypeError(msg)
-        # Inline tables can't host sections / AoTs as values; check
-        # eagerly so the error fires at the actual point of mistake
-        # rather than deferring to the synth-path at attach time. Runs
-        # for both attached and detached inline factories.
+        # Inline tables cannot host section-shaped values; fail at the
+        # assignment site, for both attached and detached factories.
         if self._inline:
             if isinstance(value, AoT):
                 msg = "Cannot store an array-of-tables inside an inline table"
@@ -535,7 +500,7 @@ class Container(dict[str, Any]):
             if _is_section(value):
                 msg = "Cannot store a section-style table inside an inline-style table"
                 raise TOMLError(msg)
-        # Unattached factory mode: dict-only storage, transplant on attach.
+        # Unattached factory mode: dict-only storage until attach.
         if self._layout_root is None:
             dict.__setitem__(self, key, value)
             return
@@ -550,12 +515,9 @@ class Container(dict[str, Any]):
     def _overwrite_existing(self, key: str, value: Any) -> None:
         """Replace the value at an already-bound key.
 
-        Tries cheap in-place strategies first (scalar swap, single-slot
-        typed replace) and falls through to the structural-overwrite
-        delete + reinsert + move-to-anchor path when the new value is
-        a different flavour — or the same flavour but section-shaped
-        (where in-place mutation would lose Python identity semantics
-        for the new view).
+        Uses in-place swaps when the existing binding is a single KV.
+        Structural values take the delete + reinsert + move-to-anchor
+        path so the new view's Python identity becomes the live one.
         """
         current = dict.__getitem__(self, key)
         # Fast-path: pure scalar → scalar (cheap, no synth alloc).
@@ -572,16 +534,8 @@ class Container(dict[str, Any]):
         ) and (is_scalar(value) or _is_synth_inline(value)):
             self._inline_typed_replace(key, value)
             return
-        # Structural overwrite: capture position + leading of the
-        # existing primary, delete the binding (which detaches the old
-        # view into a PrivateRoot), then re-enter __setitem__ at the
-        # new-key path. After the new value is installed (at end-of-doc
-        # by default), move its slot block back to the captured
-        # position with the saved leading.
-        #
-        # Same-flavour structural (header-bearing section ← Mapping,
-        # AoT ← AoT/list) also falls through here so the old view's
-        # user references stop reaching the live doc.
+        # Structural overwrite keeps the doc-stream anchor but detaches
+        # old user references from the live doc.
         if (
             is_scalar(value)
             or _is_synth_inline(value)
@@ -625,8 +579,7 @@ class Container(dict[str, Any]):
         if _is_section(value):
             self._attach_section(key, value)
             return
-        # Reach here only for unsupported types (tuple, bytes, set, …):
-        # raise the canonical TypeError with the type name.
+        # Unsupported types get the canonical TypeError.
         msg = f"Cannot convert {type(value).__name__} to a TOML value"
         raise TypeError(msg)
 
@@ -635,27 +588,20 @@ class Container(dict[str, Any]):
 
         Live-attached sources or private orphans with intact entry
         slots route through :func:`clone_aot` to preserve per-entry
-        trivia + nested sub-sections (the ``to_list()`` snapshot path
-        drops both). Detached AoTs without preserved slots are
-        rehomed entry-by-entry.
+        trivia and nested sub-sections. Detached AoTs without preserved
+        slots are rehomed entry-by-entry.
         """
-        # If `value` is attached to a live doc, route through clone_aot
-        # to preserve per-entry trivia + nested sub-sections.
         src_root = value._layout_root  # noqa: SLF001
         if src_root is not None and not src_root._is_private:  # noqa: SLF001
             if key in self:
                 _layout_ops.delete_key(self, key)
             _layout_ops.clone_aot(self, key, value)
             return
-        # Snapshot existing entry tables. If their `_owner_aot_entry`
-        # records still hold intact `entry_slots` (e.g. the user just
-        # deleted the old binding via the structural-overwrite
-        # `del+set` path, which preserves slots into a private orphan),
-        # capture them so we can deep-clone the CST into the rehomed
-        # AoT — preserving per-KV trivia, nested sub-section slots,
-        # and inter-entry separator style. The generic
-        # `add_aot_entry(rehome=)` path is lossy: it rebuilds slots
-        # from dict storage and drops all of that.
+        # Private orphans may still own intact entry_slots from a
+        # structural-overwrite detach; clone those to keep per-KV
+        # trivia, nested sub-sections, and inter-entry separators.
+        # The generic add_aot_entry(rehome=) path rebuilds from dict
+        # storage and drops that CST.
         existing_entries: list[Table] = list(value)
         preserved_entries: list[AoTEntry | None] = [
             et._owner_aot_entry  # noqa: SLF001
@@ -676,10 +622,8 @@ class Container(dict[str, Any]):
         attached = _layout_ops.attach_empty_aot(self, key, value)
         dict.__setitem__(self, key, attached)
         if can_clone:
-            # Deep-clone CST from intact orphan slots. Sacrifices
-            # per-entry-table Python identity (the rehomed AoT
-            # holds fresh entry tables) in exchange for trivia
-            # preservation. AoT object identity is still preserved.
+            # Clone CST from intact orphan slots. Entry-table identities
+            # are replaced; the AoT object's identity is preserved.
             for src_entry in preserved_entries:
                 assert src_entry is not None
                 _layout_ops.clone_aot_entry(
@@ -692,15 +636,11 @@ class Container(dict[str, Any]):
     def _attach_section(self, key: str, value: Container) -> None:
         """Install ``value`` (a section-flavoured Table) under ``key``.
 
-        Routing:
-          * AoT-entry source → entry-cloner with ``head_kind="table"``
-            so trivia survives and the head normalises from ``[[..]]``
-            to ``[..]``.
-          * Cross-doc / same-doc attached header-bearing source →
-            deep-clone slots via ``clone_section_as_section``.
-          * Implicit attached source → recursive walk via
-            ``_install_attached_subtree``.
-          * Detached / private source → rehome in place.
+        AoT-entry sources clone as a table so trivia survives and the
+        head normalises from ``[[..]]`` to ``[..]``. Attached
+        header-bearing sections clone slots; attached implicit sources
+        recurse via ``_install_attached_subtree``; detached/private
+        sources rehome in place.
         """
         src_root = value._layout_root
         live_source = src_root is not None and not src_root._is_private  # noqa: SLF001
@@ -712,11 +652,8 @@ class Container(dict[str, Any]):
             elif value._header_ref is not None:
                 _layout_ops.clone_section_as_section(self, key, value)
             else:
-                # Implicit source / whole-Document: walk recursively
-                # and re-install each structural child via tuple-path
-                # ``install``, preserving sections / AoTs as such (no
-                # flatten-to-inline) and keeping implicit chains
-                # implicit when there are no direct KVs to host.
+                # Implicit source / whole Document: tuple-path install
+                # preserves structural children and implicit chains.
                 _install_attached_subtree(self, (key,), value)
             return
         if src_root is not None and src_root._is_private:  # noqa: SLF001
@@ -844,23 +781,20 @@ class Container(dict[str, Any]):
     ) -> None:
         """Sort direct child keys in place, preserving per-key trivia.
 
-        Mirrors ``list.sort``: keyword-only ``key`` / ``reverse``, stable,
-        in-place. The sort is **TOML-aware**: structural keys (children
-        bound to an ``AoT`` or to a section ``Table``, i.e. one rendered
-        with a ``[header]``) are always placed after bare keys, since a
-        bare key that followed a section header would re-bind as nested
-        under it. ``key`` and ``reverse`` apply *within* the bare-key and
-        section partitions; they never interleave the two. Implicit
-        sections built from dotted keys (e.g. ``a.x = 1``) are physically
-        bare-key slots and sort as bare keys.
+        Mirrors ``list.sort``: keyword-only ``key`` / ``reverse``,
+        stable, in-place. Structural keys (children bound to an ``AoT``
+        or to a section ``Table``, i.e. one rendered with a ``[header]``)
+        are always placed after bare keys; otherwise a bare key after a
+        section header would re-bind under it. ``key`` and ``reverse``
+        apply within, never across, the partitions. Implicit sections
+        built from dotted keys (e.g. ``a.x = 1``) sort as bare keys.
 
         Inline containers have no structural children, so the partition
-        is a no-op there and ``key`` / ``reverse`` behave as on a plain
-        dict.
+        is a no-op and ``key`` / ``reverse`` behave as on a plain dict.
 
         See [`has_header`][tomlrt.Table.has_header] for the predicate
-        that defines the partition; a custom ``key`` function can call
-        it to decide which side of the split a given child sits on.
+        that defines the partition; a custom ``key`` function can call it
+        to decide which side of the split a given child sits on.
         """
         current = list(dict.keys(self))
         if len(current) <= 1:
@@ -868,12 +802,9 @@ class Container(dict[str, Any]):
         if self._inline:
             new_order = sorted(current, key=key, reverse=reverse)
         else:
-            # A key's *leaf* content (a bare or dotted ``key = value``)
-            # must precede every section header, so partition into three
-            # groups — pure leaves, "mixed" keys that own both a leaf and
-            # a sub-section, and pure sections — and keep the mixed group
-            # between them: its leaf part stays ahead of all sections,
-            # and its own header stays ahead of the pure sections.
+            # A key's leaf content must precede every section header.
+            # Keep mixed keys between pure leaves and pure sections so
+            # their leaf part stays ahead of all sections.
             pure_leaves = [
                 k for k in current if self._has_leaf(k) and not self.has_header(k)
             ]
@@ -896,10 +827,9 @@ class Container(dict[str, Any]):
         Returns ``True`` when this container's block for ``key`` contains
         a structural header slot — i.e. a ``[header]`` section or a
         ``[[header]]`` array-of-tables entry. Returns ``False`` for bare
-        ``key = value`` leaves, inline tables, and implicit sections
-        built entirely from dotted keys (e.g. ``a.x = 1``, where ``a``
-        has no header line of its own). Returns ``False`` for keys not
-        present.
+        ``key = value`` leaves, inline tables, implicit sections built
+        entirely from dotted keys (e.g. ``a.x = 1``, where ``a`` has no
+        header line of its own), and missing keys.
         """
         refs = self._index.get(key, ())
         return any(isinstance(r.slot, StructuralHeaderSlot) for r in refs)
@@ -907,9 +837,8 @@ class Container(dict[str, Any]):
     def _has_leaf(self, key: str) -> bool:
         """Whether ``key``'s block contains a leaf ``key = value`` slot.
 
-        True for a bare or dotted KV (``k = 1`` / ``k.x = 1``); a key can
-        have *both* a leaf and a sub-section header (``z.k = 1`` plus
-        ``[z.m]``), in which case both this and `has_header` return True.
+        A key can have both a leaf and a sub-section header, in which
+        case both this and `has_header` return True.
         """
         refs = self._index.get(key, ())
         return any(isinstance(r.slot, KVSlot) for r in refs)
@@ -939,9 +868,7 @@ class Container(dict[str, Any]):
     def _inline_setitem(self, key: str, value: Any) -> None:
         # ``__setitem__`` has already rejected ``AoT`` / section values
         # for inline hosts. Non-coerceable types (``set``, custom
-        # classes, …) reach ``_synth_value``, which raises the canonical
-        # ``TypeError: Cannot convert ... to a TOML value`` — same
-        # message the regular-table path produces.
+        # classes, …) reach ``_synth_value`` for the canonical TypeError.
         if is_scalar(value):
             cst: Value = coerce_scalar(value)
             decoded: object = value
@@ -954,13 +881,8 @@ class Container(dict[str, Any]):
                 owner=self._owner_aot_entry,
             )
         if key in self and isinstance(dict.__getitem__(self, key), Container):
-            # Overwriting a dotted-prefix sub-table (e.g. `server` in
-            # `{server.host = "x", server.port = 80}`) with a scalar /
-            # inline value: drop every `server.*` entry and add a fresh
-            # single-keypart `server` entry. Stay on the CST side and
-            # overwrite the dict entry in place below — a dict-level
-            # ``del self[key]`` would momentarily empty this navigator
-            # and prune it (and its ancestors) from the parent chain.
+            # Stay on the CST side when replacing a dotted-prefix
+            # navigator; dict-level delete would prune the parent chain.
             _inline_ops.overwrite_entry(self, key, cst)
         elif key in self:
             ok = _inline_ops.replace_entry_value(self, key, cst)
@@ -985,10 +907,8 @@ class Container(dict[str, Any]):
             )
             raise AssertionError(msg)
         dict.__delitem__(self, key)
-        # Clean up: a synthetic dotted-prefix sub-table that is now
-        # empty has no representation in the backing
-        # `InlineTableValue` either, so drop it from the parent's
-        # dict view as well — and propagate up the chain.
+        # Empty dotted-prefix navigators have no backing CST entry; prune
+        # them from the dict chain too.
         cur: Container | None = self
         while (
             cur is not None
@@ -1013,10 +933,8 @@ class Container(dict[str, Any]):
         if self._inline and len(parts) > 1:
             msg = "cannot install dotted path into an inline-style table"
             raise TOMLError(msg)
-        # If the value is a section-flavoured Table or an AoT, route
-        # straight to the multi-component attach path so intermediate
-        # path components stay implicit (no [tool] header for
-        # `install("tool.poetry", Table.section())`).
+        # Section / AoT values need the multi-component attach path so
+        # intermediate components stay implicit.
         is_section = isinstance(value, Table) and not value._inline  # noqa: SLF001
         is_aot = isinstance(value, AoT)
         if (is_section or is_aot) and len(parts) > 1 and self._layout_root is not None:
@@ -1039,10 +957,8 @@ class Container(dict[str, Any]):
                     break
                 cur = nxt
                 i += 1
-            # If we stopped at an inline-table prefix containing the
-            # remaining tail, drop the conflicting tail key from the
-            # inline so attach_section_at can install the section
-            # without leaving a stale `name = "x"` shadow.
+            # Drop conflicting inline-tail keys before installing the
+            # section, or a stale inline value would shadow it.
             if (
                 i < len(parts) - 1
                 and parts[i] in cur
@@ -1050,28 +966,18 @@ class Container(dict[str, Any]):
                 and dict.__getitem__(cur, parts[i])._inline  # noqa: SLF001
             ):
                 inline_holder: Container = dict.__getitem__(cur, parts[i])
-                # Walk inline entries looking for the next path
-                # component(s); delete each in order.
+                # Delete the next inline path component in order.
                 tail = parts[i + 1 :]
                 if tail and tail[0] in inline_holder:
                     del inline_holder[tail[0]]
                     if len(inline_holder) == 0:
                         _layout_ops.delete_key(cur, parts[i])
-            # Overwrite-existing path: leaf already present, fall through
-            # to direct __setitem__ on the deepest existing container.
+            # Leaf already present: use normal overwrite dispatch.
             if i == len(parts) - 1:
                 cur[parts[-1]] = value
                 return cur[parts[-1]]
-            # Build the implicit-table intermediates, then dispatch the
-            # final binding via __setitem__ so it flows through the
-            # standard Container dispatchers (_install_section /
-            # _attach_aot). Those already pick the right path for
-            # every source state — attached header-bearing sections
-            # clone via clone_section_as_section, attached implicit
-            # sources recurse via _install_attached_subtree, attached
-            # AoTs clone via clone_aot, detached / private values
-            # synthesise — so we don't need to second-guess the
-            # source state here.
+            # Then use normal Container dispatch; it already handles
+            # attached, detached, section, and AoT source states.
             anchor = _layout_ops.ensure_implicit_chain(cur, tuple(parts[i:-1]))
             anchor[parts[-1]] = value
             return anchor[parts[-1]]
@@ -1160,8 +1066,7 @@ class Container(dict[str, Any]):
                 f"comments that would be lost"
             )
             raise TOMLError(msg)
-        # Capture leading + eol from the existing KV slot so we can
-        # transfer them onto the new section header.
+        # Transfer the existing KV slot's leading + eol to the header.
         old_slot = _direct_kv_slot(self, key)
         saved_leading = old_slot.leading if old_slot is not None else None
         saved_eol = old_slot.eol if old_slot is not None else None
@@ -1176,10 +1081,8 @@ class Container(dict[str, Any]):
                 new_header.leading = saved_leading
             if saved_eol is not None:
                 new_header.eol = saved_eol
-            # Seam: ensure a blank line separates the parent's direct
-            # entries from the promoted child header. promote_inline
-            # turns a KV (originally inline, no separator) into a
-            # section header (deserves visual separation).
+            # A promoted KV becomes a section header and needs a visual
+            # separator from the parent's direct entries.
             if (
                 self._body_tail is not None
                 and new_header._prev is self._body_tail  # noqa: SLF001
@@ -1228,9 +1131,7 @@ class Container(dict[str, Any]):
                     )
                     raise TOMLError(msg)
         snapshot = cur.to_list()
-        # Capture the original KV slot's leading + eol so we can carry
-        # them onto the first new ``[[..]]`` header and the last
-        # entry's tail.
+        # Carry the original KV slot's leading/eol onto the promoted AoT.
         old_slot = _direct_kv_slot(self, key)
         saved_leading = old_slot.leading if old_slot is not None else None
         saved_eol = old_slot.eol if old_slot is not None else None
@@ -1238,17 +1139,15 @@ class Container(dict[str, Any]):
         self[key] = AoT(snapshot)
         result = dict.__getitem__(self, key)
         assert isinstance(result, AoT)
-        # Apply saved leading to the first entry's header; saved eol
-        # to the last entry's last slot.
+        # Apply saved leading to the first entry header and saved eol to
+        # the last entry's last slot.
         if saved_leading is not None and len(result) > 0:
             first_entry = result[0]
             entry_record = first_entry._owner_aot_entry  # noqa: SLF001
             if entry_record is not None and entry_record.entry_slots:
                 first_slot = entry_record.entry_slots[0]
                 if isinstance(first_slot, StructuralHeaderSlot):
-                    # Prepend saved leading pieces in front of any
-                    # leading already on the header (e.g. blank-line
-                    # separator from `_build_section_leading`).
+                    # Preserve any separator already placed on the header.
                     first_slot.leading.pieces = [
                         *saved_leading.pieces,
                         *first_slot.leading.pieces,
@@ -1318,7 +1217,7 @@ class Table(Container):
     def section(cls, mapping: Mapping[str, TomlInput] | None = None) -> Table:
         """Return a standard-section table, optionally populated from ``mapping``.
 
-        Use from an assignment site to install a ``[k]`` block:
+        Assign the result to install a ``[k]`` block:
 
             doc[k] = Table.section({"x": 1})
         """
@@ -1332,7 +1231,7 @@ class Table(Container):
     def inline(cls, mapping: Mapping[str, TomlInput] | None = None) -> Table:
         """Return an inline table, optionally populated from ``mapping``.
 
-        Use from an assignment site to install a ``{x = 1}`` value:
+        Assign the result to install a ``{x = 1}`` value:
 
             doc[k] = Table.inline({"x": 1})
         """
@@ -1348,9 +1247,8 @@ class Document(Container):
     """Top-level TOML document.
 
     A [`Document`][tomlrt.Document] is the root of a parsed TOML
-    file. It is a `dict` subclass, so ``isinstance(doc, dict)``
-    holds and it can be passed wherever a `dict` or `Mapping` is
-    expected.
+    file. It is a `dict` subclass and can be passed wherever a
+    `dict` or `Mapping` is expected.
     """
 
     __slots__ = (
@@ -1368,7 +1266,7 @@ class Document(Container):
     def __init__(self, data: Mapping[str, Any] | None = None) -> None:
         """Return a fresh empty document, optionally populated from ``data``.
 
-        With a mapping, recursively populates the document so that:
+        With a mapping:
 
         * nested mappings become standard ``[section]`` blocks (not
           inline tables);
@@ -1414,23 +1312,21 @@ class Document(Container):
         """Comment block at the top of the document.
 
         A "preamble" is the run of ``# …`` lines that opens the file
-        and is blank-line-separated from anything below. Comments that
-        sit directly above the first key (no blank line) are *not*
-        preamble — they are the leading comments of that key, accessed
-        via `leading_comments`. In a document with no structural
-        content, the entire opening comment block is treated as
-        preamble.
+        and is blank-line-separated from anything below. Comments
+        directly above the first key (no blank line) are that key's
+        `leading_comments`. With no structural content, the opening
+        comment block is preamble.
 
         Setter accepts a sequence of bare comment texts (without the
         leading ``#``) and replaces the current preamble; assign ``()``
         to remove. Newlines inside any line are rejected.
 
-        On a document whose first slot is a section header or bare key, the
+        When the first slot is a section header or bare key, the
         preamble is stored as the above-blank prefix of that slot's
         leading trivia — the same storage that
         [`Table.header_leading_block`][tomlrt.Table.header_leading_block] /
         [`Document.leading_block`][tomlrt.Document.leading_block] expose
-        for the first slot.  Writes through either path are visible
+        for the first slot. Writes through either path are visible
         through the other.
         """
         return _doc_preamble_get(self)
@@ -1448,8 +1344,8 @@ class Document(Container):
         """Comment block at the very end of the document.
 
         Returns the trailing run of ``# …`` lines that follows all
-        structural content. Empty when the document has no structural
-        content (in that case everything is `preamble`).
+        structural content; with no structural content everything is
+        `preamble`.
 
         Setter accepts a sequence of bare comment texts and replaces
         the current epilogue. Assign ``()`` to remove.
@@ -1515,13 +1411,10 @@ def _deep_clone(c: Container) -> Container:
     """Build a detached deep clone of ``c`` as a lossy snapshot.
 
     The clone preserves the source's inline vs section shape (so a
-    deepcopy of an inline table returns an inline view), and recurses
-    into nested ``Container`` and ``AoT`` values so their shape is
-    preserved too. Render-level formatting (trivia, comments,
-    per-item layout) is not preserved — the result is a dict-style
-    snapshot, and a fresh CST is built on re-installation. For
-    byte-exact preservation of an entire document, use ``Document``'s
-    own ``__deepcopy__`` (which round-trips via ``loads(render())``).
+    deepcopy of an inline table returns an inline view) and recurses
+    into nested ``Container`` / ``AoT`` values. Render-level formatting
+    is not preserved; for byte-exact preservation of an entire document,
+    use ``Document``'s ``__deepcopy__``.
     """
     out = Table.inline() if c._inline else Table.section()  # noqa: SLF001
     for k, v in c.items():
@@ -1542,14 +1435,10 @@ def _reset_table_for_rehome(t: Container, *, recurse: bool = False) -> None:
     / `_refs` / `_index` / `_header_ref` / `_body_tail` so the
     standard attach path treats `t` as if freshly constructed.
 
-    With ``recurse=True``, walks dict values and resets nested
-    non-inline ``Container`` / ``AoT`` children whose
-    ``_layout_root`` matches the root's previous layout root (i.e.
-    they belong to the same detached subtree). Children pointing
-    at a different doc are left alone — they're an "alien" live
-    view that the standard cross-doc clone path will handle.
-    Recursion is opt-in because most rehome callers operate on a
-    single freshly-detached Table and don't pay the subtree walk.
+    With ``recurse=True``, also resets nested non-inline ``Container`` /
+    ``AoT`` children from the same detached subtree. Children pointing
+    at a different doc are left for the cross-doc clone path. Recursion
+    is opt-in so single-table rehomes avoid a subtree walk.
 
     Used when re-installing a held view that was detached into a
     private orphan ``Document``.
@@ -1606,19 +1495,15 @@ def _install_attached_subtree(
 ) -> None:
     """Recursively install an attached implicit / Document source.
 
-    Walks ``src_table.items()`` and re-installs each entry under
-    ``dst_parent``. Section / AoT children clone via tuple-path
-    :meth:`Container.install` (so attached sections preserve their
-    headers and AoTs clone slot-for-slot). Direct (non-structural)
-    entries at this implicit level are written as dotted KVs hosted
-    by ``dst_parent``'s nearest header-bearing ancestor, so the
-    source's dotted form is preserved on per-key clone.
+    Section / AoT children clone via tuple-path :meth:`Container.install`
+    so headers and slots survive. Direct entries at this implicit level
+    are written as dotted KVs hosted by ``dst_parent``'s nearest
+    header-bearing ancestor, preserving dotted form per key.
 
     Note: bucketing into directs vs structurals can reorder relative
     to ``src_table.items()`` — at a given implicit level all dotted
-    leaves emit before any subsection. TOML is structurally
-    insensitive to that order; the dotted-form preservation is the
-    win.
+    leaves emit before any subsection. TOML is insensitive to that
+    order; the dotted-form preservation is the win.
     """
     direct_kvs: list[tuple[str, object]] = []
     structural: list[tuple[str, object]] = []
@@ -1650,9 +1535,8 @@ def _install_dotted_direct_kvs(
 
     ``host`` is the nearest header-bearing ancestor at-or-above
     ``dst_parent`` (or the doc / AoT-entry root). Creates implicit
-    intermediates between host and the leaf as needed. Each value is
-    deep-cloned via ``_to_python`` + ``_synth_value`` so the source's
-    CST is not disturbed.
+    intermediates as needed. Values are deep-cloned through
+    ``_to_python`` + ``_synth_value`` so the source CST is not disturbed.
     """
     host: Container = dst_parent
     while host._header_ref is None and host._parent is not None:  # noqa: SLF001
@@ -1749,10 +1633,11 @@ TomlInput: TypeAlias = (
     | Mapping[str, Any]
     | list[Any]
 )
-"""What you can pass *in* to mutators and factories: any
-[`Table`][tomlrt.Table], [`Array`][tomlrt.Array], or
+"""Values accepted by mutators and factories.
+
+Includes [`Table`][tomlrt.Table], [`Array`][tomlrt.Array],
 [`AoT`][tomlrt.AoT], any TOML scalar (`str`, `int`, `float`, `bool`,
-`datetime`, `date`, `time`), or any plain `Mapping[str, Any]` /
+`datetime`, `date`, `time`), and plain `Mapping[str, Any]` /
 `list[Any]`.
 
 The nested `list` / `Mapping` arms intentionally use `Any` for
@@ -1772,10 +1657,8 @@ def _is_synth_inline(v: object) -> bool:
     """True iff ``v`` is a value we can synthesise to an inline TOML value.
 
     Accepts:
-    - any ``Mapping`` (dict, MappingProxyType, …) — including our own
-      inline ``Container`` views (deep-copy semantics)
-    - ``list`` — including our own ``Array`` views (deep-copy semantics)
-    - inline ``Container`` and ``Array`` views from another document
+    - any ``Mapping`` or inline ``Container`` view (deep-copy semantics)
+    - ``list`` or ``Array`` views (deep-copy semantics)
 
     Rejects everything else (tuple, bytes, sets, AoT, section
     Container, …) so the caller can route to a stronger error.
@@ -1805,16 +1688,11 @@ def _synth_value(
 ) -> tuple[Value, object]:
     """Synthesise a (CST value, decoded view) pair from ``v``.
 
-    The CST value goes into the host slot's ``value`` field; the
-    decoded view is what gets stored in the parent dict (and is the
-    object the user retrieves via ``[]``).
-
     Plain ``dict`` / ``Mapping`` → ``InlineTableValue`` + inline ``Table``.
     ``list`` / ``Array`` view → ``ArrayValue`` + ``Array``.
     Section ``Container`` / ``AoT`` raise ``TOMLError`` — those can't
-    live as inline values.
-    Anything else raises ``TypeError`` (mentioning the type name and
-    the prefix ``"Cannot convert"``).
+    live as inline values. Anything else raises the canonical
+    ``TypeError``.
     """
     if is_scalar(v):
         return coerce_scalar(v), v
@@ -1824,12 +1702,8 @@ def _synth_value(
     if _is_section(v):
         msg = "Cannot store a section-style table inside an inline-style table"
         raise TOMLError(msg)
-    # Unattached inline Container or Array — live-attach: rehome the
-    # existing object (so the user's reference stays the document's
-    # view) instead of synthesising a fresh one. Inline tables that
-    # were previously attached and then displaced into a private root
-    # need a small reset before the inline-attach path treats them
-    # as freshly-constructed; arrays carry no such heavy state.
+    # Live-attach unattached inline values so user identity is preserved.
+    # Displaced inline tables need a reset before reattach; arrays do not.
     if (_is_inline_table(v) or isinstance(v, Array)) and not v._attached:  # noqa: SLF001
         if isinstance(v, Array):
             _retarget_to_doc(v._value, layout_root)  # noqa: SLF001
@@ -1845,10 +1719,8 @@ def _synth_value(
             path=path,
             owner=owner,
         )
-    # Cross-document (or same-doc live) inline value — deep-clone the
-    # CST so the destination preserves the source's formatting rather
-    # than being re-synthesised. Plain Mapping / list inputs have no
-    # CST to clone and fall through to the synth paths below.
+    # Cross-document / same-doc live inline values clone CST so source
+    # formatting survives. Plain Mapping / list inputs have no CST.
     if _is_inline_table(v) or isinstance(v, Array):
         from tomlrt._build import _decode_value  # noqa: PLC0415
 
@@ -1881,11 +1753,9 @@ def _retarget_to_doc(val: Value, layout_root: Document | None) -> None:
     r"""Retarget ``val``'s baked-in newlines to ``layout_root``'s line ending.
 
     Called whenever pre-existing inline CST is dragged into a
-    destination doc — both the deep-clone path (cross-document graft
-    of an attached value) and the live-attach path for an unattached
-    ``Array(multiline=True)`` factory whose constructor hard-codes
-    ``\n``. Without this the destination dump ends up with mixed
-    ``\n`` / ``\r\n`` newlines.
+    destination doc. Without this, cross-document grafts and unattached
+    ``Array(multiline=True)`` factories can dump mixed ``\n`` /
+    ``\r\n`` newlines.
     """
     if layout_root is not None:
         retarget_value_newlines(val, layout_root._newline)  # noqa: SLF001
@@ -1923,11 +1793,9 @@ def _populate_inline_table(
 ) -> tuple[InlineTableValue, Container]:
     """Wire ``table`` as an inline view and populate its entries.
 
-    Two callers: the live-attach path (passes a user-supplied
-    ``Table.inline()`` so identity is preserved) and the plain-Mapping
-    synth path (passes a fresh ``Table()``). Each entry is laid out as
-    ``" k = v"`` with comma-then-space separators except after the
-    last entry, and a single trailing space when non-empty.
+    The live-attach path passes a user-supplied ``Table.inline()`` so
+    identity is preserved; the plain-Mapping synth path passes a fresh
+    ``Table()``. Entries use canonical single-line spacing.
     """
     val = InlineTableValue()
     table._wire(  # noqa: SLF001

--- a/src/tomlrt/_format.py
+++ b/src/tomlrt/_format.py
@@ -1,9 +1,8 @@
-"""Container / Array formatter — canonicalise layout without losing comments.
+"""Canonicalise Container / Array layout without losing comments.
 
-Pure functions over slots / trivia / values. Idempotent and
-shape-preserving for inline values (single-line stays single-line;
-multi-line stays multi-line). Used by the public
-``Container.format`` / ``Array.format`` methods.
+Pure, idempotent slot/trivia/value helpers for ``Container.format`` and
+``Array.format``. Inline values are shape-preserving: single-line stays
+single-line; multi-line stays multi-line.
 
 Canonical layout enforced here:
 
@@ -80,9 +79,8 @@ if TYPE_CHECKING:
 def _canon_comment_text(text: str) -> str:
     """Rewrite a comment lexeme to canonical ``# body`` / ``#`` form.
 
-    Input always starts with ``#``.  Normalises any leading whitespace
-    inside the body to exactly one space; strips trailing whitespace.
-    An empty-body comment collapses to a bare ``#``.
+    Input starts with ``#``; leading body whitespace collapses to one
+    space and trailing whitespace is stripped.
     """
     assert text.startswith("#"), text
     body = text[1:].rstrip().lstrip(" \t")
@@ -99,28 +97,17 @@ def _canon_trivia_text(
 ) -> None:
     r"""Normalise trivia content in place.
 
-    Always strips trailing whitespace on blank lines (``  \n`` →
-    ``\n``).  When ``strip_pre_comment_ws`` is true (the default),
-    also strips any whitespace that precedes a CommentNode within
-    a trivia line. If ``comment_indent`` is non-empty, restamps the
-    pre-comment whitespace to that indent string instead of stripping
-    to column 0 — used inside multi-line inline arrays / tables where
-    full-line comments sit at the array's element indent. Pass
-    ``strip_pre_comment_ws=False`` for EOL-style trivia where the
-    space between the previous token and the ``#`` is the structural
-    separator, set by the caller.
+    Strips trailing whitespace on blank lines. Full-line comments drop
+    pre-comment whitespace, or restamp to ``comment_indent`` for
+    multi-line inline element comments. Set ``strip_pre_comment_ws=False``
+    for EOL trivia, where the caller-owned separator before ``#`` must
+    survive.
 
-    When ``first_line_is_eol`` is true, the pre-first-NL run is
-    treated as an EOL context (``strip_pre_comment_ws=False``, no
-    ``comment_indent``), and only subsequent lines use the full-line
-    rules. Used for ``header_trivia`` of multi-line inline values,
-    where the opening bracket may carry a row-attached EOL comment.
-
-    When ``comments`` is true also rewrites each CommentNode's text
-    via :func:`_canon_comment_text`.
-
-    Newline text itself is untouched here; callers run
-    :func:`retarget_trivia_newlines` separately.
+    ``first_line_is_eol`` treats only the pre-first-newline run as an
+    EOL context; this covers bracket pads whose opening row stores a
+    row-attached EOL comment. When ``comments`` is true, comment text is
+    rewritten via :func:`_canon_comment_text`. Newline text is retargeted
+    by callers.
     """
     pieces = t.pieces
     new: list[TriviaPiece] = []
@@ -166,33 +153,20 @@ def _canon_leading(
 ) -> None:
     """Rewrite ``slot.leading`` to canonical form.
 
-    The leading is decomposed into three regions:
+    Splits leading trivia into head blanks, middle comment/orphan block,
+    and trailing column indent. Canonical form keeps the middle (with
+    newline/comment cleanup), drops the column indent, and applies
+    ``target_blanks`` to the head.
 
-    * ``head_blanks`` — leading whitespace-only lines (structural
-      blank gap from the previous slot)
-    * ``middle`` — everything else *except* the slot's own column
-      indent (orphan blank-separated groups + the attached comment
-      run)
-    * ``indent`` — the slot's column-indent line (trailing
-      whitespace-only piece with no terminating newline)
-
-    Canonical form: ``target_blanks`` blank lines at the head,
-    middle preserved verbatim (with newline / comment text
-    normalised), no indent at the tail.
-
-    When ``target_blanks`` is ``None`` the head-blank region is
-    preserved verbatim (used for the first slot in a document /
-    subtree, where the preceding gap is owned by something outside
-    the subtree).
+    ``target_blanks=None`` preserves preamble/subtree-boundary blanks.
+    When ``middle`` is non-empty, clamp the head gap to 0/1 so
+    comment-block separation intent survives.
     """
     lines = split_lines(list(slot.leading.pieces))
 
-    # Trailing column-indent line (no newline, no comment).
     if lines and not line_has_newline(lines[-1]) and not line_has_comment(lines[-1]):
-        # Drop it entirely — canonical layout is unindented.
         lines.pop()
 
-    # Split off the head-blank region (run of newline-only lines at the start).
     head_count = 0
     while head_count < len(lines) and not line_has_comment(lines[head_count]):
         if not line_has_newline(lines[head_count]):
@@ -200,19 +174,12 @@ def _canon_leading(
         head_count += 1
     middle = lines[head_count:]
 
-    # Normalise newline / comment / blank-line WS in the middle.
     middle_t = Trivia([p for line in middle for p in line])
     retarget_trivia_newlines(middle_t, nl)
     _canon_trivia_text(middle_t, comments=comments)
 
-    # Pick the head-blank count:
-    #
-    # * ``target_blanks is None`` — preamble / subtree boundary,
-    #   preserve the user's count verbatim.
-    # * ``middle`` non-empty — comment block carries the user's
-    #   separation intent; clamp the head blank to 0 or 1 matching
-    #   whether the source had a blank above the comment block.
-    # * otherwise — apply the structural ``target_blanks`` exactly.
+    # Preamble/subtree boundaries keep authored head gaps; attached
+    # comment blocks clamp to 0/1 so separation intent survives.
     if target_blanks is None:
         n_blanks = head_count
     elif middle:
@@ -232,11 +199,9 @@ def _canon_leading(
 def _canon_eol(eol: EolTrivia, *, nl: str, comments: bool) -> None:
     """Normalise an :class:`EolTrivia`.
 
-    * Newline retargeted to ``nl`` (preserved as ``None`` for the
-      last line of a no-final-newline file).
-    * ``trailing_ws`` → ``None`` when no comment; ``" "`` (one
-      space) before a comment.
-    * Comment text rewritten when ``comments`` is true.
+    Retargets newline to ``nl`` (leaving ``None`` for a no-final-newline
+    tail), canonicalises optional comment text, and keeps exactly one
+    separator space before comments.
     """
     retarget_eol_newline(eol, nl)
     if eol.comment is None:
@@ -295,12 +260,7 @@ def _canon_inline_value(
     comments: bool,
     parent_indent: str = "",
 ) -> None:
-    """Canonicalise the layout of an inline array or inline table.
-
-    Recurses into nested inline values, then dispatches to the
-    single-line or multi-line shape, then (for multi-line) runs a
-    final text pass over the value's trivia tree.
-    """
+    """Canonicalise inline array/table layout while preserving shape."""
     items = v.items
     multi = value_is_multiline(v)
     item_indent = parent_indent + "  " if multi else parent_indent
@@ -329,14 +289,10 @@ def _canon_multiline_shape(
 ) -> None:
     """Apply multi-line canonical shape to ``v``.
 
-    Shared backbone of the ``format()`` walk (``_canon_inline_value``)
-    and ``Array.set_multiline(multiline=True, ...)``. Canonicalises
-    per-item trivia, restamps the bracket-pad, then runs the final
-    text pass that retargets newlines and rewrites comment text.
-
-    The single-line path bypasses this entirely — its shaping
-    produces only empty / single-space trivia (no newlines, no
-    comments), so the finalise pass would be a no-op there.
+    Shared by the format walk and ``Array.set_multiline``. Canonicalises
+    per-item trivia, restamps bracket pads, then retargets newlines and
+    rewrites comment text. The single-line path bypasses this because it
+    produces only empty/single-space trivia.
     """
     items = v.items
     last_line_open = _canon_multi_line_items(items, nl=nl, indent=item_indent)
@@ -391,15 +347,10 @@ def _compose_pad(
 ) -> Trivia:
     r"""Compose a bracket-pad from (row-attached EOL, above-block, indent).
 
-    Layout: ``head_eol`` (already terminated by ``\n`` when
-    non-empty), an optional structural ``\n`` to start the fresh
-    line, the above-block, then a trailing indent (column of the
-    first item, or of the closing bracket).
-
-    Skip the structural ``\n`` when ``head_eol`` supplies one, or
-    when ``line_already_open`` says the upstream context (the
-    previous item's ``post_comma_trivia``) already terminated the
-    line.
+    Layout is ``head_eol`` (already terminated when non-empty), optional
+    structural ``\n``, above-block, then trailing indent. Skip the
+    structural newline when ``head_eol`` or upstream
+    ``post_comma_trivia`` already closed the line.
     """
     pieces: list[TriviaPiece] = list(head_eol.pieces)
     if not head_eol.pieces and not line_already_open:
@@ -413,10 +364,9 @@ def _compose_pad(
 def _inner_space(v: ArrayValue | InlineTableValue) -> Trivia:
     """Bracket-inner padding for a single-line inline value.
 
-    Inline tables wear ``{ a = 1 }`` with one space of inner
-    padding; inline arrays wear ``[a, b]`` with none.  Each call
-    produces a fresh ``Trivia`` so callers can assign it to
-    ``header_trivia`` and ``final_trivia`` independently.
+    Inline tables wear ``{ a = 1 }`` with one space; inline arrays wear
+    ``[a, b]`` with none. Each call returns fresh ``Trivia`` for
+    independent ``header_trivia`` / ``final_trivia`` assignment.
     """
     if v.items and v._single_line_pad:  # noqa: SLF001
         return Trivia([WhitespaceNode(v._single_line_pad)])  # noqa: SLF001
@@ -445,17 +395,13 @@ def _finalise_inline_trivia(
 ) -> None:
     """Retarget newlines + canonicalise comment / blank-WS text across ``v``.
 
-    Run after shape canonicalisation; touches the bracket-pad trivia
-    and every per-item trivia channel. ``item_indent`` is the column
-    at which full-line comments inside ``v`` should sit; passed by
-    multi-line callers so above-item comment blocks are indented to
-    align with the items, not stripped to column 0.
+    Runs after shape canonicalisation over bracket pads and all per-item
+    trivia. ``item_indent`` keeps full-line comments aligned with
+    multi-line items, not stripped to column 0.
 
-    ``final_first_line_is_eol`` flags the empty-value case where the
-    row-attached EOL on the opening bracket is stored in
-    ``final_trivia`` (because there is no item to delimit it from
-    the closing bracket), so its first line must be canonicalised as
-    an EOL context, not a full-line one.
+    ``final_first_line_is_eol`` covers the empty-value case where the
+    opening bracket's row-attached EOL lives in ``final_trivia`` and must
+    be treated as EOL context.
     """
     retarget_trivia_newlines(v.header_trivia, nl)
     retarget_trivia_newlines(v.final_trivia, nl)
@@ -491,30 +437,20 @@ def _canon_multi_line_items(
     nl: str,
     indent: str,
 ) -> bool:
-    r"""Shape-preserving multi-line canonicalisation of per-item trivia.
+    r"""Canonicalise per-item trivia for a multi-line inline value.
 
-    Returns whether the last item's ``post_comma_trivia`` closed its
-    line (a row-attached EOL comment was preserved): the caller uses
-    this to decide whether ``final_trivia`` should start with a fresh
-    newline.
+    Returns whether the last item's ``post_comma_trivia`` closed its row,
+    so the caller can avoid adding a duplicate ``final_trivia`` newline.
 
-    For each item k:
-      - k == 0: ``leading`` stays empty (item 0's structural pad
-        lives in ``header_trivia`` per the canonical model).
-      - k >= 1: split into (head_pad, above, tail_pad) via
-        :func:`split_item_above`; replace head/tail with canonical
-        ``\n`` + indent; preserve ``above`` (an above-item comment
-        block, possibly empty).  The leading ``\n`` is suppressed
-        when item ``k-1``'s ``post_comma_trivia`` already closed
-        the line (typically because it carries an EOL comment).
+    Item 0's structural pad lives in ``header_trivia``, so its leading is
+    empty. Later items keep their above-item comment block but get
+    canonical newline+indent, suppressed when the previous item's
+    ``post_comma_trivia`` already closed the row.
 
-    All items get ``has_comma=True`` (trailing-comma idiom). When an
-    item had no comma in source, its EOL comment may live in
-    ``trailing``; that section is migrated into ``post_comma_trivia``
-    so the synthesised comma sits between value and comment. After
-    migration ``trailing`` is cleared and ``post_comma_trivia``
-    shrinks to just an EOL section (`" # comment\n"`) when a comment
-    is attached, otherwise empty.
+    All items use trailing-comma style. If an item lacked a comma, move
+    its EOL comment from ``trailing`` to ``post_comma_trivia`` so the
+    comma renders before the comment; then shrink ``post_comma_trivia``
+    to an EOL section or empty.
     """
     prev_line_open = False
     for k, it in enumerate(items):
@@ -580,14 +516,11 @@ def _in_subtree(
     path: tuple[str, ...],
     owner: AoTEntry | None,
 ) -> bool:
-    """True iff ``slot`` belongs to the subtree rooted at ``path`` / ``owner``.
+    """Return whether ``slot`` belongs to the ``path`` / ``owner`` subtree.
 
-    When ``owner`` is set the caller is an AoT-entry view (or a section
-    nested inside one): the path-prefix check is not enough because
-    sibling entries of the same AoT share the caller's path. Restrict
-    the walk to slots whose nearest AoT-entry ancestor is ``owner``
-    itself or a descendant entry (strictly longer path prefix-matching
-    ``owner.path``).
+    ``owner`` disambiguates AoT-entry views (and sections nested inside
+    them), where sibling entries share the same path. Matching slots must
+    belong to ``owner`` or to a descendant AoT entry under ``owner.path``.
     """
     if isinstance(slot, KVSlot):
         if slot.host_path[: len(path)] != path:
@@ -617,18 +550,12 @@ def format_subtree(
 ) -> None:
     """Canonicalise every slot in the subtree rooted at ``path``.
 
-    Walks the doc-stream linked list starting at ``start`` forward,
-    stopping at the first slot outside the subtree.
+    Walks the doc-stream from ``start`` until the first outside slot.
+    ``owner`` disambiguates AoT-entry subtrees that share ``path``.
 
-    ``owner`` is the AoT entry that anchors the subtree, when the
-    caller is an AoT-entry view or a non-AoT section nested inside
-    one. It disambiguates sibling AoT entries that share ``path``.
-
-    The first slot's leading head-blanks are preserved verbatim
-    (they belong to the document preamble or to the parent of the
-    subtree).  Subsequent slots' leading head-blanks are rewritten
-    to the canonical count: 1 blank line before any structural
-    header, 0 otherwise.
+    The first slot's leading head-blanks belong to the document preamble
+    or parent subtree and are preserved. Later slots get the canonical
+    count: 1 blank line before a structural header, 0 otherwise.
     """
     prev: Slot | None = None
     slot = start
@@ -664,14 +591,10 @@ def format_document_trailing(
 ) -> None:
     """Canonicalise the trailing trivia of a :class:`Document`.
 
-    Retargets newlines to ``nl``, strips trailing whitespace on
-    blank lines, strips column-indent whitespace before orphan
-    comments, and (when ``comments`` is true) rewrites comment
-    text to canonical ``# body`` form.
-
-    Structural shape — line count, blank-line placement — is
-    preserved, so the user-visible split between preamble and
-    epilogue is unaffected.
+    Retargets newlines, strips blank-line trailing whitespace, strips
+    column-indent whitespace before orphan comments, and optionally
+    rewrites comment text. Structural shape is preserved, so the
+    preamble/epilogue split is unaffected.
     """
     retarget_trivia_newlines(trailing, nl)
     _canon_trivia_text(trailing, comments=comments)

--- a/src/tomlrt/_inline_ops.py
+++ b/src/tomlrt/_inline_ops.py
@@ -1,28 +1,13 @@
-"""Inline-table mutation primitives.
+"""Mutate inline-table entries without touching doc-stream slots.
 
-Inline tables are decoupled from the doc-stream linked list: a top-
-level inline table is wrapped by a single `KVSlot` whose `value` is
-an `InlineTableValue`. Mutation of the inline-table contents is a
-local operation on the `InlineTableValue.items` list, plus a
-matching `dict.__setitem__` / `__delitem__` on the logical view.
-This module owns the trivia fixups required to keep the result a
-valid, nicely-spaced inline table:
+A top-level inline table is a single ``KVSlot`` whose value is an
+``InlineTableValue``; mutations edit its ``items`` plus the logical dict
+view. Dotted-key entries like ``{a.b = 1}`` live in the outermost inline
+root with multi-component ``key_parts``, so lookups climb ``_parent``
+before splicing.
 
-* `append_entry` — splice a new entry at the end, transferring
-  the prior closing space to the new entry's trailing and giving
-  the previous entry a comma + a single space after it.
-* `replace_entry_value` — overwrite the `value` field of the entry
-  matching the given logical key (no spacing changes).
-* `delete_entry` — remove the entry, then if the deleted entry was
-  last, fold the prior entry's post-comma trivia into its trailing
-  and clear its comma so we don't render a trailing comma (illegal
-  in TOML 1.0; allowed in 1.1 but not what we want by default for a
-  delete).
-
-All entry lookups walk up the inline-table chain (via `_parent`) to
-the outermost inline-table that owns the backing
-`InlineTableValue` — entries for dotted keys like ``{a.b = 1}`` are
-filed there, with multi-component `key_parts`.
+Structural layout fixes — bracket pads, comma state, EOL comments, and
+trailing-comma policy — are delegated to :mod:`tomlrt._comma_ops`.
 """
 
 from __future__ import annotations
@@ -69,7 +54,7 @@ def _outermost_inline(t: Container) -> Container:
 
 
 def _entry_key_path(t: Container, leaf: str) -> tuple[str, ...]:
-    """Full dotted path used as `key_parts` in the outermost inline value."""
+    """Return the dotted path used as ``key_parts`` in the outermost value."""
     root = _outermost_inline(t)
     suffix = t._path[len(root._path) :]  # noqa: SLF001
     return (*suffix, leaf)
@@ -85,10 +70,10 @@ def _find_entry(
 
 
 def _find_prefix_entries(iv: InlineTableValue, key_path: tuple[str, ...]) -> list[int]:
-    """Indices of entries whose `key_parts` start with `key_path`.
+    """Return indices of entries whose ``key_parts`` start with ``key_path``.
 
-    Used when deleting a synthetic dotted-prefix container — e.g.
-    ``del obj["a"]`` for ``{a.b = 1, a.c = 2}`` removes both entries.
+    Used when deleting a synthetic dotted-prefix container, e.g.
+    ``del obj["a"]`` for ``{a.b = 1, a.c = 2}``.
     """
     n = len(key_path)
     out: list[int] = []
@@ -154,13 +139,11 @@ def append_entry(t: Container, key: str, new_value: Value) -> None:
 def overwrite_entry(t: Container, key: str, new_value: Value) -> None:
     """Replace a dotted-prefix sub-table with a single fresh entry.
 
-    Drops every ``key.*`` entry then re-adds a single ``key`` entry.
-    The outer table is only *transiently* emptied while the old prefix
-    entries are removed (it always ends up holding ``key``), so its
-    authored single-line bracket pad must survive the delete + re-add —
-    otherwise overwriting a sole-content prefix would canonicalise a
-    tight ``{...}`` to padded ``{ ... }``. Multi-line pads are left to
-    ``splice_in`` to recompute per-row.
+    Drops every ``key.*`` entry, adds ``key``, and preserves the authored
+    single-line bracket pad while the outer table is transiently empty.
+    Without that, overwriting a sole-content prefix would canonicalise
+    tight ``{...}`` to padded ``{ ... }``. Multi-line pads are recomputed
+    by ``splice_in``.
     """
     iv = _outermost_inline(t)._value  # noqa: SLF001
     assert iv is not None
@@ -207,19 +190,11 @@ def delete_entry(t: Container, key: str) -> bool:
 def reorder_inline(c: Container, new_key_order: list[str]) -> None:
     """Reorder direct children of an inline-table container.
 
-    Permutes ``InlineTableValue.items`` so that the c-direct-child
-    keys appear in ``new_key_order``. Direct-child-key grouping
-    keeps dotted-prefix entries (``a.b``, ``a.c``) adjacent under
-    their shared prefix. Foreign entries (whose key path doesn't
-    start with c's prefix — only possible when c is a dotted-inner
-    navigator) keep their absolute positions; only owned positions
-    are reordered. The actual permutation machinery (positional vs
-    entry-attached state) lives in
-    :func:`tomlrt._format.reorder_owned`.
-
-    ``new_key_order`` is trusted to be a permutation of
-    ``dict.keys(c)``. Only mutates the CST; dict storage is the
-    caller's responsibility.
+    Direct-child-key grouping keeps dotted-prefix entries adjacent under
+    their shared prefix. Foreign entries (only possible for a dotted-inner
+    navigator) keep their absolute positions; only owned positions are
+    reordered. ``new_key_order`` is trusted to be a permutation of
+    ``dict.keys(c)``; dict storage is caller-owned.
     """
     root = _outermost_inline(c)
     iv = root._value  # noqa: SLF001

--- a/src/tomlrt/_kind.py
+++ b/src/tomlrt/_kind.py
@@ -1,10 +1,7 @@
 """The shape a `Container` (Document or Table) is in.
 
-This lives in its own leaf module so that both `_container.py`
-(which derives `_kind` from existing flags) and `_inline_ops.py`
-(which dispatches on it) can import the enum without running into
-the existing circular import: `_container` imports `_inline_ops`
-at module top, so `_inline_ops` cannot import from `_container`.
+This leaf module lets `_container.py` and `_inline_ops.py` share the
+enum without worsening their existing circular import.
 """
 
 from __future__ import annotations

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -71,17 +71,21 @@ _reinstall_as_dotted: contextvars.ContextVar[bool] = contextvars.ContextVar(
 
 @contextlib.contextmanager
 def _record_install(doc: Document) -> Iterator[list[Slot]]:
-    """Capture every slot constructed during the with-block.
+    """Record every slot spliced into the doc-stream during the with-block.
 
-    Each call to ``_new_kv_slot`` / ``_new_section_header`` inside the
-    block (and the one bare ``KVSlot(...)`` in
-    ``_append_dotted_kv_under_implicit``) appends to the yielded list in
-    creation order, which matches doc-stream order for all installers
-    here.
+    The three insertion primitives (:func:`insert_after`,
+    :func:`insert_before`, :func:`insert_before_head`) — the sole points
+    at which a slot is linked into the document — append to the yielded
+    list. Recording at the splice boundary (rather than at slot
+    construction) captures synthesised *and* deep-cloned slots uniformly,
+    in doc-stream insertion order.
 
-    ``reposition_install`` uses this to learn what ``del + set`` just
-    installed without re-deriving it from cache snapshots. Nested
-    contexts stack; only the innermost is active.
+    The block is an install transaction: it only adds slots (the delete
+    runs before it, the reinstall never moves existing slots), so the
+    record is materialisation, not movement. ``reposition_install`` uses
+    it to learn what ``del + set`` installed so it can move that block
+    back to the saved anchor. Nested contexts stack; only the innermost
+    is active.
     """
     prev = doc._install_recorder  # noqa: SLF001
     recorder: list[Slot] = []
@@ -183,13 +187,19 @@ def reposition_install(parent: Container, key: str, value: Any) -> None:
     # ``_maybe_demote_synthetic_empty_header``). Drop those orphans:
     # moving one would corrupt the linked list. ``unlink_slot`` repairs
     # the chain, so the survivors stay contiguous.
-    new_slots = [
+    survivors = [
         s
-        for s in new_slots
+        for s in dict.fromkeys(new_slots)  # de-dup, preserve order
         if s is doc._head or s._prev is not None or s._next is not None  # noqa: SLF001
     ]
-    if not new_slots:
+    if not survivors:
         return
+    # The surviving recorded slots must form exactly one contiguous
+    # doc-stream span (the reinstall appends them as a block). Recover
+    # their true doc order by walking the linked list from the span head,
+    # and assert the single-span invariant so a future installer that
+    # breaks it fails loudly instead of silently moving the wrong range.
+    new_slots = _ordered_recorded_span(survivors)
     # A header-less new binding (scalar / synth-inline) takes its scope
     # from physical position, so it only needs its anchor inside
     # ``parent``'s body region. A binding that brings a structural
@@ -220,6 +230,31 @@ def reposition_install(parent: Container, key: str, value: Any) -> None:
     for slot, original, expected_pred in restores:
         if slot._prev is expected_pred:  # noqa: SLF001
             slot.leading.pieces = list(original)
+
+
+def _ordered_recorded_span(survivors: list[Slot]) -> list[Slot]:
+    """Return ``survivors`` in doc-stream order, asserting they are contiguous.
+
+    The recorded survivors of an install transaction must form exactly
+    one contiguous doc-stream span. Find the span head (the survivor with
+    no predecessor in the set) and walk forward; assert that the walk
+    reaches every survivor, so a non-contiguous or multi-span record
+    fails loudly rather than corrupting the subsequent move.
+    """
+    ids = {id(s) for s in survivors}
+    heads = [
+        s
+        for s in survivors
+        if s._prev is None or id(s._prev) not in ids  # noqa: SLF001
+    ]
+    assert len(heads) == 1, "recorded install slots are not a single span"
+    ordered: list[Slot] = []
+    cur: Slot | None = heads[0]
+    while cur is not None and id(cur) in ids:
+        ordered.append(cur)
+        cur = cur._next  # noqa: SLF001
+    assert len(ordered) == len(survivors), "recorded install slots are not contiguous"
+    return ordered
 
 
 def _ancestor_chain(c: Container) -> list[Container]:
@@ -455,6 +490,7 @@ def insert_after(anchor: Slot, new_slot: Slot, doc: Document) -> None:
         nxt._prev = new_slot  # noqa: SLF001
     else:
         doc._tail = new_slot  # noqa: SLF001
+    _record_new_slot(doc, new_slot)
 
 
 def insert_before(anchor: Slot, new_slot: Slot, doc: Document) -> None:
@@ -467,6 +503,7 @@ def insert_before(anchor: Slot, new_slot: Slot, doc: Document) -> None:
         p._next = new_slot  # noqa: SLF001
     else:
         doc._head = new_slot  # noqa: SLF001
+    _record_new_slot(doc, new_slot)
 
 
 def insert_before_head(new_slot: Slot, doc: Document) -> None:
@@ -486,6 +523,7 @@ def insert_before_head(new_slot: Slot, doc: Document) -> None:
     else:
         doc._tail = new_slot  # noqa: SLF001
     doc._head = new_slot  # noqa: SLF001
+    _record_new_slot(doc, new_slot)
 
 
 def _promote_trailing_to_preamble(new_head: Slot, doc: Document) -> None:
@@ -1336,14 +1374,14 @@ def _new_kv_slot(
     owner: AoTEntry | None,
     leading: Trivia,
 ) -> KVSlot:
-    """Synthesise a fresh KV slot, recording it on the active install recorder.
+    """Synthesise a fresh KV slot (recorded when spliced, not here).
 
     ``key_parts`` and ``key_seps`` are derived from ``key`` in the
     canonical synthetic form (``make_keypart`` per segment, ``.`` as
     separator). Mutation-side construction is the only caller, so the
     parser's source-text-preserving spelling is not needed here.
     """
-    slot = KVSlot(
+    return KVSlot(
         leading=leading,
         host_path=host_path,
         key_parts=make_keyparts(key),
@@ -1355,8 +1393,6 @@ def _new_kv_slot(
         owner_aot_entry=owner,
         key=key,
     )
-    _record_new_slot(doc, slot)
-    return slot
 
 
 def _build_kv_slot(c: Container, key: str, value: Value, doc: Document) -> KVSlot:
@@ -1583,8 +1619,7 @@ def _synthesise_header_then_insert_kv_at_doc_tail(
     if entry_last is not None:
         insert_after(entry_last, header_slot, doc)
     elif doc._tail is None:  # noqa: SLF001
-        doc._head = header_slot  # noqa: SLF001
-        doc._tail = header_slot  # noqa: SLF001
+        insert_before_head(header_slot, doc)
         # Empty doc → no preceding header → drop the leading.
         header_slot.leading = Trivia()
     else:
@@ -1742,7 +1777,7 @@ def _new_section_header(
     entry: AoTEntry | None = None,
     owner_aot_entry: AoTEntry | None = None,
 ) -> StructuralHeaderSlot:
-    slot = StructuralHeaderSlot(
+    return StructuralHeaderSlot(
         leading=leading,
         path=path,
         key_parts=make_keyparts(path),
@@ -1752,8 +1787,6 @@ def _new_section_header(
         owner_aot_entry=owner_aot_entry,
         synthetic=True,
     )
-    _record_new_slot(doc, slot)
-    return slot
 
 
 def _belongs_to_parent_extent(

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1388,6 +1388,7 @@ def install_dotted_kv_slot(
     value: Value,
     *,
     leaf_parent: Container,
+    leading: Trivia | None = None,
 ) -> None:
     """Insert a single dotted-KV slot hosted by ``host``.
 
@@ -1395,6 +1396,10 @@ def install_dotted_kv_slot(
     ``[host, ..., leaf_parent]``, updates ``_body_tail`` along the
     chain, and maintains ``AoTEntry.entry_slots`` membership. The caller
     owns dict storage at ``leaf_parent``.
+
+    ``leading`` overrides the synthesised separator/indent — used by the
+    trivia-preserving graft to carry a cloned source slot's leading
+    (standalone comments) onto the new slot.
 
     Pre-conditions (checked by caller):
     ``host`` can own the KV scope; the implicit chain already exists;
@@ -1420,7 +1425,9 @@ def install_dotted_kv_slot(
         value=value,
         doc=doc,
         owner=owner,
-        leading=_kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
+        leading=leading
+        if leading is not None
+        else _kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
     )
 
     inserted_at_head = _splice_body_slot(
@@ -2260,8 +2267,6 @@ def _install_cloned_section(
     ``parent._path + (key,)``), wires the section container, splices at
     the parent's subtree anchor, and populates child views.
     """
-    from tomlrt._container import Table  # noqa: PLC0415
-
     layout_root = parent._layout_root  # noqa: SLF001
     if layout_root is None:  # pragma: no cover
         msg = "cloned-section install requires parent attached to a document"
@@ -2280,8 +2285,32 @@ def _install_cloned_section(
 
     head = cloned_slots[0]
     assert isinstance(head, StructuralHeaderSlot)
-    cloned_header: StructuralHeaderSlot = head
-    _retarget_header_separator(cloned_header, _build_section_leading(doc))
+    _retarget_header_separator(head, _build_section_leading(doc))
+    return _finish_cloned_section(
+        parent,
+        key,
+        doc=doc,
+        target_path=target_path,
+        cloned_header=head,
+        cloned_slots=cloned_slots,
+    )
+
+
+def _finish_cloned_section(
+    parent: Container,
+    key: str,
+    *,
+    doc: Document,
+    target_path: tuple[str, ...],
+    cloned_header: StructuralHeaderSlot,
+    cloned_slots: list[Slot],
+) -> Table:
+    """Wire a cloned section block under ``parent[key]`` and store it.
+
+    Shared tail of :func:`_install_cloned_section` (clones an existing
+    header) and :func:`clone_document_as_section` (synthesises one).
+    """
+    from tomlrt._container import Table  # noqa: PLC0415
 
     section = Table.section()
     _install_cloned_structural_block(
@@ -2294,7 +2323,6 @@ def _install_cloned_section(
         cloned_slots=cloned_slots,
         anchor=_parent_subtree_tail(parent),
     )
-
     dict.__setitem__(parent, key, section)
     return section
 
@@ -2382,6 +2410,54 @@ def clone_section_as_section(
         msg = "Source section's first owned slot is not a header"
         raise AssertionError(msg)  # noqa: TRY004
     return _install_cloned_section(parent, key, src_slots, src_table._path)  # noqa: SLF001
+
+
+def clone_document_as_section(
+    parent: Container,
+    key: str,
+    src_doc: Document,
+) -> Table:
+    """Install a whole ``Document``'s body under ``parent[key]`` as a section.
+
+    The document is header-less, so a fresh ``[parent.key]`` header is
+    synthesised and the document's entire slot stream is cloned verbatim
+    beneath it (rebasing paths from the document root to the target). This
+    preserves body trivia — standalone comments and inline-array pad —
+    that re-synthesising from logical values would drop. The document's
+    file-level preamble / epilogue belong to no key and are not carried.
+    """
+    doc = parent._attached_doc  # noqa: SLF001
+    target_path = (*parent._path, key)  # noqa: SLF001
+
+    src_slots: list[Slot] = []
+    s = src_doc._head  # noqa: SLF001
+    while s is not None:
+        src_slots.append(s)
+        s = s._next  # noqa: SLF001
+
+    header = _new_section_header(
+        target_path,
+        leading=_build_section_leading(doc),
+        doc=doc,
+        owner_aot_entry=parent._owner_aot_entry,  # noqa: SLF001
+    )
+    cloned_body = _clone_entry_slots(
+        src_slots,
+        new_entry=None,
+        body_owner=parent._owner_aot_entry,  # noqa: SLF001
+        src_prefix=src_doc._path,  # noqa: SLF001
+        target_prefix=target_path,
+        dst_newline=doc._newline,  # noqa: SLF001
+        has_header=False,
+    )
+    return _finish_cloned_section(
+        parent,
+        key,
+        doc=doc,
+        target_path=target_path,
+        cloned_header=header,
+        cloned_slots=[header, *cloned_body],
+    )
 
 
 def clone_aot(

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -596,6 +596,68 @@ def _strip_leading_blank_lines(slot: Slot) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _splice_body_slot(
+    new_slot: Slot,
+    *,
+    anchor_body_tail: Slot | None,
+    anchor_header_ref: SlotRef | None,
+    doc: Document,
+) -> bool:
+    """Splice ``new_slot`` into the doc-stream at the canonical body anchor.
+
+    Anchor preference: body tail > header > head-of-doc seam > empty doc.
+    Shared by the direct-KV and dotted-KV insert paths. Returns ``True``
+    iff ``new_slot`` became the new doc head ahead of an existing head
+    (the seam case), where ancestor refs must go at index 0.
+    """
+    if anchor_body_tail is not None:
+        insert_after(anchor_body_tail, new_slot, doc)
+        return False
+    if anchor_header_ref is not None:
+        insert_after(anchor_header_ref.slot, new_slot, doc)
+        return False
+    if doc._head is not None:  # noqa: SLF001
+        # Section-only doc: splice before the first slot, separating it.
+        old_head = doc._head  # noqa: SLF001
+        insert_before_head(new_slot, doc)
+        _ensure_leading_blank_line(old_head, doc)
+        return True
+    # Empty doc: splice in as head, hoisting any preamble trivia.
+    insert_before_head(new_slot, doc)
+    _promote_trailing_to_preamble(new_slot, doc)
+    return False
+
+
+def _file_body_ref(
+    anc: Container,
+    new_slot: Slot,
+    *,
+    anchor_slot: Slot | None,
+    inserted_at_head: bool,
+    local_key: str,
+) -> SlotRef:
+    """File a ref to ``new_slot`` on ``anc`` at its doc-stream position.
+
+    After ``anchor_slot``'s ref when ``anc`` holds one; else index 0 for a
+    head-of-doc insert; else the tail. Rebuilds ``anc._index[local_key]``
+    rather than appending, which would misorder a key with later refs
+    (e.g. ``a.x = 1`` then ``[a.b]``).
+    """
+    new_ref = SlotRef(slot=new_slot, container=anc)
+    if anchor_slot is not None and any(
+        r.slot is anchor_slot
+        for r in anc._refs  # noqa: SLF001
+    ):
+        anchor_idx = _find_ref_index_by_slot(anc, anchor_slot)
+        anc._refs.insert(anchor_idx + 1, new_ref)  # noqa: SLF001
+    elif inserted_at_head and anc._refs:  # noqa: SLF001
+        anc._refs.insert(0, new_ref)  # noqa: SLF001
+    else:
+        anc._refs.append(new_ref)  # noqa: SLF001
+    _rebuild_index_for_key(anc, local_key)
+    return new_ref
+
+
 def append_direct_kv(c: Container, key: str, value: Value) -> None:
     """Append a fresh direct (non-dotted) KV to ``c``.
 
@@ -646,44 +708,22 @@ def append_direct_kv(c: Container, key: str, value: Value) -> None:
 
     new_slot = _build_kv_slot(c, key, value, doc)
 
-    if body_tail is not None:
-        insert_after(body_tail, new_slot, doc)
-    elif header_ref is not None:
-        # Header-only container: anchor at the header itself.
-        insert_after(header_ref.slot, new_slot, doc)
-    elif doc._head is not None:  # noqa: SLF001
-        # Section-only doc: insert the new KV at the head of the doc
-        # stream, before the first existing slot. Ensure a blank-line
-        # separator on what is about to become the second slot, so the
-        # new KV does not visually collide with `[s]`.
-        old_head = doc._head  # noqa: SLF001
-        insert_before_head(new_slot, doc)
-        _ensure_leading_blank_line(old_head, doc)
-    else:
-        # Empty doc (slotless): splice the new KV in as the head and
-        # hoist any pre-existing preamble trivia (from
-        # `Document.preamble`, or a parsed comment-only source) onto
-        # its leading.
-        insert_before_head(new_slot, doc)
-        _promote_trailing_to_preamble(new_slot, doc)
-
-    new_ref = SlotRef(slot=new_slot, container=c)
-    # The new ref's correct position in ``c._refs`` is immediately
-    # after the anchor ref (the previous body_tail's ref). With no
-    # anchor: head-of-doc insert (3d-5) → index 0, so the ref
-    # ordering matches doc-stream (existing section-header refs come
-    # after); header-only / empty-doc → end (no preceding refs to
-    # order against).
-    if body_tail is not None:
-        anchor_idx = _find_ref_index_by_slot(c, body_tail)
-        c._refs.insert(anchor_idx + 1, new_ref)  # noqa: SLF001
-    elif header_ref is None and doc._head is new_slot:  # noqa: SLF001
-        # Head-of-doc insert: the new ref must precede any existing
-        # section-header refs in c._refs to keep doc-stream order.
-        c._refs.insert(0, new_ref)  # noqa: SLF001
-    else:
-        c._refs.append(new_ref)  # noqa: SLF001
-    c._index.setdefault(key, []).append(new_ref)  # noqa: SLF001
+    inserted_at_head = _splice_body_slot(
+        new_slot,
+        anchor_body_tail=body_tail,
+        anchor_header_ref=header_ref,
+        doc=doc,
+    )
+    anchor_slot: Slot | None = body_tail or (
+        header_ref.slot if header_ref is not None else None
+    )
+    _file_body_ref(
+        c,
+        new_slot,
+        anchor_slot=anchor_slot,
+        inserted_at_head=inserted_at_head,
+        local_key=key,
+    )
     c._body_tail = new_slot  # noqa: SLF001
 
 
@@ -1459,52 +1499,26 @@ def install_dotted_kv_slot(
         leading=_kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
     )
 
-    # Splice into the doc-stream linked list. Anchor preference:
-    # host's body_tail > host's header > head-of-doc seam > empty doc.
-    inserted_at_head = False
-    if body_tail is not None:
-        insert_after(body_tail, new_slot, doc)
-    elif header_ref is not None:
-        insert_after(header_ref.slot, new_slot, doc)
-    elif doc._head is not None:  # noqa: SLF001
-        old_head = doc._head  # noqa: SLF001
-        insert_before_head(new_slot, doc)
-        _ensure_leading_blank_line(old_head, doc)
-        inserted_at_head = True
-    else:
-        insert_before_head(new_slot, doc)
-        _promote_trailing_to_preamble(new_slot, doc)
+    inserted_at_head = _splice_body_slot(
+        new_slot,
+        anchor_body_tail=body_tail,
+        anchor_header_ref=header_ref,
+        doc=doc,
+    )
 
-    # File refs on every chain ancestor. ``_refs`` is the doc-stream
-    # subset; ``_index`` preserves "primary at index 0 + all
-    # contributors". The anchor for host is body_tail or its header;
-    # implicit intermediates we created are fresh with empty ``_refs``
-    # so any append is equivalent to insert-at-0.
+    # File a ref on every chain ancestor, anchored at host's body_tail
+    # or header (fresh implicit intermediates have empty ``_refs``).
     anchor_slot: Slot | None = body_tail or (
         header_ref.slot if header_ref is not None else None
     )
     for i, anc in enumerate(chain):
-        new_ref = SlotRef(slot=new_slot, container=anc)
-        if anchor_slot is not None and any(
-            r.slot is anchor_slot
-            for r in anc._refs  # noqa: SLF001
-        ):
-            anchor_idx = _find_ref_index_by_slot(anc, anchor_slot)
-            anc._refs.insert(anchor_idx + 1, new_ref)  # noqa: SLF001
-        elif inserted_at_head and anc._refs:  # noqa: SLF001
-            # New slot is the new doc head; its ref must precede any
-            # existing refs (e.g. section-header refs on the doc root)
-            # to keep ``_refs`` in doc-stream order.
-            anc._refs.insert(0, new_ref)  # noqa: SLF001
-        else:
-            anc._refs.append(new_ref)  # noqa: SLF001
-        # Rebuild ``_index[local_key]`` rather than blindly appending —
-        # appending is only correct when the new ref is also the last
-        # with its key in ``_refs``, which fails when the ancestor has
-        # later refs under the same key (e.g. ``a.x = 1`` then
-        # ``[a.b]`` — the new ``a.z`` slot sits before the ``[a.b]``
-        # header in ``_index['a']``, not at the end).
-        _rebuild_index_for_key(anc, leaf_keypath[i])
+        _file_body_ref(
+            anc,
+            new_slot,
+            anchor_slot=anchor_slot,
+            inserted_at_head=inserted_at_head,
+            local_key=leaf_keypath[i],
+        )
         if anc._body_tail is body_tail or anc._body_tail is None:  # noqa: SLF001
             # Propagate the body_tail bump up the chain. ``is body_tail``
             # is the old-path case (every chain ancestor of an implicit

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1,28 +1,21 @@
-"""Section-side mutation primitives.
+"""Mutate section-side layout.
 
-Linked-list and per-container cache updates for direct (non-dotted)
-KV insert and leaf delete. Inline-table mutation lives in
-``_inline_ops.py``; this module never touches inline-tables.
+This module owns linked-list and per-container cache updates for
+direct KV insert and leaf delete. Inline-table mutation lives in
+``_inline_ops.py``.
 
 Design notes:
 
-* The doc-stream linked list is the single source of physical
-  ordering. Insert primitives splice exactly one slot at a time at
-  an explicitly-named anchor — no list-index search, no
-  doc-stream-wide rescans.
-
-* ``c._refs`` mirrors the doc-stream subset of slots referenced by
-  ``c``. For direct (non-dotted) KV inserts, the new ref's correct
-  position in ``c._refs`` is **immediately after the anchor's ref**
-  (or at the front if there is no anchor ref). This avoids drift in
-  layouts where ``c`` has later child-section refs sitting after its
-  body region.
-
-* ``c._body_tail`` is maintained incrementally: O(1) on insert, and
-  O(len(c._refs)) only on the rare delete-of-current-tail.
-
-* No ancestor walk: a non-dotted direct KV files exactly one ref,
-  on its host container. Ancestors are unaffected.
+* The doc-stream linked list is the single source of physical ordering;
+  inserts splice exactly one slot at an explicit anchor.
+* ``c._refs`` mirrors the doc-stream subset referenced by ``c``. For a
+  direct KV insert, the new ref belongs immediately after the anchor's
+  ref (or at the front), not blindly at the tail where child-section
+  refs may already sit.
+* ``c._body_tail`` is incremental: O(1) on insert, O(len(c._refs)) only
+  when deleting the current tail.
+* A non-dotted direct KV files exactly one ref on its host container;
+  ancestors are unaffected.
 """
 
 from __future__ import annotations
@@ -82,14 +75,13 @@ def _record_install(doc: Document) -> Iterator[list[Slot]]:
 
     Each call to ``_new_kv_slot`` / ``_new_section_header`` inside the
     block (and the one bare ``KVSlot(...)`` in
-    ``_append_dotted_kv_under_implicit``) appends to the yielded list,
-    in creation order — which matches doc-stream order for every
-    install primitive in this module.
+    ``_append_dotted_kv_under_implicit``) appends to the yielded list in
+    creation order, which matches doc-stream order for all installers
+    here.
 
-    Used by ``reposition_install`` to learn what ``del + set`` just
-    installed without having to re-derive it from ``_index`` /
-    ``_header_ref`` snapshots. Re-entrancy: nested contexts stack;
-    only the innermost is active.
+    ``reposition_install`` uses this to learn what ``del + set`` just
+    installed without re-deriving it from cache snapshots. Nested
+    contexts stack; only the innermost is active.
     """
     prev = doc._install_recorder  # noqa: SLF001
     recorder: list[Slot] = []
@@ -114,14 +106,12 @@ def _record_displacements(
     """Capture each pre-existing slot whose ``leading`` the install rewrote.
 
     ``_synthesise_header_then_insert_kv`` rewrites the leading of the
-    descendant it inserts a synthetic header before — a sibling it does
-    not own — on the premise that the header now precedes it. When that
-    install happens inside ``reposition_install`` the synthesised block
-    is then relocated, which can break the premise. Each rewrite records
-    ``(slot, original_leading_pieces, original_predecessor)`` so the
-    leading can be restored iff the move left ``slot`` back beside its
-    original predecessor. Companion to ``_record_install``; re-entrancy
-    stacks the same way.
+    descendant it inserts a synthetic header before. When
+    ``reposition_install`` relocates that synthesised block, the premise
+    can break. Record ``(slot, original_leading_pieces,
+    original_predecessor)`` so leading is restored only if ``slot`` ends
+    up back beside its original predecessor. Re-entrancy mirrors
+    ``_record_install``.
     """
     prev = doc._displaced_recorder  # noqa: SLF001
     recorder: list[tuple[Slot, list[TriviaPiece], Slot | None]] = []
@@ -142,33 +132,16 @@ def _record_displacement(doc: Document, slot: Slot, original_pred: Slot | None) 
 def reposition_install(parent: Container, key: str, value: Any) -> None:
     """Replace ``parent[key]`` while preserving its physical position.
 
-    Snapshots the bound region's anchor, leading, and successor leading;
-    deletes the binding; reinstalls via ``parent[key] = value``;
-    captures the freshly-built slots through ``_record_install`` (and any
-    displaced siblings through ``_record_displacements``); moves them back
-    to the saved anchor; and restores perturbed neighbour leadings.
+    The binding is deleted, reinstalled via ``parent[key] = value``,
+    captured with ``_record_install`` / ``_record_displacements``, then
+    moved back to the saved anchor.
 
-    Neighbour-leading restore obeys a single rule: **a surviving
-    neighbour keeps its pre-op leading iff, after the move, it sits
-    immediately after the slot that legitimately precedes it.** Two kinds
-    of neighbour feed that rule, differing only in *which* slot that is:
-
-    * the region's *successor* — the slot after the binding's landing
-      site, whose rightful predecessor is the relocated block's tail
-      (``new_slots[-1]``). This covers delete-side perturbations
-      (``unlink_slot`` stripping a new doc-head's blank lines), the
-      install-side head-of-doc guard, and the case where synthesis lands
-      the block back in front of it (restoring the user's exact gap in
-      place of synthesis's canonical separator);
-    * a *displaced sibling* — a slot ``_synthesise_header_then_insert_kv``
-      transiently shoved a synthetic header in front of, whose rightful
-      predecessor is its own *original* predecessor ``R``; restored when
-      the move relocated the block away from it.
-
-    A neighbour's expected predecessor is unique (the block tail and a
-    sibling's original ``R`` are distinct slots), so the rule resolves
-    each neighbour to at most one restore even when the successor and a
-    displaced sibling are the same slot.
+    A surviving neighbour keeps its pre-op leading iff, after the move,
+    it sits immediately after the slot that legitimately precedes it:
+    the relocated block tail for the original successor, or the original
+    predecessor ``R`` for a sibling temporarily displaced by synthetic
+    header insertion. The expected predecessor is unique, so a slot that
+    is both successor and displaced sibling is restored at most once.
 
     A header-less new binding (scalar / synth-inline) is left where
     ``_insert_new`` placed it when the captured anchor lies outside
@@ -299,14 +272,9 @@ def _file_ref_at_tail(c: Container, ref: SlotRef) -> None:
 def record_ref(c: Container, slot: Slot) -> SlotRef:
     """Create a `SlotRef(slot, c)` and file it at the tail of ``c``'s caches.
 
-    The ``_index`` key, when filed, is :attr:`SlotRef.local_key` —
-    derived from ``(slot, container)`` geometry. Callers don't pass
-    it, so they can't accidentally file the ref under a key that
-    disagrees with the property's derivation.
-
-    Used by ``_build`` (initial population from a parse) and by
-    section-clone install paths. For one-off keyed refs constructed
-    elsewhere, callers can use ``_file_ref_at_tail`` directly.
+    The ``_index`` key is :attr:`SlotRef.local_key`, derived from
+    ``(slot, container)`` geometry, so callers cannot file under a
+    disagreeing key. Used by ``_build`` and section-clone installers.
     """
     ref = SlotRef(slot, c)
     _file_ref_at_tail(c, ref)
@@ -354,16 +322,12 @@ def _file_synthetic_header_and_kv(
 ) -> KVSlot:
     """Common tail of the two header-synthesis paths.
 
-    Files ``c``'s own-header ref at ``header_ref_index``, builds and
-    inserts the ``key = value`` KV directly after ``header_slot``,
-    files the KV ref at ``header_ref_index + 1``, and updates
-    ``c._header_ref`` / ``c._index[key]`` / ``c._body_tail``. Returns
-    the new KV slot so callers can register it on
-    ``owner.entry_slots`` and similar bookkeeping.
+    Files ``c``'s own-header ref, inserts ``key = value`` directly
+    after ``header_slot``, files the KV ref, and updates
+    ``c._header_ref`` / ``c._index[key]`` / ``c._body_tail``.
 
-    Anchoring (where ``header_slot`` itself sits in the slot stream)
-    and ancestor binding-ref filing remain explicit in callers; both
-    are highly position-sensitive and not safe to share.
+    Anchoring and ancestor binding-ref filing stay explicit in callers;
+    both are highly position-sensitive and not safe to share.
     """
     own_header_ref = SlotRef(slot=header_slot, container=c)
     c._refs.insert(header_ref_index, own_header_ref)  # noqa: SLF001
@@ -661,16 +625,9 @@ def _file_body_ref(
 def append_direct_kv(c: Container, key: str, value: Value) -> None:
     """Append a fresh direct (non-dotted) KV to ``c``.
 
-    Updates ``c._refs`` / ``_index`` / ``_body_tail`` and the dict
-    storage.
-
-    Routing:
-
-    * implicit-headerless non-root container with a body anchor →
-      dotted-KV synthesis under the nearest header-bearing ancestor;
-    * AoT-entry sub-table body → not yet supported;
-    * everything else → direct single-keypart KV with anchor =
-      body_tail / header_ref / head-of-doc seam.
+    Updates ``c._refs`` / ``_index`` / ``_body_tail`` and dict storage.
+    Implicit headerless containers route through dotted-KV synthesis;
+    AoT-entry sub-table bodies are not yet supported.
     """
     if c._kind is _Kind.IMPLICIT_SECTION:  # noqa: SLF001
         # Implicit / headerless non-root container. A fresh
@@ -692,10 +649,8 @@ def append_direct_kv(c: Container, key: str, value: Value) -> None:
         _append_dotted_kv_under_implicit(c, key, value)
         return
     if c._owner_aot_entry is not None and c._header_ref is not None:  # noqa: SLF001
-        # AoT-entry root container: header-bearing, header is `[[arr]]`.
-        # Body inserts work like normal header-bearing container, but
-        # we also need to maintain the entry's `entry_slots` list in
-        # doc-stream order.
+        # Body inserts work like a normal header-bearing container, plus
+        # entry_slots membership maintenance.
         _append_kv_in_aot_entry(c, key, value)
         return
     if c._owner_aot_entry is not None:  # noqa: SLF001
@@ -904,26 +859,11 @@ def _materialise_empty_inline_table(
 def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> None:
     """Delete ``key`` from ``c`` — scalar, inline, section, AoT, or dotted-subtree.
 
-    Steps:
-
-    1. Compute the owned-slot identity set: every physical slot whose
-       refs all live in ``c._index[key]`` plus every descendant
-       container's ``_refs``.
-    2. Compute the containers-to-scrub set: ``c``'s ancestor chain
-       (up to and including the doc root) plus every non-inline
-       container in the subtree rooted at ``c[key]``.
-    3. Scrub: rebuild ``_refs``/``_index`` of each scrubbed container,
-       dropping refs whose slot is in the owned set. Recompute
-       ``_body_tail`` on each container whose old tail was unlinked.
-       Drop any unlinked slot from its owning ``AoTEntry.entry_slots``.
-    4. Debug-only: assert no still-live container retains a ref to any
-       owned slot.
-    5. Unlink each owned slot from the doc linked list.
-    6. Drop the dict entry on ``c``.
-
-    Cascade-prune is intentionally *not* performed: ``del c[k]``
-    follows Python-dict semantics, removing exactly ``k`` and leaving
-    any now-emptied implicit ancestor chain reachable as nested empty
+    Owned slots are scrubbed from live refs/indexes via slot
+    back-pointers, body tails and ``AoTEntry.entry_slots`` are repaired,
+    then the slots are unlinked. Cascade-prune is intentionally *not*
+    performed: ``del c[k]`` removes exactly ``k`` and leaves any
+    now-emptied implicit ancestor chain reachable as nested empty
     ``Table`` views.
 
     ``materialise_empty`` is opt-in for the public delete API: if the
@@ -967,7 +907,7 @@ def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> No
         assert isinstance(primary, (KVSlot, StructuralHeaderSlot))
         mat_primary = primary
 
-    # 1. Owned-slot identity set + retained slot objects (for unlink).
+    # Owned-slot identity set + retained slot objects (for unlink).
     owned_ids: set[int] = set()
     owned_slots: list[Slot] = []
 
@@ -980,7 +920,7 @@ def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> No
     for r in c._index.get(key, []):  # noqa: SLF001
         _add_slot(r.slot)
 
-    # 2. Subtree containers + AoTs + descendant owned slots.
+    # Subtree containers + AoTs + descendant owned slots.
     subtree_containers: list[Container] = []
     subtree_aots: list[AoT] = []
     _collect_subtree(val, subtree_containers, subtree_aots, _add_slot)
@@ -999,17 +939,13 @@ def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> No
         else:
             _materialise_empty_inline_table(c, mat_primary, doc)
 
-    # 3. Slot-driven scrub via back-pointers, *skipping* subtree
-    # containers — those are about to be orphaned to a fresh
-    # Document and must keep their internal `_refs` / `_index`
-    # intact. Chain containers (ancestors + ``c``) and any other
-    # live container holding a ref to an owned slot are scrubbed.
+    # Slot-driven scrub via back-pointers, *skipping* subtree containers:
+    # those move to a fresh Document and keep their internal caches.
     skip_ids = frozenset(id(sc) for sc in subtree_containers)
     _scrub_owned_slots_via_backptrs(owned_slots, skip_container_ids=skip_ids)
 
-    # 4. Body-tail recompute on the ancestor chain. The
-    # `min_owned_depth` bound short-circuits the walk for the
-    # common leaf-KV case (chain is just ``c`` itself).
+    # Body-tail recompute on the ancestor chain. `min_owned_depth`
+    # short-circuits the common leaf-KV case.
     min_owned_depth = len(c._path)  # noqa: SLF001
     for s in owned_slots:
         d = len(s.host_path) if isinstance(s, KVSlot) else 0
@@ -1017,11 +953,9 @@ def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> No
             min_owned_depth = d
     _invalidate_body_tail_chain(c, owned_ids, min_depth=min_owned_depth, recompute=True)
 
-    # 5. Unlink owned slots; transplant to an orphan Document if any
-    # subtree containers / AoTs may still be user-referenced. Skip
-    # the entry_slots strip for AoTEntries whose AoT is itself being
-    # moved — those entries leave with their slots intact so
-    # downstream clone_aot / re-install can read the full CST.
+    # Unlink owned slots; transplant user-referenced subtrees to an
+    # orphan Document. Keep entry_slots for AoTEntries whose AoT moves
+    # with them, so clone/re-install can still read the full CST.
     moving_aot_entry_ids: set[int] = set()
     for ao in subtree_aots:
         for entry_table in list.__iter__(ao):
@@ -1098,7 +1032,7 @@ def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> No
         if ar._attached:  # noqa: SLF001
             _reset_array_for_rehome(ar)
 
-    # 6. Drop the dict entry.
+    # Drop the dict entry.
     dict.__delitem__(c, key)
 
 
@@ -1160,14 +1094,11 @@ def _collect_subtree(
 def _owned_slots_in_doc_order(start: Slot, owned_ids: set[int]) -> list[Slot]:
     """Walk the doc-stream forward from ``start``, collecting owned slots.
 
-    ``start`` must be the doc-stream-first slot of the owned set; the walk
-    follows ``_next``, gathering slots in ``owned_ids`` in physical order
-    and skipping past any interleaved foreign slots (a binding's slots
-    need not be contiguous — ``[[a]] … [b] … [[a]]`` is legal TOML). It
-    stops once every owned slot has been seen. Shared by
-    :func:`_gather_subtree_slots` and the ``delete_key`` orphan
-    transplant, both of which need a subtree's slots in physical order
-    rather than collection order.
+    ``start`` must be the owned set's doc-stream-first slot. The walk
+    skips interleaved foreign slots (a binding's slots need not be
+    contiguous — ``[[a]] … [b] … [[a]]`` is legal) and stops after every
+    owned slot has been seen. Used where physical order, not collection
+    order, is required.
     """
     out: list[Slot] = []
     seen: set[int] = set()
@@ -1460,22 +1391,15 @@ def install_dotted_kv_slot(
 ) -> None:
     """Insert a single dotted-KV slot hosted by ``host``.
 
-    Files the new slot's refs on ``host`` + every implicit
-    intermediate in the chain ``[host, ..., leaf_parent]`` per the
-    dotted-KV ref-propagation rule, updates ``_body_tail`` along the
-    chain, and maintains ``AoTEntry.entry_slots`` order when host has
-    an owner. The caller is responsible for dict storage at
-    ``leaf_parent``.
+    Files refs on ``host`` and every implicit intermediate in
+    ``[host, ..., leaf_parent]``, updates ``_body_tail`` along the
+    chain, and maintains ``AoTEntry.entry_slots`` membership. The caller
+    owns dict storage at ``leaf_parent``.
 
     Pre-conditions (checked by caller):
-      * ``host`` has a header, is the doc root, or is an AoT entry root.
-      * The implicit chain along ``leaf_keypath[:-1]`` already exists
-        under ``host`` (run ``ensure_implicit_chain`` first).
-      * ``leaf_parent`` is the existing container at
-        ``host._path + leaf_keypath[:-1]``.
-      * ``leaf_keypath[-1]`` is not yet bound at ``leaf_parent``.
-      * ``len(leaf_keypath) >= 2`` — a single-keypart leaf is not
-        dotted; use ``append_direct_kv`` for that.
+    ``host`` can own the KV scope; the implicit chain already exists;
+    ``leaf_parent`` is that chain's leaf; ``leaf_keypath[-1]`` is
+    unbound; and ``len(leaf_keypath) >= 2``.
     """
     assert len(leaf_keypath) >= 2
     doc = host._attached_doc  # noqa: SLF001
@@ -1538,14 +1462,8 @@ def _append_dotted_kv_under_implicit(c: Container, key: str, value: Value) -> No
     """Insert into an implicit-headerless container via dotted KV.
 
     Thin wrapper over :func:`install_dotted_kv_slot` that derives the
-    host and leaf keypath from ``c``. Routes through the nearest
-    header-bearing ancestor (or the doc root). Handles both a ``c`` with
-    an existing dotted body and a fully-empty ``c`` (no anchor of its
-    own — ``install_dotted_kv_slot`` falls back to the host's anchor).
-
-    Pre-conditions (checked by caller):
-      * ``c._path`` is non-empty (c is not the doc root)
-      * ``c._header_ref is None`` (c is implicit-headerless)
+    nearest header-bearing host and leaf keypath. Handles both existing
+    dotted bodies and fully-empty ``c`` (no anchor of its own).
     """
     host = _nearest_header_host(c)
 
@@ -1560,19 +1478,15 @@ def _append_dotted_kv_under_implicit(c: Container, key: str, value: Value) -> No
 def _synthesise_header_then_insert_kv(c: Container, key: str, value: Value) -> None:
     """Promote a purely-implicit container ``c`` to an explicit section.
 
-    Pre-conditions (checked by caller):
-      * ``c._path`` is non-empty
-      * ``c._header_ref is None``
-      * ``c._body_tail is None``
-      * ``c._refs`` is non-empty (at least one descendant binding ref)
-
     Synthesises a ``[c._path]`` header before the first descendant
     slot in doc-stream order, adopts that descendant's old leading
     onto the synthetic header (preserving the existing seam-from-
     above), and rewrites the descendant's leading to the document's
     current inter-section separator style (compact or blank-line).
-    Then inserts a fresh single-keypart KV ``key = value`` directly
-    after the synthetic header.
+    Then inserts ``key = value`` directly after the synthetic header.
+
+    Pre-condition: ``c`` is non-root, header-less, body-less, and has at
+    least one descendant binding ref.
     """
     doc = c._attached_doc  # noqa: SLF001
 
@@ -1642,9 +1556,7 @@ def _synthesise_header_then_insert_kv_at_doc_tail(
 
     Used by the structural-replace path when ``c``'s previous
     contributors were just deleted, leaving ``c`` empty and implicit.
-    The outer caller (typically ``_move_slots_to_anchor``) is
-    responsible for repositioning the resulting block to the captured
-    anchor when one exists.
+    The outer caller repositions the block to the captured anchor.
     """
     doc = c._attached_doc  # noqa: SLF001
     owner = c._owner_aot_entry  # noqa: SLF001
@@ -2203,29 +2115,19 @@ def clone_aot_entry(
 ) -> Table:
     """Append a deep CST clone of ``src`` to ``aot``.
 
-    ``src`` is either an attached entry's ``Table`` (the live-source
-    case used by ``parent[k] = some_entry_table`` and AoT extension)
-    or a bare ``AoTEntry`` (the AoT private-orphan rehome path where
-    the source table has already been reset but the underlying
-    ``AoTEntry.entry_slots`` are intact in a private orphan document).
+    ``src`` is either an attached entry's ``Table`` or a bare
+    ``AoTEntry`` from the AoT private-orphan rehome path, where the
+    table has been reset but ``entry_slots`` still hold the CST.
 
     Preserves the source entry's per-slot leading / EOL / lexeme bytes
     so per-entry comments and trailing-comment formatting survive.
-    The cloned entry's header leading is rewritten to the
-    destination's ``_aot_separator`` policy by default — that's what
-    a single-entry append wants. Pass
-    ``preserve_source_separator=True`` to keep the source's structural
-    leading verbatim, which is what bulk-cloning a whole AoT
-    (:func:`clone_aot`) wants so the source's inter-entry layout
-    survives the transplant.
+    Header leading follows the destination's ``_aot_separator`` policy
+    unless ``preserve_source_separator=True`` (used by
+    :func:`clone_aot` to preserve inter-entry layout).
 
     Supports source entries that include nested ``[a.sub]`` headers
-    and their KVSlots. ``dst_path`` (defaults to ``aot._path``) lets
-    callers rebase the entry under a different key — both the
-    entry header path and any nested sub-section paths are rewritten
-    so e.g. ``[a.sub]`` becomes ``[b.sub]`` when cloning into ``b``.
-
-    Returns the new ``Table`` view.
+    and KVSlots. ``dst_path`` (defaults to ``aot._path``) rebases both
+    the entry header path and nested sub-section paths.
     """
     if isinstance(src, AoTEntry):
         src_entry = src
@@ -2292,18 +2194,14 @@ def _install_cloned_aot_entry(
 ) -> Table:
     """Common installer for appending a cloned aot-entry to ``aot``.
 
-    Deep-clones ``src_slots`` (head becomes an aot-entry via
-    ``new_entry``), wires a fresh entry container, splices the entry's
-    slots after the AoT's last slot (or at doc end), files the parent
+    Deep-clones ``src_slots`` (head becomes an aot-entry), wires a fresh
+    entry container, splices after the AoT's last slot, files the parent
     binding ref, and populates child views.
 
     ``rewrite_separator``: if True, the source's structural leading
     is replaced with destination-style preamble (entry 0) or the
-    AoT's existing inter-entry separator (entry > 0). Single-entry
-    append paths want this so the new entry adopts the destination's
-    layout. Bulk clone of a whole AoT
-    (:func:`clone_aot`) sets this False past entry 0 so the source's
-    inter-entry separator survives the transplant.
+    AoT's inter-entry separator (entry > 0). :func:`clone_aot` sets this
+    False past entry 0 so source separators survive.
     """
     from tomlrt._container import Table  # noqa: PLC0415
 
@@ -2359,10 +2257,8 @@ def _install_cloned_section(
 
     Deep-clones ``src_slots`` (rewriting head from ``[..]`` / ``[[..]]``
     to ``[<key>]``, rebasing paths from ``src_prefix`` to
-    ``parent._path + (key,)``), wires the section container, splices
-    the slots in at the parent's subtree anchor, files the parent
-    binding ref, and populates child views. Used by both
-    ``clone_aot_entry_as_table`` and ``clone_section_as_section``.
+    ``parent._path + (key,)``), wires the section container, splices at
+    the parent's subtree anchor, and populates child views.
     """
     from tomlrt._container import Table  # noqa: PLC0415
 
@@ -2410,10 +2306,9 @@ def clone_aot_entry_as_table(
 ) -> Table:
     """Install an AoT entry under ``parent[key]`` as a standard ``[key]`` table.
 
-    Used by ``parent[key] = some_aot_entry`` and ``install`` paths.
     Deep-clones the source entry's slots, rewriting the head from
-    ``[[..]]`` to ``[..]``, rebasing all paths from the source's
-    AoT prefix to ``parent._path + (key,)``.
+    ``[[..]]`` to ``[..]`` and rebasing paths from the source AoT prefix
+    to ``parent._path + (key,)``.
     """
     src_entry = src_entry_table._owner_aot_entry  # noqa: SLF001
     if src_entry is None:  # pragma: no cover
@@ -2426,11 +2321,9 @@ def clone_aot_entry_as_table(
 def _gather_subtree_slots(src_table: Container) -> list[Slot]:
     """Collect a container subtree's owned slots in doc-stream order.
 
-    Includes the container's own header, every direct/dotted KV slot,
-    every nested sub-section's header + KV slots, and every nested
-    ``[[a.x]]`` aot-entry's header + KV slots — i.e. the entire
-    physical body of ``src_table``. Works on both standard sections
-    and AoT-entry tables (both expose a ``_header_ref``).
+    Includes the container's own header, direct/dotted KVs, nested
+    sub-sections, and nested ``[[a.x]]`` AoT entries — the entire
+    physical body of ``src_table``.
     """
     assert src_table._header_ref is not None  # noqa: SLF001
 
@@ -2454,9 +2347,8 @@ def clone_table_as_aot_entry(
     """Append ``src_table`` (a standard ``[k]`` section) to ``aot`` as an entry.
 
     Deep-clones the source section's slots, rewriting the head from
-    ``[k]`` to ``[[aot._path]]``, rebasing all paths from the source's
-    section path to ``aot._path``. Preserves per-slot leading / EOL
-    / lexeme bytes (so per-section comments survive).
+    ``[k]`` to ``[[aot._path]]`` and rebasing paths to ``aot._path``.
+    Preserves per-slot leading / EOL / lexeme bytes.
     """
     src_slots = _gather_subtree_slots(src_table)
     if not isinstance(src_slots[0], StructuralHeaderSlot):  # pragma: no cover
@@ -2481,11 +2373,9 @@ def clone_section_as_section(
 ) -> Table:
     """Install a deep clone of a standard section under ``parent[key]``.
 
-    Used for cross-doc table assignment / same-doc clone of an
-    attached standard ``[k]`` section. Preserves per-slot trivia
-    (header leading, KV leading / EOL) and any nested sub-sections
-    by deep-cloning every owned slot and rebasing paths from
-    ``src_table._path`` to ``parent._path + (key,)``.
+    Used for cross-doc assignment and same-doc clone of an attached
+    ``[k]`` section. Preserves per-slot trivia and nested sub-sections
+    while rebasing paths under ``parent._path + (key,)``.
     """
     src_slots = _gather_subtree_slots(src_table)
     if not isinstance(src_slots[0], StructuralHeaderSlot):  # pragma: no cover
@@ -2541,16 +2431,13 @@ def _clone_entry_slots(
     entry header. Its ``entry`` is set to ``new_entry`` — so passing
     ``new_entry=None`` converts an aot-entry header to a table
     header, and passing a non-None ``new_entry`` does the inverse.
-    When ``has_header`` is False, the slot list is treated as
-    body-only (e.g. for in-place body replacement that keeps the
-    destination's existing header).
+    With ``has_header=False`` the list is body-only, used by in-place
+    body replacement that keeps the destination header.
 
-    ``body_owner`` is written to every slot's ``owner_aot_entry`` (so
-    cloning into a table that itself sits under another AoT entry
-    keeps physical ownership coherent). ``new_entry`` is the
-    AoTEntry the cloned slots are *logically* owned by — used for
-    the head's ``entry`` back-pointer and for the ``entry_slots``
-    membership list.
+    ``body_owner`` is written to every slot's ``owner_aot_entry`` so
+    cloning under another AoT entry keeps physical ownership coherent.
+    ``new_entry`` is the AoTEntry the cloned slots are *logically*
+    owned by.
 
     Nested aot-entry headers inside the body keep their AoT shape:
     a fresh `AoTEntry` is allocated per unique source entry found
@@ -2561,9 +2448,8 @@ def _clone_entry_slots(
     ``[[a.x]]`` to a duplicated ``[a.x]`` (issue #108).
 
     ``dst_newline`` is the destination document's line ending; every
-    cloned slot's structural-newline trivia is retargeted to it so a
-    cross-document graft does not leave alien ``\r\n`` / ``\n``
-    pieces behind in the destination's slot stream.
+    cloned slot's structural-newline trivia is retargeted so a
+    cross-document graft does not leave alien line endings behind.
     """
     body_start = 1 if has_header else 0
     nested_entry_map: dict[int, AoTEntry] = {}
@@ -2631,23 +2517,18 @@ def _populate_entry_views(
 ) -> None:
     """Walk cloned non-header slots, building child Container views.
 
-    Mirrors the parser's slot-builder for an entry: KV slots file
-    refs into their host container; sub-section headers create child
-    Containers under the entry root and file own-header refs +
-    parent-binding refs. Nested ``[[a.b]]`` aot-entry headers are
-    handled too: a fresh `AoT` view (and entry `Table`) is created
-    or extended at the rebased path so cross-doc graft preserves
-    AoT structure.
+    Mirrors the parser's slot-builder for an entry: KVs file refs into
+    their host container, sub-section headers create child Containers,
+    and nested ``[[a.b]]`` headers create/extend an `AoT` at the rebased
+    path so cross-doc graft preserves AoT structure.
 
     Owner inheritance: every newly created container inherits its
-    parent's ``_owner_aot_entry``, which matches how the parser
-    resolves implicit containers under an entry. The caller wires
-    the root ``entry_table`` with the correct owner.
+    parent's ``_owner_aot_entry``, matching parser behaviour for
+    implicit containers under an entry. The caller wires the root.
 
     Decoded Python values are derived from each slot's (already
-    deep-cloned) ``Value`` via ``_decode_value`` — never aliased
-    from the source dict — so the destination view is fully
-    independent of the source.
+    deep-cloned) ``Value`` via ``_decode_value``, never aliased from the
+    source dict.
     """
     from tomlrt._array import AoT  # noqa: PLC0415
     from tomlrt._build import _decode_value  # noqa: PLC0415
@@ -2911,13 +2792,10 @@ def _aot_append_anchor(aot: AoT, doc: Document) -> Slot | None:
     entry's whole subtree — including slots owned by nested ``[[a.sub]]``
     AoT entries, which ``entry_slots`` deliberately excludes.
 
-    Derived from the doc-stream rather than ``entry_slots[-1]`` so it is
-    correct regardless of ``entry_slots`` ordering and works when the
-    entry's subtree is physically non-contiguous (e.g. a ``[[a.sub]]``
-    separated from its parent entry by an unrelated ``[other]``).
-    Membership comes from ``_subtree_membership`` (``_refs`` + recursion);
-    order comes from a backward walk of the doc-stream — O(1) in the
-    common case where the AoT sits at the document tail.
+    Derived from the doc-stream rather than ``entry_slots[-1]`` so
+    ``entry_slots`` ordering and non-contiguous subtrees cannot misplace
+    the append. Membership comes from ``_subtree_membership``; order
+    comes from a backward doc-stream walk.
 
     For an empty AoT (no entries, or all entries slot-less) the anchor
     is the parent container's subtree tail, so the first materialised
@@ -3037,10 +2915,8 @@ def remove_aot_entry(aot: AoT, index: int) -> Table:
 
     Returns the popped entry ``Table`` itself (not a fresh copy), reset
     so it behaves as an unattached, freshly-constructed container —
-    mirroring `delete_key`'s orphan-transplant model. Any user-held
-    reference to the entry pre-pop is therefore the same object as the
-    return value, and remains usable for reads, mutations, and
-    re-attachment.
+    mirroring `delete_key`'s orphan-transplant model. User-held
+    references remain the same object and are reusable.
     """
     n = len(aot)
     if not -n <= index < n:
@@ -3056,8 +2932,7 @@ def remove_aot_entries(aot: AoT, indices: Iterable[int]) -> list[Table]:
 
     The indices must already be **non-negative, in-range, distinct,
     and ascending**; callers are responsible for normalising. Returns
-    the popped entry ``Table``s themselves (reset for re-use), in the
-    same order as ``indices``.
+    the reset popped entry ``Table``s in the same order as ``indices``.
 
     Batching matters because the per-pop ref-scrub is O(parent
     siblings); doing it once for the union of all popped entries'
@@ -3170,10 +3045,8 @@ def replace_aot_entry_with_clone(
     """Replace ``aot[index]`` with a deep clone of ``src_entry_table``.
 
     Preserves the *destination* entry header's leading trivia (and
-    therefore any pre-header comment block above the original
-    ``[[..]]`` line) while replacing the entry's body with a clone
-    of the source entry's slots — preserving the source's per-KV
-    leading / EOL / lexeme trivia.
+    any pre-header comment block) while replacing the body with a clone
+    of the source entry's slots, preserving source per-KV trivia.
 
     Both entries must be attached AoT-entry tables.
     """
@@ -3258,7 +3131,7 @@ def replace_aot_entry(aot: AoT, index: int, body: Mapping[str, Any] | None) -> N
 
     O(m) in the size of ``body``, independent of AoT length and
     document size. Header position and `_refs` ordering are preserved
-    by construction (no slot splicing involved).
+    because no slot splicing is involved.
     """
     n = len(aot)
     if not -n <= index < n:
@@ -3278,12 +3151,9 @@ def replace_aot_entry(aot: AoT, index: int, body: Mapping[str, Any] | None) -> N
 def renormalise_aot_order(aot: AoT, new_logical_order: Sequence[Table]) -> None:
     """Re-order an attached AoT's entries to ``new_logical_order``.
 
-    Implements the locked-in "normalise on reorder" policy from the
-    plan: snapshot a stable splice anchor (the slot just before the
-    AoT's first owned slot in doc-stream); unlink every slot owned
-    by any of this AoT's entries; reinsert the entries in the new
-    order, each entry as a contiguous block, immediately after the
-    anchor.
+    Normalises on reorder: snapshot the slot before the AoT's first
+    owned slot, unlink every owned entry slot, then reinsert entries in
+    the new order as contiguous blocks.
 
     ``new_logical_order`` must be a permutation of the AoT's current
     entries (same set of `Table` objects, possibly reordered).
@@ -3391,11 +3261,9 @@ def _splice_blocks_in_order(
 
     ``physical_blocks`` is the list of non-empty slot blocks in
     physical doc-stream order (``physical_blocks[0][0]`` is the
-    earliest owned slot). ``new_order_indices`` is a permutation of
-    ``range(len(physical_blocks))``: new position ``i`` is filled by
-    ``physical_blocks[new_order_indices[i]]``. ``new_head_leadings``
-    is the precomputed leading to stamp on each block's head at its
-    new position; indexed by new position.
+    earliest owned slot). ``new_order_indices`` maps each new position
+    to the old physical block index. ``new_head_leadings`` is indexed by
+    new position.
 
     The helper is purely permutational on the doc-stream linked
     list. Trivia policy (positional vs slot-attached) is the
@@ -3434,11 +3302,9 @@ def _find_binding_successor(parent: Container, key: str) -> Slot | None:
     ``(*parent._path, key)``, and returns the first non-matching slot
     (or ``None`` if the run extends to doc tail).
 
-    Used by ``Container._structural_overwrite`` to capture the original
-    successor of the binding's region — its ``leading`` is restored
-    after the new binding is moved back to the saved anchor, so that
-    the visual gap between the binding and what came after it survives
-    the ``del + set`` round-trip.
+    ``Container._structural_overwrite`` restores this successor's
+    ``leading`` after moving the new binding back, preserving the visual
+    gap across the ``del + set`` round-trip.
 
     The "first contiguous run" choice (rather than "last of all
     matches across the whole doc") matches the semantics of
@@ -3477,13 +3343,11 @@ def _move_slots_to_anchor(
 ) -> None:
     """Move ``slots`` to ``saved_anchor_prev`` in the doc-stream.
 
-    Splices the (contiguous) slot block immediately after
-    ``saved_anchor_prev`` (or to doc head if None), applies
-    ``saved_leading_pieces`` to the new head, and resorts the
-    affected ancestor ``_refs``. Used by the
+    Splices the contiguous block immediately after ``saved_anchor_prev``
+    (or to doc head), applies ``saved_leading_pieces`` to the new head,
+    and resorts affected ancestor ``_refs``. Used by the
     ``Container.__setitem__`` position-preserving structural replace
-    path: capture old position + leading before the replacement is
-    installed at end-of-doc, then move it back.
+    path.
 
     ``slots`` must be in doc-stream order and contiguous in the
     linked list (i.e. ``slots[i]._next is slots[i + 1]`` for all i).
@@ -3579,13 +3443,10 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
 
     ``new_key_order`` is trusted to be a permutation of
     ``dict.keys(c)``. Each key's slots — KV slots filed under the
-    key, plus any header / body / entry slots of a child section or
-    AoT, gathered from anywhere in the doc-stream — are spliced
-    together as one contiguous block at the key's new position. All
-    slots' leadings are preserved as-is, except the head of each
-    key's block (which receives the *positional separator* recorded
-    at its new position, plus the head slot's own attached-comment
-    remainder).
+    key, plus child section/AoT slots gathered from anywhere in the
+    doc-stream — are spliced together as one contiguous block. Only the
+    head of each block receives a new *positional separator*; attached
+    comments and other leadings travel with their slots.
 
     Non-contiguous keys (e.g. ``[a]; [other]; [a.sub]`` where 'a'
     has two runs at root) are handled by collecting both runs and
@@ -3595,13 +3456,9 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
     header and silently change its re-parse scope — which both keeps it
     correctly bound and lets the owned span be spliced contiguously.
 
-    If ``c`` owns an explicit (non-synthetic) ``[c]`` header, that
-    header is spliced in at the start of the reordered region — it
-    either precedes the first KV-only block (binding its direct KVs
-    to ``c``) or precedes the first structural block (vestigial but
-    valid). Without this, a structural-last reorder of a super-table
-    mixing nested AoTs with direct KVs would re-bind the KVs to the
-    document root.
+    If ``c`` owns an explicit (non-synthetic) ``[c]`` header, it moves
+    to the start of the reordered region so direct KVs stay bound to
+    ``c`` after re-parse.
 
     When ``c`` is an AoT entry (``c._owner_aot_entry is not None``),
     only slots within ``c``'s own subtree participate (see
@@ -3622,31 +3479,17 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
     c_path = c._path  # noqa: SLF001
     c_plen = len(c_path)
 
-    # c's own explicit header (if any) travels with the splice so
-    # that direct KVs of c keep their binding after re-parse. The
-    # leaf-before-structural check below guarantees KV blocks come
-    # first in new_key_order, so the header always belongs at the
-    # head of the splice. Unlike child blocks, the header is the
-    # region marker, not a sortable peer: it always sits at the new
-    # top of the region.
+    # c's explicit header is the region marker, not a sortable peer: it
+    # travels at the splice head so direct KVs keep their binding.
     header_slot: StructuralHeaderSlot | None = None
     header_ref = c._header_ref  # noqa: SLF001
     if header_ref is not None:
         assert isinstance(header_ref.slot, StructuralHeaderSlot)
-        # A non-synthetic header is always the region marker. An
-        # aot-entry header is too: it defines the entry's existence
-        # and can never be an elidable placeholder. A synthetic table
-        # header is the marker only when it currently binds a body
-        # (its next slot is a KV) — otherwise it is an elidable empty
-        # placeholder that should not anchor the region. This mirrors
-        # `_maybe_demote_synthetic_empty_header` exactly (same
-        # `synthetic AND kind == "table" AND empty` skip condition):
-        # reorder preserves a synthetic header exactly when demotion
-        # would keep it. Without this, a synthetic header that binds
-        # direct or dotted KVs (e.g. an `[a]` promoted by overwriting
-        # `a.b`) is skipped, and its body KVs are spliced ahead of
-        # every header — re-parse then rebinds them to the document
-        # root.
+        # Preserve exactly the synthetic headers demotion would keep:
+        # non-table/aot-entry headers, non-synthetic headers, and
+        # synthetic table headers that currently bind a KV body. Skipping
+        # such a header would splice its body KVs ahead of every header
+        # and rebind them to the document root.
         if (
             header_ref.slot.kind != "table"
             or not header_ref.slot.synthetic
@@ -3657,22 +3500,13 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
         ):
             header_slot = header_ref.slot
 
-    # 1. Walk the doc once, building blocks in physical doc-stream
-    # order. The c-header (if any) appears as a one-slot block at its
-    # own physical position; child keys appear as blocks at the
-    # position where they're first seen.
+    # Build blocks in physical doc-stream order. The c-header (if any)
+    # is a one-slot block; child keys appear where first seen.
     #
-    # A non-AoT container owns a unique table per path, so any slot a
-    # bind-key below matches is necessarily within c's subtree — no
-    # membership test is needed (and we skip the O(subtree) walk). An
-    # AoT entry, by contrast, shares its path with sibling entries, so
-    # restrict to c's own subtree: `_subtree_membership` is c's own
-    # slots plus those of every nested section and nested AoT entry,
-    # but not sibling entries (a different Table, outside the subtree).
-    # That is what lets a nested-AoT child — owned by its *own* entry
-    # rather than by c's — travel with its key while keeping sibling
-    # content out, mirroring how `renormalise_aot_order` blocks an
-    # entry by its whole subtree.
+    # Only AoT entries need a membership filter: they share paths with
+    # sibling entries, but nested AoT children owned by their own entries
+    # still move with their key. Non-AoT paths are unique, so matching
+    # bind-keys are necessarily within c's subtree.
     membership = (
         _subtree_membership(c)
         if c._owner_aot_entry is not None  # noqa: SLF001
@@ -3699,12 +3533,11 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
             key_blocks[bind_key].append(cur)
         cur = cur._next  # noqa: SLF001
 
-    # 2. Reject orders that would re-bind a leaf KV under a structural
+    # Reject orders that would re-bind a leaf KV under a structural
     # section header. A block with *any* leaf KV (a bare or dotted
     # ``key = value``) must not follow a structural block — including a
     # "mixed" key that owns both a leaf and a sub-section, whose leaf
-    # part would be captured. Slotless keys (empty AoT bindings) don't
-    # participate in physical layout, so skip them.
+    # part would be captured.
     def _has_leaf(slots: list[Slot]) -> bool:
         # Only a KV hosted directly by ``c`` (a bare or dotted leaf of
         # ``c``) can be captured by a preceding header; a KV under the
@@ -3734,17 +3567,11 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
 
     earliest_owned = physical_blocks[0][0]
 
-    # Foreign slots (belonging to an outer scope) interleaved in c's
-    # owned span must keep their re-parse scope across the gather below.
-    # A foreign slot in c's *containing* scope — a bare/dotted KV that
-    # appears before any foreign header in the span — must stay in that
-    # scope, so hoist it to the region head (ahead of the gathered run,
-    # where the containing scope is still open). A foreign *header*, and
-    # everything after it (its own body), establishes an independent
-    # scope: the ordinary gather leaves it after the reordered owned
-    # run, where it re-parses unchanged. Hoisting such a header instead
-    # would pull it ahead of c's dotted leaves and capture them — so we
-    # stop hoisting at the first foreign header.
+    # Foreign slots interleaved in c's owned span must keep their
+    # re-parse scope. Hoist foreign KVs that still belong to c's
+    # containing scope to the region head; stop at a foreign header,
+    # which establishes its own scope and would capture c's dotted leaves
+    # if hoisted.
     owned_ids = {id(s) for blk in physical_blocks for s in blk}
     front_foreign: list[Slot] = []
     seen = 1  # earliest_owned itself
@@ -3769,17 +3596,14 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
             list(head_structural.pieces) + list(front_foreign[0].leading.pieces)
         )
 
-    # 3. Snapshot region-external structural from the doc-stream-
-    # earliest owned slot. After reorder this becomes c-header's
-    # leading prefix (so doc preambles / above-region separators
-    # survive even when c-header was not physically first in source).
+    # Region-external prefix moves to c-header's leading so preambles /
+    # above-region separators survive even if c-header was not first.
     region_head_structural, region_head_remainder = _split_leading_for_reorder(
         doc, earliest_owned
     )
 
-    # c-header's own remainder (attached comments) always travels
-    # with it. The structural part is replaced by the region-
-    # external prefix above.
+    # c-header's attached comments travel with it; its structural prefix
+    # is replaced by the region-external prefix above.
     if header_slot is not None:
         if header_slot is earliest_owned:
             c_header_remainder = region_head_remainder
@@ -3788,12 +3612,9 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
     else:
         c_header_remainder = Trivia()
 
-    # 4. Snapshot child positional structurals + remainders. The gap
-    # above child-position-0 is meaningful only when c-header sat
-    # above the first child in source; otherwise the structural we'd
-    # capture there is region-external prefix (already consumed by
-    # c-header's new leading) and the in-source header→child gap
-    # didn't exist.
+    # Snapshot child positional prefixes. Child position 0 keeps a gap
+    # only if c-header actually sat above the first child in source; else
+    # that prefix is the region-external one already consumed above.
     child_keys_in_phys_order = sorted(phys_idx_of_key, key=phys_idx_of_key.__getitem__)
     child_physical_blocks = [key_blocks[k] for k in child_keys_in_phys_order]
     child_phys_pos_of_key: dict[str, int] = {
@@ -3815,13 +3636,9 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
         child_structural_at_new_pos.append(structural)
         child_remainder_of.append(remainder)
 
-    # 5. Build new_order_indices (permutation of physical_blocks
-    # indices) and new_head_leadings (indexed by new position).
-    #
-    # When c-header is present, it occupies new position 0; children
-    # follow at new positions 1..n. Each new child position k gets
-    # child_structural_by_position[k - (1 if header else 0)] +
-    # remainder of the block now placed there.
+    # c-header, when present, occupies new position 0; children follow.
+    # Each child position gets that position's structural prefix plus the
+    # moved block's attached-comment remainder.
     new_order_indices: list[int] = []
     new_head_leadings: list[Trivia] = []
 
@@ -3847,11 +3664,9 @@ def reorder_container(c: Container, new_key_order: list[str]) -> None:
         )
         new_child_pos += 1
 
-    # 6. Splice.
     _splice_blocks_in_order(doc, physical_blocks, new_order_indices, new_head_leadings)
 
-    # 7. Resort _refs / _index on c and ancestor chain; recompute
-    # cached body tails that the splice may have invalidated.
+    # Resort refs and recompute cached body tails invalidated by splice.
     chain: list[Container] = [c]
     anc: Container | None = c._parent  # noqa: SLF001
     while anc is not None:

--- a/src/tomlrt/_parser.py
+++ b/src/tomlrt/_parser.py
@@ -1,12 +1,8 @@
 """Hand-written recursive-descent parser.
 
-Walks the source via `_Scanner` and emits a flat ordered list of
-physical slots (`KVSlot` and `StructuralHeaderSlot`) plus the
-document's trailing trivia. Drives `_Validator` at three points:
-
-- when a header has just been parsed,
-- when a key/value line has just been built,
-- when a key inside an inline table is about to be added.
+Walks source via `_Scanner` and emits physical slots plus trailing
+trivia. Drives `_Validator` for headers, key/value lines, and
+inline-table keys.
 """
 
 from __future__ import annotations
@@ -31,10 +27,8 @@ if TYPE_CHECKING:
 class ParseResult:
     """The output of `_Parser.parse`.
 
-    `slots` is in physical document order. `trailing` is whatever
-    trivia (blank lines, comments) hangs at end-of-file after the
-    last slot. `newline` is the document-wide line ending detected
-    by the scanner.
+    `slots` is in physical document order. `trailing` is EOF trivia;
+    `newline` is the scanner-detected document-wide line ending.
     """
 
     slots: list[Slot] = field(default_factory=list)
@@ -53,21 +47,14 @@ class _Parser:
         self._validator = _Validator(self._sc.error)
         self._value_depth = 0
 
-    # ------------------------------------------------------------------
-    # Entry point
-    # ------------------------------------------------------------------
-
     def parse(self) -> ParseResult:
         result = ParseResult()
         sc = self._sc
         src = sc.src
         end = sc.end
 
-        # A leading UTF-8 BOM (U+FEFF) is permitted by TOML 1.1 only at
-        # the very start of the document. Strip it from the parse
-        # stream and stash it on `Document` as a prelude — keeping it
-        # orthogonal to the slot / trivia plumbing means user mutations
-        # (delete first slot, set leading_comments, ...) can never
+        # TOML 1.1 permits a leading UTF-8 BOM only at document start.
+        # Store it as Document prelude so slot/trivia mutations cannot
         # silently drop or duplicate it.
         if sc.pos < end and src[sc.pos] == "\ufeff":
             result.prelude = "\ufeff"
@@ -88,7 +75,7 @@ class _Parser:
                 slot = self._parse_key_value(leading)
             result.slots.append(slot)
 
-        # Stitch the doubly-linked list.
+        # Stitch the physical slot list.
         prev: Slot | None = None
         for slot in result.slots:
             slot._prev = prev  # noqa: SLF001
@@ -98,10 +85,6 @@ class _Parser:
 
         result.newline = sc.detected_newline()
         return result
-
-    # ------------------------------------------------------------------
-    # Headers
-    # ------------------------------------------------------------------
 
     def _parse_header(self, leading: Trivia) -> StructuralHeaderSlot:
         sc = self._sc
@@ -149,16 +132,11 @@ class _Parser:
             owner.entry_slots.append(slot)
         return slot
 
-    # ------------------------------------------------------------------
-    # Keys
-    # ------------------------------------------------------------------
-
     def _parse_key(self) -> tuple[list[KeyPart], list[str], str]:
         """Parse a dotted key.
 
-        Returns ``(parts, seps, trailing_ws)`` where ``trailing_ws`` is
-        the whitespace consumed after the last key part — usable
-        directly as the caller's ``pre_eq`` / ``inner_post`` field.
+        ``trailing_ws`` is consumed after the last key part and can be
+        used directly as ``pre_eq`` / ``inner_post``.
         """
         sc = self._sc
         parts: list[KeyPart] = [sc.scan_key_part()]
@@ -169,10 +147,6 @@ class _Parser:
                 return parts, seps, text
             seps.append(text)
             parts.append(sc.scan_key_part())
-
-    # ------------------------------------------------------------------
-    # Key/value lines
-    # ------------------------------------------------------------------
 
     def _parse_key_value(self, leading: Trivia) -> KVSlot:
         sc = self._sc
@@ -208,10 +182,6 @@ class _Parser:
             owner.entry_slots.append(slot)
         return slot
 
-    # ------------------------------------------------------------------
-    # Values
-    # ------------------------------------------------------------------
-
     def _parse_value(self) -> Value:
         sc = self._sc
         pos = sc.pos
@@ -231,8 +201,6 @@ class _Parser:
                 self._value_depth -= 1
         return sc.scan_value_atom()
 
-    # --- arrays -------------------------------------------------------
-
     def _parse_array(self) -> ArrayValue:
         sc = self._sc
         src = sc.src
@@ -242,8 +210,7 @@ class _Parser:
         head = sc.scan_array_trivia()
         end = sc.end
         if sc.pos < end and src[sc.pos] == "]":
-            # Empty array: head trivia is interior, attribute it to
-            # final_trivia (the canonical pre-`]` slot).
+            # Empty array: head trivia is the canonical pre-`]` slot.
             node.final_trivia = head
             sc.pos += 1
             return node
@@ -260,17 +227,14 @@ class _Parser:
                 post_comma, next_leading = split_eol_section(scanned)
                 items.append(ArrayItem(leading, value, trailing, True, post_comma))  # noqa: FBT003
                 if sc.pos < end and src[sc.pos] == "]":
-                    # Trailing-comma terminator: structural rest is the
-                    # bracket pad.
+                    # Trailing-comma terminator: rest is bracket pad.
                     node.final_trivia = next_leading
                     sc.pos += 1
                     return node
                 leading = next_leading
             elif ch == "]":
                 items.append(ArrayItem(leading, value, trailing, False, Trivia()))  # noqa: FBT003
-                # Terminal item with no trailing comma: split the
-                # trailing scan into the EOL section (stays on the
-                # item) and the structural bracket pad (final_trivia).
+                # No trailing comma: split item EOL from bracket pad.
                 eol, rest = split_eol_section(items[-1].trailing)
                 items[-1].trailing = eol
                 node.final_trivia = rest
@@ -279,8 +243,6 @@ class _Parser:
             else:
                 msg = f"expected ',' or ']' in array, got {ch!r}"
                 raise sc.error(msg)
-
-    # --- inline tables ------------------------------------------------
 
     def _parse_inline_table(self) -> InlineTableValue:
         sc = self._sc

--- a/src/tomlrt/_scalar.py
+++ b/src/tomlrt/_scalar.py
@@ -1,9 +1,7 @@
 """Scalar predicates and Python-to-TOML scalar coercion.
 
-These helpers are pure: they depend on `_values` for the wire-format
-`Value` types and on `datetime` for type discrimination, but they do
-not touch the container layer. Lifted out of `_container` so the same
-tests cover them in isolation and the container module shrinks.
+Pure helpers for wire-format `Value` types, kept out of the container
+layer.
 """
 
 from __future__ import annotations
@@ -22,8 +20,7 @@ from tomlrt._values import (
 
 def is_scalar(v: object) -> bool:
     """True iff ``v`` is a TOML scalar (and not an array / table)."""
-    # `bool` is an `int` subclass — explicit allow keeps the semantics
-    # in this gate clear.
+    # `bool` is an `int` subclass; keep the gate explicit.
     if isinstance(v, bool):
         return True
     if isinstance(v, (int, float, str)):
@@ -54,8 +51,7 @@ def float_lexeme(v: float) -> str:
         return "nan"
     if math.isinf(v):
         return "-inf" if v < 0 else "inf"
-    # repr() of any finite float always carries a fractional component or
-    # an exponent (e.g. "1.0", "1e+16"), both of which TOML accepts as-is.
+    # repr() of finite floats includes a TOML-accepted fraction or exponent.
     return repr(v)
 
 

--- a/src/tomlrt/_scanner.py
+++ b/src/tomlrt/_scanner.py
@@ -1,18 +1,13 @@
 """Cursor + scanner used by `tomlrt._parser`.
 
-The scanner owns the `(src, end, pos)` triple — it is the single
-cursor authority while the parser drives. Methods that recognise a
-syntactic construct return either a fully-formed CST node (for the
-messy, allocation-heavy bits like strings and trivia blocks) or a
-small tuple/`str` (for bare value tokens that the parser still
-needs to dispatch on).
+The scanner owns `(src, end, pos)`, so it is the parser's cursor
+authority. It returns CST nodes for source-preserving constructs and
+small tuples/strings for tokens the parser still dispatches.
 
-String scanning is, by design, *semantic* — escape sequences are
-decoded, surrogate code points are rejected, the leading newline
-after the opening triple-quote delimiter is trimmed, and the
-multi-line trailing-quote allowance is enforced. The returned
-`StringValue` carries both the raw lexeme (filled by `scan_string`)
-and the decoded value.
+String scanning is semantic: escapes are decoded, surrogates rejected,
+the leading newline after an opening triple quote trimmed, and the
+multi-line trailing-quote allowance enforced. `scan_string` fills the
+raw lexeme while preserving the decoded value.
 """
 
 from __future__ import annotations
@@ -44,17 +39,13 @@ if TYPE_CHECKING:
 # Comment body: anything except newline + control chars (tab is OK).
 _RE_COMMENT_BODY: Final = re.compile(r"[^\r\n\x00-\x08\x0b-\x1f\x7f]*")
 
-# Body of a basic string: any run of chars that are NOT a quote,
-# backslash, newline, or control char (control = U+0000-U+001F or
-# U+007F, except tab which we *do* allow).
+# Body of a basic string: not quote, backslash, newline, or control
+# char (U+0000-U+001F / U+007F, except tab).
 _RE_BASIC_STR_BODY: Final = re.compile(r'[^"\\\n\r\x00-\x08\x0b-\x1f\x7f]+')
-# Body of a literal string: anything except quote, newline, control
-# char (tab and newline-not-allowed handled by the caller).
+# Body of a literal string: no quote, newline, or control char.
 _RE_LITERAL_STR_BODY: Final = re.compile(r"[^'\n\r\x00-\x08\x0b-\x1f\x7f]+")
-# Body of a multi-line basic string fragment: stops at " or \\ or \r or
-# \n or a control char. \n and \r\n are valid in ML strings, so the
-# caller handles them; we stop at \r so the caller can verify it's
-# followed by \n and emit a normalized pair.
+# Body of a multi-line basic string fragment. Newlines are valid there,
+# so the caller handles them; stop at \r to verify CRLF before emitting it.
 _RE_ML_BASIC_BODY: Final = re.compile(r'[^"\\\r\n\x00-\x08\x0b-\x1f\x7f]+')
 _RE_ML_LITERAL_BODY: Final = re.compile(r"[^'\r\n\x00-\x08\x0b-\x1f\x7f]+")
 # Bare key: ASCII alphanum + underscore + dash. (TOML 1.1 broadens
@@ -70,19 +61,16 @@ _DEC_DIGITS: Final[frozenset[str]] = frozenset("0123456789")
 def _is_ascii_digits(s: str) -> bool:
     """Return True iff ``s`` is non-empty and contains only ASCII ``0-9``.
 
-    ``str.isdigit`` accepts Unicode decimal digits (e.g. Arabic-Indic
-    ``\u0660``) and ``int(s)`` will then happily parse them — but TOML
-    integer / float literals are restricted to the ASCII digit set.
+    ``str.isdigit`` and ``int(s)`` accept non-ASCII decimal digits, but
+    TOML integer / float literals are restricted to ASCII.
     """
     return bool(s) and all(c in _DEC_DIGITS for c in s)
 
 
-# First character that ends a bare-value token (whitespace, newline,
-# array/table close, comma, comment).
+# First character that ends a bare-value token.
 _RE_VALUE_END: Final = re.compile(r"[ \t\n\r,\]}#]")
 
-# Simple backslash-escape map, shared across every string parse so we
-# don't rebuild the dict on each escape character.
+# Shared simple backslash-escape map.
 _SIMPLE_ESCAPES: Final[dict[str, str]] = {
     "b": "\b",
     "t": "\t",
@@ -102,10 +90,8 @@ class _Scanner:
         self.src = src
         self.end = len(src)
         self.pos = 0
-        # Track newline kinds as we scan so the Document layer doesn't
-        # have to walk the entire CST to discover the file's line
-        # ending. ``"\r\n"`` is reported only when every emitted newline
-        # was CRLF; mixed or LF-only documents report ``"\n"``.
+        # Track newline kinds during scanning so Document needn't walk
+        # the CST. Report CRLF only when every emitted newline was CRLF.
         self._seen_lf = False
         self._seen_crlf = False
 
@@ -118,10 +104,6 @@ class _Scanner:
         if self._seen_crlf and not self._seen_lf:
             return "\r\n"
         return "\n"
-
-    # ------------------------------------------------------------------
-    # Cursor primitives
-    # ------------------------------------------------------------------
 
     def peek(self, offset: int = 0) -> str:
         """Return the character `offset` chars ahead of the cursor.
@@ -151,10 +133,6 @@ class _Scanner:
         self.pos += n
         return s
 
-    # ------------------------------------------------------------------
-    # Diagnostics
-    # ------------------------------------------------------------------
-
     def line_col(self, pos: int) -> tuple[int, int]:
         """Return the 1-based (line, column) for source offset `pos`."""
         line = 1
@@ -171,10 +149,6 @@ class _Scanner:
         offset = self.pos if at is None else at
         line, col = self.line_col(offset)
         return TOMLParseError(message, line=line, col=col, offset=offset)
-
-    # ------------------------------------------------------------------
-    # Trivia / comment scanners
-    # ------------------------------------------------------------------
 
     def scan_comment(self) -> CommentNode:
         """Consume a comment from `#` to (but not including) the newline.
@@ -200,9 +174,8 @@ class _Scanner:
     def scan_doc_trivia(self) -> Trivia:
         """Consume a document-scope trivia block.
 
-        Whitespace, blank lines and full-line comments. Stops *before*
-        the next non-trivia character on a line — so the structural
-        token (or EOF) follows immediately at the cursor.
+        Whitespace, blank lines and full-line comments are consumed.
+        Stops before the next structural token (or EOF).
         """
         trivia = Trivia()
         pieces = trivia.pieces
@@ -268,10 +241,8 @@ class _Scanner:
     def scan_inline_ws_text(self) -> str:
         """Consume one run of inline whitespace; return raw text (or "").
 
-        Like :meth:`scan_inline_ws` but skips the ``WhitespaceNode``
-        allocation. Used by parser sites that store the result as a
-        plain ``str`` (header inner_pre/inner_post, KV pre_eq/post_eq,
-        inline-table pre_eq/post_eq).
+        Like :meth:`scan_inline_ws`, but skips the ``WhitespaceNode``
+        allocation for parser fields stored as plain ``str``.
         """
         src = self.src
         end = self.end
@@ -360,20 +331,13 @@ class _Scanner:
             raise self.error(msg)
         return EolTrivia(trailing, comment, newline)
 
-    # ------------------------------------------------------------------
-    # Strings
-    # ------------------------------------------------------------------
-
     def scan_string(self, *, allow_multiline: bool = True) -> StringValue:
         """Scan a string starting at the cursor; populate `raw`.
 
-        Dispatches on the opening quote character: `"` -> basic,
-        `'` -> literal. The returned `StringValue` carries both the
-        verbatim source slice (for round-tripping) and the decoded
-        value; its `style` reflects the chosen flavour.
-
-        `allow_multiline` defaults to True; key parsers pass False
-        to reject multi-line strings in key position.
+        Dispatches on the opening quote character and returns a
+        `StringValue` with verbatim source (for round-tripping), decoded
+        value, and style. Key parsers pass ``allow_multiline=False`` to
+        reject multi-line strings.
 
         Precondition: cursor is at `"` or `'`. Callers always peek
         first; this is asserted, not validated.
@@ -468,8 +432,7 @@ class _Scanner:
                 return StringValue(lexeme="", value="".join(out))
             ch = self.peek()
             if ch == '"':
-                # Single or double quote (not the closing triple) — emit and
-                # continue. The body regex stops at any quote.
+                # Single or double quote, not the closing triple.
                 out.append('"')
                 self.pos += 1
                 continue
@@ -495,8 +458,7 @@ class _Scanner:
                             while self.peek() in (" ", "\t"):
                                 self.pos += 1
                         continue
-                    # Not actually a line-ending backslash; rewind and
-                    # treat as a normal escape.
+                    # Not a line-ending backslash; rewind and parse an escape.
                     self.pos = save
                 out.append(self._scan_escape())
                 continue
@@ -583,7 +545,7 @@ class _Scanner:
                 return StringValue(lexeme="", value="".join(out))
             ch = self.peek()
             if ch == "'":
-                # Single quote, not the closing triple — emit and continue.
+                # Single quote, not the closing triple.
                 out.append("'")
                 self.pos += 1
                 continue
@@ -638,10 +600,6 @@ class _Scanner:
             raise self.error(msg)
         return chr(cp)
 
-    # ------------------------------------------------------------------
-    # Keys
-    # ------------------------------------------------------------------
-
     def scan_key_part(self) -> KeyPart:
         """Scan one key part: bare, basic-quoted, or literal-quoted."""
         src = self.src
@@ -662,14 +620,9 @@ class _Scanner:
     def scan_key_separator(self) -> tuple[str, bool]:
         """Scan an optional dotted-key separator and trailing whitespace.
 
-        Returns ``(text, is_separator)``:
-
-        - If the next non-whitespace char is ``.``, consume ``ws "." ws``
-          and return ``(lexeme, True)``.
-        - Otherwise consume only the leading whitespace (if any) and
-          return ``(ws_text, False)``. The caller can use ``ws_text``
-          directly as the ``pre_eq`` / ``inner_post`` field, avoiding
-          a duplicate inline-ws scan.
+        If the next non-whitespace char is ``.``, consumes ``ws "." ws``
+        and returns ``(lexeme, True)``. Otherwise returns leading
+        whitespace as ``(ws_text, False)`` for ``pre_eq`` / ``inner_post``.
         """
         src = self.src
         end = self.end
@@ -692,20 +645,15 @@ class _Scanner:
         self.pos = sep_end
         return src[save:sep_end], True
 
-    # Bare value tokens: bool, special-float keywords, integer, float,
-    # date / time / datetime. The parser dispatches strings, arrays
-    # and inline tables itself; everything else funnels through
-    # ``scan_value_atom``.
+    # Bare value tokens: bool, special floats, numbers, and date/time values.
+    # The parser dispatches strings, arrays, and inline tables itself.
 
     def scan_value_atom(self) -> Value:
         """Scan a non-container, non-string value at the cursor.
 
-        Recognises bools, special floats (``inf`` / ``nan``, with
-        optional sign), integers, floats, and date/time/datetime
-        literals. Bool and special-float keywords are matched on the
-        whole bare token, so ``trueish`` / ``infinity`` reliably
-        error rather than silently parsing as ``true`` / ``inf``
-        followed by garbage.
+        Bool and special-float keywords are whole-token matches, so
+        ``trueish`` / ``infinity`` error rather than parsing as
+        ``true`` / ``inf`` followed by garbage.
         """
         start = self.pos
         end = self._scan_value_end(start)
@@ -746,29 +694,22 @@ class _Scanner:
         return self._parse_integer_token(token, at=start)
 
     def _scan_value_end(self, start: int) -> int:
-        """Return the offset of the first char that ends a bare value.
-
-        Stops at whitespace, newline, ``,``, ``]``, ``}``, ``#``, EOF.
-        """
+        """Return the offset of the first char that ends a bare value."""
         m = _RE_VALUE_END.search(self.src, start)
         return m.start() if m is not None else len(self.src)
 
     @staticmethod
     def _looks_like_datetime(token: str) -> bool:
-        # Date: ``YYYY-MM-DD``; local time: ``HH:MM:SS``; datetime
-        # contains both and is detected via the date head. The grammar
-        # restricts every digit position to ASCII 0-9; ``str.isdigit``
-        # also accepts other Unicode decimal digits, so use the strict
-        # ASCII check.
+        # Date uses ``YYYY-MM-DD``; local time uses ``HH:MM:SS``. The
+        # grammar requires ASCII digits, so don't use ``str.isdigit``.
         if len(token) >= 5 and token[4] == "-" and _is_ascii_digits(token[:4]):
             return True
         return bool(len(token) >= 3 and token[2] == ":" and _is_ascii_digits(token[:2]))
 
     @staticmethod
     def _looks_like_float(token: str) -> bool:
-        # A decimal float must contain ``.``, ``e`` or ``E``;
-        # hex/oct/bin integers never do. A leading sign is fine to
-        # keep since none of the marker characters are signs.
+        # Decimal floats contain ``.``, ``e`` or ``E``; hex/oct/bin
+        # integers never do.
         body = token[1:] if token[:1] in "+-" else token
         if body.startswith(("0x", "0o", "0b")):
             return False
@@ -881,9 +822,8 @@ class _Scanner:
         return FloatValue(token, value)
 
     def _parse_datetime_token(self, token: str, *, at: int) -> DateTimeValue:
-        # TOML allows a single space as the date/time separator. If we
-        # just scanned a 10-char date and the next chars look like
-        # ``" HH:..."``, fold them into one local-datetime token.
+        # Fold a TOML date followed by ``" HH:..."`` into one
+        # local-datetime token.
         src = self.src
         pos = self.pos
         if (
@@ -909,7 +849,6 @@ class _Scanner:
         at: int,
         raw: str,
     ) -> DateTimeValue:
-        # Local time?
         if len(text) >= 3 and text[2] == ":":
             try:
                 value = self._parse_time_text(text)

--- a/src/tomlrt/_slots.py
+++ b/src/tomlrt/_slots.py
@@ -1,12 +1,9 @@
 """Physical slot layer.
 
-A document is an ordered intrusive doubly-linked list of physical
-slots. Three slot kinds:
-
-- ``KVSlot`` — one ``key = value`` line (possibly dotted).
-- ``StructuralHeaderSlot`` — one ``[a.b]`` or ``[[a.b]]`` line.
-
-`SlotRef` is the per-container occurrence of a slot.
+A document is an intrusive doubly linked list of physical slots:
+``KVSlot`` for ``key = value`` lines and ``StructuralHeaderSlot`` for
+``[a.b]`` / ``[[a.b]]`` headers. `SlotRef` records a slot's occurrence
+in one container.
 """
 
 from __future__ import annotations
@@ -39,9 +36,8 @@ from tomlrt._values import render_dotted, retarget_value_newlines
 class AoTEntry:
     """Identifies one entry of an array-of-tables.
 
-    Carried by every physical slot that belongs to that entry
-    (``owner_aot_entry``). The ``entry_slots`` list is populated by
-    the slot-builder so render can iterate without scanning.
+    Carried by every physical slot in that entry. ``entry_slots`` is a
+    membership list populated by the slot-builder.
     """
 
     path: tuple[str, ...]
@@ -66,27 +62,22 @@ class Slot:
     owner_aot_entry: AoTEntry | None = None
     """The AoT entry that physically contains this slot, if any.
 
-    Set on every slot regardless of kind so the field is uniformly
-    typed at the base; both subclasses preserve `None` defaults.
+    Lives on the base so all slot kinds expose the field uniformly.
     """
 
     _refs: list[SlotRef] = field(default_factory=list, repr=False, compare=False)
     """Back-pointers from this slot to every `SlotRef` that references it.
 
-    Bounded length (≤ path depth + 1). Used by AoT removal to scrub
+    Bounded length (≤ path depth + 1). AoT removal uses this to scrub
     refs in O(depth) per slot instead of O(siblings) per container.
-    Maintained by `SlotRef.__post_init__` (registers) and
-    `unfile_ref` (unregisters).
     """
 
     def __deepcopy__(self, memo: dict[int, object]) -> Slot:
         """Deep-copy without following ``_refs``/``_prev``/``_next``.
 
-        Cloned slots start with a fresh empty ``_refs`` (callers
-        construct new ``SlotRef``s pointing at the clone) and
-        unlinked from any doc-stream chain (callers splice them in).
-        Following ``_prev``/``_next`` would otherwise drag the entire
-        source document into the deepcopy.
+        Clones start with empty refs and no doc-stream links; callers
+        file new refs and splice them in. Following ``_prev``/``_next``
+        would drag the whole source document into the deepcopy.
         """
         new = type(self).__new__(type(self))
         memo[id(self)] = new
@@ -110,10 +101,7 @@ class KVSlot(Slot):
     """A single ``key = value`` line."""
 
     host_path: tuple[str, ...] = field(kw_only=True)
-    """Full path of the host table — the table whose body this KV
-    physically belongs to. For top-level KVs ``()``; for KVs under
-    ``[a.b]`` ``("a", "b")``.
-    """
+    """Full path of the table body this KV physically belongs to."""
 
     key_parts: list[KeyPart] = field(kw_only=True)
     """The dotted-key parts as written. ``len >= 1``."""
@@ -129,11 +117,8 @@ class KVSlot(Slot):
     key: tuple[str, ...] = field(kw_only=True)
     """Decoded dotted-key path.
 
-    Set by every construction site (parser, mutation, synthesis).
-    The parser passes the tuple it already built for the validator;
-    mutation paths pass the path they were given. Read by
-    ``_build._apply_kv`` (and any future logic that wants the decoded
-    path without re-walking ``key_parts``).
+    Set by every construction site so ``_build._apply_kv`` can avoid
+    re-walking ``key_parts``.
     """
 
     def render_key(self) -> str:
@@ -152,10 +137,9 @@ class KVSlot(Slot):
 class StructuralHeaderSlot(Slot):
     """One ``[a.b]`` or ``[[a.b]]`` header line.
 
-    ``entry`` is the discriminator: an aot-entry header carries a
-    non-``None`` :class:`AoTEntry`; a plain table header carries
-    ``None``. The :attr:`kind` property is derived from ``entry``
-    so the two cannot drift apart.
+    ``entry`` is the discriminator: AoT-entry headers carry an
+    :class:`AoTEntry`, plain table headers carry ``None``. :attr:`kind`
+    is derived from ``entry`` so the two cannot drift.
     """
 
     path: tuple[str, ...] = field(kw_only=True)
@@ -201,10 +185,8 @@ class StructuralHeaderSlot(Slot):
 class SlotRef:
     """A per-container occurrence of a slot.
 
-    A `SlotRef` records that `slot` contributes to `container`'s
-    logical view. The key under which it is filed in
-    `container._index` is derived from the geometry of
-    (slot, container) and exposed via `local_key`.
+    `local_key` derives the key under which the ref is filed in
+    `container._index` from `(slot, container)` geometry.
     """
 
     __slots__ = ("container", "slot")
@@ -212,9 +194,8 @@ class SlotRef:
     def __init__(self, slot: Slot, container: Container) -> None:
         self.slot = slot
         self.container = container
-        # Register on the slot's back-pointer list so AoT removal
-        # can scrub all containers holding refs to a doomed slot
-        # without scanning the slot's ancestors.
+        # Back-pointers let AoT removal scrub doomed slots without
+        # scanning ancestor containers.
         slot._refs.append(self)  # noqa: SLF001
 
     @property
@@ -222,9 +203,8 @@ class SlotRef:
         """Key under which this ref is filed in ``container._index``.
 
         ``None`` for the container's own header ref (which lives in
-        ``_refs`` + ``_header_ref``, not in ``_index``); otherwise a
-        single path component, derived from the slot's logical path
-        and the container's depth.
+        ``_refs`` + ``_header_ref``, not ``_index``); otherwise a single
+        path component derived from the slot path and container depth.
         """
         slot = self.slot
         c_path = self.container._path  # noqa: SLF001
@@ -240,10 +220,7 @@ def retarget_slot_newlines(slot: Slot, target: str) -> None:
     """Rewrite every ``NewlineNode.text`` reachable from ``slot`` to ``target``.
 
     Used by graft paths so cross-document spliced slots adopt the
-    destination document's line ending. Walks the slot's leading
-    trivia, its EOL (for ``KVSlot`` / ``StructuralHeaderSlot``), and
-    recurses into any nested ``ArrayValue`` / ``InlineTableValue``
-    on a ``KVSlot``.
+    destination document's line ending, including nested inline values.
     """
     retarget_trivia_newlines(slot.leading, target)
     if isinstance(slot, KVSlot):

--- a/src/tomlrt/_trivia.py
+++ b/src/tomlrt/_trivia.py
@@ -1,10 +1,7 @@
-"""Trivia primitives.
+"""Represent source-preserving whitespace, newlines, and comments.
 
-A `Trivia` is an ordered run of `TriviaPiece`s — whitespace,
-newlines, and comments. Trivia hangs off slots and value nodes;
-together with the `lexeme`/`raw` of value-bearing nodes the trivia
-captures every byte of the source so the document round-trips
-exactly.
+Trivia hangs off slots and value nodes; together with value lexemes it
+captures every byte needed for exact round-trips.
 """
 
 from __future__ import annotations
@@ -77,9 +74,7 @@ def trivia_has_newline(t: Trivia) -> bool:
 def split_lines(pieces: list[TriviaPiece]) -> list[list[TriviaPiece]]:
     """Group ``pieces`` into logical lines terminated by ``NewlineNode``.
 
-    Each inner list is the pieces that appeared on a single source line
-    up to and including the terminating newline (if any). A trailing
-    run without a newline becomes the final inner list.
+    A trailing run without a newline becomes the final inner list.
     """
     out: list[list[TriviaPiece]] = []
     cur: list[TriviaPiece] = []
@@ -106,10 +101,8 @@ def line_has_newline(line: list[TriviaPiece]) -> bool:
 def retarget_trivia_newlines(t: Trivia, target: str) -> None:
     """Rewrite every ``NewlineNode.text`` in ``t`` to ``target``.
 
-    Used by graft paths (cross-document clone / inline-value
-    deepcopy) so freshly-spliced slots adopt the destination
-    document's line ending instead of preserving the source's. A
-    no-op when every newline already matches.
+    Grafted slots adopt the destination document's line ending rather
+    than preserving the source's.
     """
     for p in t.pieces:
         if isinstance(p, NewlineNode) and p.text != target:
@@ -125,26 +118,15 @@ def retarget_eol_newline(eol: EolTrivia, target: str) -> None:
 def split_above_block(t: Trivia) -> tuple[Trivia, Trivia]:
     """Split ``t`` into ``(pad, above)``.
 
-    ``above`` is the item-attached comment block and ``pad`` is the
-    structural padding that surrounds it (opening newline + value
-    indent).
+    ``above`` is the item-attached comment block; ``pad`` is the
+    opening newline plus value indent that surrounds it. Boundary
+    mutators use this to move an above-item block between bracket pads
+    and item-leading trivia.
 
-    Used by inline-array / inline-table mutators to relocate an
-    above-item comment block from one item's leading slot to another's
-    when the boundary item changes (``insert(0)``, ``del[0]``, sort,
-    reverse, slice assignment at index 0, append onto an array whose
-    ``final_trivia`` carries an above-`]` comment block).
-
-    Two parts are returned, but they are *not* a simple concatenation:
-    the comment block lives between the opening newline (a single
-    ``NewlineNode`` from ``pad``) and the trailing value indent (the
-    rest of ``pad``). To reconstruct, splice ``above`` between
-    ``pad[0]`` and ``pad[1:]`` (use :func:`join_above_block`).
-
-    By construction ``above`` is the run of pieces strictly between
-    the first ``NewlineNode`` and the trailing whitespace immediately
-    preceding nothing (or the end of trivia). ``above`` is empty iff
-    no ``CommentNode`` appears in that run.
+    The parts are *not* a simple concatenation: reconstruct with
+    :func:`join_above_block`, which splices ``above`` between
+    ``pad[0]`` and ``pad[1:]``. ``above`` is empty iff that middle
+    region contains no ``CommentNode``.
     """
     pieces = t.pieces
     first_nl = -1
@@ -154,12 +136,10 @@ def split_above_block(t: Trivia) -> tuple[Trivia, Trivia]:
             break
     if first_nl < 0:
         return Trivia(list(pieces)), Trivia()
-    # Trailing-WS run (zero or one piece).
     tail_start = len(pieces)
     if tail_start > first_nl + 1 and isinstance(pieces[tail_start - 1], WhitespaceNode):
         tail_start -= 1
     middle = pieces[first_nl + 1 : tail_start]
-    # ``above`` is non-empty only if a CommentNode appears in middle.
     if not any(isinstance(p, CommentNode) for p in middle):
         return Trivia(list(pieces)), Trivia()
     pad = Trivia(list(pieces[: first_nl + 1]) + list(pieces[tail_start:]))
@@ -215,18 +195,14 @@ def restamp_bracket_pad_for_first(
 ) -> tuple[Trivia, Trivia]:
     r"""Reframe an empty bracket pad ahead of inserting the first item.
 
-    Given an empty bracketed value's ``final_trivia`` (which owns
-    everything between ``[`` / ``{`` and ``]`` / ``}``), returns the
-    ``(header_trivia, final_trivia)`` pair appropriate for an
+    For an empty value, ``final_trivia`` owns everything between the
+    brackets. Return the ``(header_trivia, final_trivia)`` pair for an
     about-to-be-inserted first item:
 
-    * Empty pad → returns two empty trivia (no-op).
-    * Single-line pad (no newline, e.g. ``[ ]``) → mirrors the pad on
-      both sides so both bracket faces stay padded.
-    * Multi-line pad (newline present, e.g. ``[\n]``) → splits at the
-      last newline. Everything up to and including that newline (plus
-      a value-indent) becomes the new ``header_trivia``; just the
-      newline becomes the new ``final_trivia``.
+    * Empty pad: two empty trivia.
+    * Single-line pad: mirror the pad on both bracket faces.
+    * Multi-line pad: split at the last newline; keep a value-indent
+      on ``header_trivia`` and the row break on ``final_trivia``.
 
     Shared between :class:`Array` and inline-table append paths.
     """
@@ -250,26 +226,15 @@ def restamp_bracket_pad_for_first(
 def strip_trailing_indent(header_trivia: Trivia, final_trivia: Trivia) -> None:
     r"""Normalise an emptied bracket pad to canonical empty form.
 
-    Used after deleting the last item / entry of a multi-line inline
-    array or inline table. On entry, ``header_trivia`` may still hold
-    the per-item indent (and possibly an above-item comment block /
-    bracket-EOL comment glued to the opening bracket) that anchored
-    the now-removed first item.
+    After deleting the last item, ``header_trivia`` may still hold the
+    removed item's indent or a bracket-EOL comment. Without comments,
+    drop the trailing whitespace/newline run so ``final_trivia`` owns
+    the canonical empty ``[\\n]`` / ``{\\n}`` newline.
 
-    * If ``header_trivia`` contains no ``CommentNode``, drop the
-      entire trailing ``WhitespaceNode`` / ``NewlineNode`` run,
-      restoring the canonical empty form ``[\\n]`` / ``{\\n}`` —
-      ``header_trivia`` empty, ``final_trivia`` holds the single
-      newline.
-    * If ``header_trivia`` contains a ``CommentNode`` (a bracket-EOL
-      comment glued to the opening bracket), drop the trailing indent
-      ``WhitespaceNode`` run, then migrate the surviving comment
-      block from ``header_trivia`` into ``final_trivia``. The
-      parse-empty canonical form is ``[ # tail\\n]`` / ``{ # tail\\n}``
-      with everything between the brackets owned by ``final_trivia``;
-      this migration makes the strip-empty state structurally
-      identical so a subsequent append correctly re-stamps the pad
-      via :func:`restamp_bracket_pad_for_first`.
+    With a bracket-EOL comment, migrate the surviving block into
+    ``final_trivia``. That matches the parse-empty ownership for
+    ``[ # tail\\n]`` / ``{ # tail\\n}``, so the next append can
+    re-stamp via :func:`restamp_bracket_pad_for_first`.
     """
     has_comment = any(isinstance(p, CommentNode) for p in header_trivia.pieces)
     if not has_comment:
@@ -296,17 +261,13 @@ def strip_trailing_indent(header_trivia: Trivia, final_trivia: Trivia) -> None:
 def split_item_above(t: Trivia) -> tuple[Trivia, Trivia, Trivia]:
     """Split an item-leading region into ``(head_pad, above, tail_pad)``.
 
-    Distinct from :func:`split_above_block` — which is for the bracket
-    pad (``header_trivia`` / ``final_trivia``) and treats a pre-NL
-    comment as an EOL glued to the bracket. This splitter is for
-    ``items[i].leading`` (i >= 1) in an inline array or inline table,
-    where there is no bracket and the leading NL may be absent
-    because item ``i-1``'s EOL hoisted it onto its
-    ``post_comma_trivia``.
+    Unlike :func:`split_above_block`, this is for ``items[i].leading``
+    (i >= 1) where there is no bracket and the leading newline may
+    have been hoisted onto item ``i-1``'s EOL section.
 
     ``head_pad`` is the leading NL (or empty); ``tail_pad`` is the
-    trailing value-indent WS (or empty); ``above`` is the comment
-    block between them (typically ``[WS, Comment, NL] * n``).
+    trailing value-indent WS (or empty); ``above`` is the comment block
+    between them.
     """
     rest = list(t.pieces)
     head: list[TriviaPiece] = []
@@ -321,19 +282,15 @@ def split_item_above(t: Trivia) -> tuple[Trivia, Trivia, Trivia]:
 def split_eol_section(t: Trivia) -> tuple[Trivia, Trivia]:
     """Split ``t`` into the inline EOL section and the structural rest.
 
-    Used to canonicalise post-comma trivia in inline arrays and inline
-    tables.  The "EOL section" is the row-attached part: any inline
-    whitespace, an EOL comment, and the terminating newline of that
-    comment row.  Anything beyond — additional newlines, indent,
-    above-item comment blocks — is structural and belongs to the
-    *next* item's leading.
+    The EOL section is row-attached: inline whitespace, an EOL comment,
+    and that row's terminating newline. Anything beyond — additional
+    newlines, indent, above-item blocks — is structural and belongs to
+    the *next* item's leading.
 
     If no EOL comment is present on the comma's row, the whole input
-    is structural and the EOL half is empty.
-
-    Note: when no comment is present, ``t`` itself is returned as the
-    structural half — callers must treat it as owned by the result and
-    must not retain or mutate the original.
+    is structural and the EOL half is empty. In that case ``t`` itself
+    is returned as the structural half; callers must treat it as owned
+    by the result.
     """
     pieces = t.pieces
     n = len(pieces)

--- a/src/tomlrt/_typecheck.py
+++ b/src/tomlrt/_typecheck.py
@@ -1,15 +1,11 @@
 """Runtime type-checks for user-supplied keys and mappings.
 
-Pure functions with no dependencies on the container / array layers,
-so any module that accepts user-supplied data at a public boundary
-(``_container``, ``_array``, …) can import them without participating
-in the circular-import graph that those layers form among themselves.
+These pure helpers have no container / array dependencies, so public
+API boundaries can import them without joining that circular-import
+graph.
 
-Distinct from :mod:`tomlrt._validator`, which is the stateful TOML
-*semantic* validator that the parser drives to enforce cross-section
-grammar rules (a key bound as a value cannot later open a table, an
-explicit ``[a]`` cannot redefine an already-opened table, etc.).
-This module is API-boundary plumbing, not parse-time machinery.
+Unlike :mod:`tomlrt._validator`, this module handles runtime API input
+validation, not parse-time TOML semantics.
 """
 
 from __future__ import annotations
@@ -41,14 +37,10 @@ def _validate_key(key: object) -> str:
 def _validate_mapping(value: object, *, label: str) -> Mapping[str, Any]:
     """Reject a non-Mapping ``value`` or any Mapping with non-string keys.
 
-    Returns the validated mapping unchanged — identity is preserved so
-    downstream paths that branch on the concrete type (e.g. ``Table``
-    vs plain ``dict``) keep working. Centralising this means every
-    factory / mutator boundary produces the same wording
-    (``"<label> must be a Mapping"`` / ``"TOML keys must be str"``)
-    instead of leaking
-    ``AttributeError: 'list' object has no attribute 'items'`` from
-    inside the layout pipeline.
+    Returns the mapping unchanged so downstream paths that branch on
+    concrete type (e.g. ``Table`` vs ``dict``) keep working. Centralise
+    this so every factory / mutator boundary reports the same errors
+    instead of leaking layout-pipeline ``AttributeError``s.
     """
     if _check_str_mapping(value, label=label):
         return value
@@ -58,15 +50,11 @@ def _validate_mapping(value: object, *, label: str) -> Mapping[str, Any]:
 def _check_str_mapping(value: object, *, label: str) -> TypeIs[Mapping[str, Any]]:
     """Validate-or-raise ``TypeIs`` predicate for ``Mapping[str, Any]``.
 
-    Performs the runtime check in a single pass and raises a labelled
-    ``TypeError`` on failure. The ``TypeIs`` return type lets the type
-    checker narrow ``value`` to ``Mapping[str, Any]`` at the call site
-    in the ``True`` branch.
+    Raises a labelled ``TypeError`` on failure. The ``TypeIs`` return
+    lets callers narrow ``value`` in the ``True`` branch.
 
-    Returns ``True`` on success and never returns ``False`` (every
-    rejection raises), so callers can write ``if _check_str_mapping(v):
-    return v`` to drive the narrowing. Don't use ``assert`` — it would
-    be stripped under ``python -O``, skipping validation entirely.
+    Never returns ``False``; every rejection raises. Don't replace this
+    with ``assert``, which ``python -O`` would strip.
     """
     if not isinstance(value, Mapping):
         msg = f"{label} must be a Mapping, got {type(value).__name__}"

--- a/src/tomlrt/_validator.py
+++ b/src/tomlrt/_validator.py
@@ -1,18 +1,10 @@
 """Semantic validator for parsed TOML.
 
-The parser drives this with two operations:
+The parser calls this for headers, key/value lines, and inline-table
+local duplicate / dotted-prefix checks.
 
-- ``enter_header(path, kind, at)`` when a ``[H]`` / ``[[H]]``
-  header has just been parsed.
-- ``record_keyvalue(key_path, value, at)`` when a ``key = value``
-  line has just been built.
-
-Plus ``check_inline_key_conflict`` for inline-table local
-duplicate / dotted-prefix detection.
-
-The validator also tracks the active ``AoTEntry`` per AoT path so
-the parser can attach the correct owning entry to each physical
-slot it builds.
+It also tracks the active ``AoTEntry`` per AoT path so the parser can
+attach the correct owner to each physical slot.
 """
 
 from __future__ import annotations
@@ -61,15 +53,9 @@ class _Validator:
         self._aot_subpaths: dict[tuple[str, ...], list[tuple[str, ...]]] = {}
         self._current_section: tuple[str, ...] = ()
 
-        # AoT-entry tracking. ``_active_aot_entries`` maps each
-        # currently-open AoT path to the most recent AoTEntry opened
-        # there.
+        # Active AoT paths map to their most recently opened entry.
         self._active_aot_entries: dict[tuple[str, ...], AoTEntry] = {}
         self._current_owner_aot_entry: AoTEntry | None = None
-
-    # ------------------------------------------------------------------
-    # Public read accessors used by the slot-builder.
-    # ------------------------------------------------------------------
 
     def current_section(self) -> tuple[str, ...]:
         return self._current_section
@@ -77,17 +63,12 @@ class _Validator:
     def current_owner_aot_entry(self) -> AoTEntry | None:
         return self._current_owner_aot_entry
 
-    # ------------------------------------------------------------------
-    # Headers
-    # ------------------------------------------------------------------
-
     def enter_header(
         self, path: tuple[str, ...], kind: HeaderKind, *, at: int
     ) -> AoTEntry | None:
         """Validate a ``[H]`` / ``[[H]]`` header.
 
-        Returns the freshly-opened ``AoTEntry`` when ``kind ==
-        "aot-entry"``; otherwise ``None``.
+        Returns the opened ``AoTEntry`` for ``[[H]]``, otherwise ``None``.
         """
         # Prefix overlaps with a bound value would mean overwriting a scalar
         # (or an inline-table value) with a table — always invalid.
@@ -129,8 +110,7 @@ class _Validator:
                     "already used as an implicit table"
                 )
                 raise self._error(msg, at=at)
-            # Opening a new AoT entry at `path` invalidates any per-entry
-            # tracking that was scoped to the previous entry.
+            # A new AoT entry invalidates per-entry tracking under it.
             self._reset_scope_under(path)
             self._aot_paths.add(path)
             self._track(path)
@@ -169,10 +149,6 @@ class _Validator:
             if entry is not None:
                 return entry
         return None
-
-    # ------------------------------------------------------------------
-    # Key/value lines
-    # ------------------------------------------------------------------
 
     def record_keyvalue(
         self, key_path: tuple[str, ...], value: Value, *, at: int
@@ -224,10 +200,6 @@ class _Validator:
                 if isinstance(item.value, InlineTableValue):
                     self._register_inline_table(item.value, abs_prefix=None)
 
-    # ------------------------------------------------------------------
-    # Inline tables
-    # ------------------------------------------------------------------
-
     def check_inline_key_conflict(
         self,
         path: tuple[str, ...],
@@ -277,10 +249,6 @@ class _Validator:
                     if isinstance(item.value, InlineTableValue):
                         self._register_inline_table(item.value, abs_prefix=None)
 
-    # ------------------------------------------------------------------
-    # AoT scope tracking
-    # ------------------------------------------------------------------
-
     def _track(self, p: tuple[str, ...]) -> None:
         aot_paths = self._aot_paths
         if not aot_paths:
@@ -304,7 +272,6 @@ class _Validator:
             self._explicit_table_paths.discard(p)
             self._implicit_table_paths.discard(p)
             self._aot_paths.discard(p)
-            # Also clear active AoT entry tracking under this path.
             self._active_aot_entries.pop(p, None)
         for nested in nested_aots:
             self._reset_scope_under(nested)

--- a/src/tomlrt/_values.py
+++ b/src/tomlrt/_values.py
@@ -1,14 +1,8 @@
-"""Value types — the inline-value layer.
+"""Represent byte-exact inline TOML values.
 
-Every TOML value (scalar, inline array, inline table) is one of
-these. They are pure data: no document/slot stream awareness.
-
-Each scalar carries its source ``lexeme`` together with the
-decoded Python value so that re-emission is byte-exact.
-
-`ArrayValue` and `InlineTableValue` carry their full internal
-layout (every separator, comment, and whitespace run) for the
-same reason.
+Values are pure data with no slot-stream awareness. Scalars carry their
+source ``lexeme``; arrays and inline tables carry every separator,
+comment, and whitespace run needed for exact re-emission.
 """
 
 from __future__ import annotations
@@ -155,12 +149,8 @@ class CommaItem:
     """One slot inside a comma-separated value.
 
     Layout: ``leading value trailing [comma post_comma_trivia]``.
-    Shared base of the two concrete leaves: `ArrayItem` (bare value,
-    used by `ArrayValue`) and `InlineTableEntry` (with a ``key = ``
-    prefix, used by `InlineTableValue`). The two leaves are siblings,
-    not parent/child — annotate with `CommaItem` when working
-    polymorphically over both, and with the concrete leaf when the
-    caller is flavour-specific.
+    Shared base of sibling leaves `ArrayItem` and `InlineTableEntry`;
+    use `CommaItem` only at polymorphic call sites.
     """
 
     leading: Trivia
@@ -178,21 +168,15 @@ class CommaItem:
 
 @dataclass(slots=True, eq=False)
 class ArrayItem(CommaItem):
-    """One bare-value slot inside an inline array.
-
-    Adds no fields over `CommaItem`; exists as a distinct concrete
-    leaf so `ArrayValue.items: list[ArrayItem]` narrows away
-    `InlineTableEntry` at the type level.
-    """
+    """Represent one bare-value slot inside an inline array."""
 
 
 @dataclass(slots=True, eq=False)
 class InlineTableEntry(CommaItem):
     """One ``key = value`` slot inside an inline table.
 
-    Extends `CommaItem` with the key prefix. The shared trivia +
-    comma machinery lives on the base; only the key-prefix fields
-    and the keyed-form `render` are added here.
+    The shared trivia/comma machinery lives on `CommaItem`; this leaf
+    adds only the key-prefix fields and keyed rendering.
     """
 
     key_parts: list[KeyPart] = field(kw_only=True)
@@ -202,12 +186,8 @@ class InlineTableEntry(CommaItem):
     key_path: tuple[str, ...] = field(kw_only=True)
     """Decoded dotted-key path.
 
-    Set by every construction site (parser, mutation, synthesis). The
-    parser passes the tuple it already built for inline-key conflict
-    detection; mutation paths pass the path they were given. Read by
-    ``_validator._register_inline_table`` and
-    ``_build._decode_inline_table`` (also reached via cross-document
-    clone of inline-table entries).
+    Set by every construction site and read by inline-table validation,
+    decoding, and cross-document cloning.
     """
 
     def render_key(self) -> str:
@@ -225,12 +205,6 @@ class InlineTableEntry(CommaItem):
         return out
 
 
-# Any per-item shape — bare `ArrayItem` or keyed `InlineTableEntry`.
-# `CommaItem` is the real base class of both; use it at call sites
-# that are polymorphic over the two flavours, and use the concrete
-# leaf where the code is flavour-specific.
-
-
 _ItemT = TypeVar("_ItemT", bound=CommaItem)
 
 
@@ -238,25 +212,18 @@ _ItemT = TypeVar("_ItemT", bound=CommaItem)
 class CommaValue(Generic[_ItemT]):
     """Shared backbone of `ArrayValue` and `InlineTableValue`.
 
-    Trivia ownership (canonical model):
-      - ``header_trivia`` owns the gap immediately after the opening
-        bracket and before the first item — bracket pad / leading
-        newline / indent / interior comments above item 0.
+    Canonical trivia ownership:
+      - ``header_trivia`` owns the gap after the opening bracket and
+        before item 0: bracket pad, leading newline, indent, comments.
       - ``items[0].leading`` is always empty.
-      - ``items[k].leading`` (k >= 1) owns the entire physical gap
-        before items[k]: structural newline + indent + above-item
-        comment block + indent before the value.
+      - ``items[k].leading`` (k >= 1) owns the physical gap before
+        item k, including structural newline, indent, and above-block.
       - ``items[k].post_comma_trivia`` carries only the row-attached
-        EOL section: same-line whitespace + EOL comment + the
-        terminating newline of that comment row.  Empty if no EOL
-        comment.
+        EOL section: same-line whitespace, comment, and row newline.
       - ``final_trivia`` owns the gap before the closing bracket
-        (bracket pad / trailing newline). For an empty value this is
-        the only place interior trivia can live.
+        and is the only interior owner for an empty value.
 
-    Concrete subclasses bind ``_ItemT`` to the item flavour they hold
-    and set ``_open`` / ``_close`` ClassVars to the appropriate
-    brackets.
+    Concrete subclasses bind ``_ItemT`` and set the bracket ClassVars.
     """
 
     items: list[_ItemT] = field(default_factory=list)
@@ -308,11 +275,7 @@ Value = (
 
 
 def item_breaks_before_comma(item: CommaItem) -> bool:
-    """True iff the row break (and any EOL comment) precedes the comma.
-
-    The single canonical test for the comma-first / leading-comma
-    layout.
-    """
+    """Return whether the row break and any EOL comment precede the comma."""
     return item.has_comma and trivia_has_newline(item.trailing)
 
 
@@ -343,11 +306,8 @@ def inter_item_separator(items: Sequence[CommaItem]) -> Trivia:
 def value_is_multiline(v: ArrayValue | InlineTableValue) -> bool:
     """Shape detection: any structural ``NewlineNode`` inside means multi-line.
 
-    Inspects every trivia region that can hold a structural newline
-    under the canonical model (``header_trivia`` / ``final_trivia`` /
-    per-item ``leading`` / ``trailing`` / ``post_comma_trivia``).
-    Sufficient and correct independent of which subset of those
-    regions actually carries the row breaks in a given layout.
+    Inspect every trivia region that can carry a row break under the
+    canonical model; layouts differ in which channel owns it.
     """
     if trivia_has_newline(v.header_trivia) or trivia_has_newline(v.final_trivia):
         return True
@@ -364,13 +324,9 @@ def value_is_multiline(v: ArrayValue | InlineTableValue) -> bool:
 def retarget_value_newlines(v: Value, target: str) -> None:
     """Recursively rewrite every ``NewlineNode.text`` under ``v`` to ``target``.
 
-    Walks the trivia inside ``ArrayValue`` / ``InlineTableValue``
-    containers (header / final / per-item) and recurses into nested
-    values. Scalar values have no trivia and are no-ops.
-
-    Multi-line string content lives in ``StringValue.lexeme``, NOT
-    in ``NewlineNode``, so this walk preserves any literal CR/LF
-    bytes inside string values.
+    Scalar values have no trivia. Multi-line string content lives in
+    ``StringValue.lexeme``, not ``NewlineNode``, so literal CR/LF bytes
+    inside strings are preserved.
     """
     if not isinstance(v, CommaValue):
         return

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -4323,3 +4323,80 @@ def test_section_overwrite_inside_aot_entry_preserves_position() -> None:
         [[a]]
         x = 2
         """)
+
+
+def test_reassign_section_keeps_aot_children_in_place() -> None:
+    """Overwriting a section keeps its AoT children under it, not at EOF (#172).
+
+    The structural-replace path reinstalls at the doc tail then moves the
+    installed block back to the anchor. The AoT child is rehomed via the
+    clone path; the install recorder must capture those cloned slots so
+    the whole block (header + body + AoT entries) relocates together,
+    rather than stranding the AoT after later sibling sections.
+    """
+    src = td("""
+        [tool.x]
+        a = 1
+
+        [[tool.x.files]]
+        glob = "./**/*.py"
+
+        [[tool.x.files]]
+        filename = "./pyproject.toml"
+        search = "old"
+
+        [tool.y]
+        b = 2
+
+        [tool.z]
+        c = 3
+        """)
+    doc = tomlrt.loads(src)
+    new_section = Table.section({"a": 99})
+    new_section["files"] = doc["tool"]["x"]["files"]
+    doc["tool"]["x"] = new_section
+    assert tomlrt.dumps(doc) == td("""
+        [tool.x]
+        a = 99
+
+        [[tool.x.files]]
+        glob = "./**/*.py"
+
+        [[tool.x.files]]
+        filename = "./pyproject.toml"
+        search = "old"
+
+        [tool.y]
+        b = 2
+
+        [tool.z]
+        c = 3
+        """)
+
+
+def test_reassign_only_section_with_aot_child() -> None:
+    """Overwriting the sole section (empty-doc reinstall) keeps the AoT under it.
+
+    Exercises the empty-doc insertion path during reinstall (the block is
+    spliced as the new doc head), which must still record every slot.
+    """
+    doc = tomlrt.loads(
+        td("""
+        [x]
+        a = 1
+
+        [[x.files]]
+        glob = "g"
+        """)
+    )
+    new_section = Table.section({"a": 99})
+    new_section["files"] = doc["x"]["files"]
+    doc["x"] = new_section
+    assert tomlrt.dumps(doc) == td("""
+        [x]
+        a = 99
+
+        [[x.files]]
+        glob = "g"
+        """)
+    assert _reparses(tomlrt.dumps(doc)) == {"x": {"a": 99, "files": [{"glob": "g"}]}}

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -879,12 +879,13 @@ def test_cross_doc_table_assign_preserves_comments() -> None:
 
 
 def test_cross_doc_assign_whole_document() -> None:
-    """Assigning a whole ``Document`` as a value snapshots its full content.
+    """Assigning a whole ``Document`` grafts its body as a section.
 
-    Exercises the ``splen == 0`` branch in ``_clone_table_sections``: the
-    source's implicit pre-header entries must survive as dotted KVs under
-    the new host section, and any ``[X]`` / ``[[X]]`` sections must be
-    re-rooted under the destination key.
+    A header-less document gains a synthesised ``[wrap]`` header and its
+    entire slot stream is cloned verbatim beneath it: top-level KVs stay
+    KVs, and ``[s]`` / ``[[a]]`` sections re-root under the destination
+    key. Body trivia is preserved (here, the source's lack of blank
+    lines between sections survives).
     """
     src = td("""
         top = 1
@@ -899,23 +900,25 @@ def test_cross_doc_assign_whole_document() -> None:
     b["wrap"] = a
     out = tomlrt.dumps(b)
     assert out == td("""
-        wrap.top = 1
-        wrap.lit = "x"
-
+        [wrap]
+        top = 1
+        lit = "x"
         [wrap.s]
         x = 1
-
         [[wrap.a]]
         n = 1
         """)
+    assert _reparses(out) == {
+        "wrap": {"top": 1, "lit": "x", "s": {"x": 1}, "a": [{"n": 1}]}
+    }
 
 
 def test_cross_doc_table_assign_dotted_kv_only_source() -> None:
     """Source table backed solely by ancestor dotted KVs (no own header).
 
-    Exercises the ``host is None`` branch in ``_clone_table_sections``:
-    the source's contents live entirely as dotted KVs under an ancestor
-    section, so the cloned block has to synthesise a host section.
+    The source's contents live entirely as dotted KVs under an ancestor
+    section; the graft re-keys them under the destination key, preserving
+    their dotted (header-less) shape.
     """
     src = td("""
         [a]
@@ -934,14 +937,82 @@ def test_cross_doc_table_assign_dotted_kv_only_source() -> None:
     assert _reparses(out) == {"x": {"c": 1, "d": 2}}
 
 
-def test_cross_doc_table_assign_merges_dotted_and_own_section() -> None:
-    """Source has both a pre-header section and an own header at full_path.
+def test_cross_doc_implicit_table_graft_preserves_trivia() -> None:
+    """Grafting an implicit (dotted) table keeps its body trivia and style.
 
-    Exercises the branch where ``host`` is a cloned own-section (rather
-    than a freshly synthesised one) into which extras must be merged.
-    Achievable via the ``Document``-as-value path: the implicit
-    pre-header entries become extras, while a top-level ``[k]`` section
-    in the source clones to the host at the destination's ``[k]``.
+    An implicit table's leaf content lives in dotted keys hosted above
+    it; cloning each source slot's value + leading keeps standalone
+    comments, string style, number format, and inline-array pad that
+    re-synthesising from the logical value would drop. Sub-sections clone
+    too, and the source's header-less (dotted) shape is preserved.
+    """
+    d1 = tomlrt.loads(
+        td("""
+        a.x = 1
+        # why lit
+        a.lit = 'literal'
+        a.hex = 0xFF
+        a.vals = [ "p", "q" ]
+        [a.sub]
+        m = 3
+        """)
+    )
+    d2 = tomlrt.loads("[tool]\n")
+    d2["tool"]["z"] = d1["a"]
+    out = tomlrt.dumps(d2)
+    assert out == td("""
+        [tool]
+        z.x = 1
+        # why lit
+        z.lit = 'literal'
+        z.hex = 0xFF
+        z.vals = [ "p", "q" ]
+
+        [tool.z.sub]
+        m = 3
+        """)
+    assert _reparses(out) == {
+        "tool": {
+            "z": {
+                "x": 1,
+                "lit": "literal",
+                "hex": 255,
+                "vals": ["p", "q"],
+                "sub": {"m": 3},
+            }
+        }
+    }
+    # The graft is an independent snapshot.
+    d1["a"]["x"] = 999
+    assert _reparses(tomlrt.dumps(d2))["tool"]["z"]["x"] == 1
+
+
+def test_cross_doc_implicit_graft_into_implicit_parent() -> None:
+    """Grafting under an implicit destination parent re-hosts at its header.
+
+    The destination ``outer`` is itself header-less, so the dotted KVs
+    are hosted at the nearest header ancestor (the doc root) and keep
+    their leading comment.
+    """
+    d1 = tomlrt.loads("a.x = 1\n# c\na.y = 2\n")
+    d2 = tomlrt.loads("outer.k = 0\n")
+    d2["outer"]["z"] = d1["a"]
+    out = tomlrt.dumps(d2)
+    assert out == td("""
+        outer.k = 0
+        outer.z.x = 1
+        # c
+        outer.z.y = 2
+        """)
+    assert _reparses(out) == {"outer": {"k": 0, "z": {"x": 1, "y": 2}}}
+
+
+def test_cross_doc_table_assign_merges_dotted_and_own_section() -> None:
+    """A whole ``Document`` with both pre-header KVs and an own section.
+
+    The pre-header ``pre = 1`` and the top-level ``[k]`` section both
+    clone under the synthesised destination ``[k]`` header (the source
+    ``[k]`` re-roots to ``[k.k]``), with body trivia preserved.
     """
     src = td("""
         pre = 1
@@ -953,12 +1024,88 @@ def test_cross_doc_table_assign_merges_dotted_and_own_section() -> None:
     b["k"] = a
     out = tomlrt.dumps(b)
     assert out == td("""
-        k.pre = 1
-
+        [k]
+        pre = 1
         [k.k]
         x = 2
         """)
     assert _reparses(out) == {"k": {"pre": 1, "k": {"x": 2}}}
+
+
+def test_cross_doc_document_graft_preserves_comments_and_pad() -> None:
+    """Grafting a parsed standalone template preserves body trivia (#171).
+
+    Standalone (above-key) comments and inline-array bracket pad live
+    only in the source slot stream; cloning the document body verbatim
+    keeps them, where re-synthesising from values would drop them.
+    """
+    template = td("""
+        current = "0.0.0"
+        # Parse versions with an optional .devN suffix.
+        parse = "x"
+        serialize = [
+          "x",
+          "y",
+        ]
+        # When dev is "release", the suffix is omitted.
+        parts.dev.values = [ "0", "release" ]
+        """)
+    section = tomlrt.loads(template)
+    host = tomlrt.loads("[tool]\n")
+    host["tool"]["x"] = section
+    out = tomlrt.dumps(host)
+    assert out == td("""
+        [tool]
+
+        [tool.x]
+        current = "0.0.0"
+        # Parse versions with an optional .devN suffix.
+        parse = "x"
+        serialize = [
+          "x",
+          "y",
+        ]
+        # When dev is "release", the suffix is omitted.
+        parts.dev.values = [ "0", "release" ]
+        """)
+    assert _reparses(out) == {
+        "tool": {
+            "x": {
+                "current": "0.0.0",
+                "parse": "x",
+                "serialize": ["x", "y"],
+                "parts": {"dev": {"values": ["0", "release"]}},
+            }
+        }
+    }
+
+
+def test_cross_doc_assign_document_to_itself_snapshots() -> None:
+    """``doc[k] = doc`` grafts an independent snapshot, not a self-reference.
+
+    TOML cannot express a cycle, so the whole-document graft deep-clones
+    the body; later edits to the original must not touch the snapshot.
+    """
+    doc = tomlrt.loads("top = 1\n[s]\nx = 2\n")
+    doc["a"] = doc
+    doc["top"] = 99
+    doc["s"]["x"] = 77
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        top = 99
+        [s]
+        x = 77
+
+        [a]
+        top = 1
+        [a.s]
+        x = 2
+        """)
+    assert _reparses(out) == {
+        "top": 99,
+        "s": {"x": 77},
+        "a": {"top": 1, "s": {"x": 2}},
+    }
 
 
 def test_self_overlap_assign_replaces_with_child_block() -> None:


### PR DESCRIPTION
Fixes #171.

Assigning an attached, header-less container into a key re-synthesised it from logical values, dropping standalone comments, inline-array bracket pad, and string / number style. Two cases now clone the source's slot CST instead:

- a whole parsed `Document` grafts its body under a synthesised header (`clone_document_as_section`), sharing the cloned-section install tail with `clone_section_as_section` via `_finish_cloned_section`;
- an implicit (dotted, header-less) table clones each leaf KV's source value and leading, keeping its dotted shape.

The reporter's expected output is now produced byte-for-byte. Self-assignment (`doc[k] = doc`) is handled as an independent snapshot (TOML cannot express a cycle), covered by a test.

> Note: this is stacked on #173 (target that branch). The reporter's literal `Table.section(document)` call still snapshots values by design; the trivia-preserving path is direct assignment.

Full suite + `slow` fuzz/mutation + compliance pass; new code fully covered.