### PR TITLE
Preserve trivia when grafting a parsed document or table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the wrong table.
 - Filling a previously-empty inline table now pads the braces (`{ a = 1 }`) to
   match synthesis and `.format()`.
+- Assigning a parsed document or table into another document now keeps its
+  comments and formatting, instead of dropping them.
 
 ## [1.7.5] - 2026-06-11
 

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -65,6 +65,19 @@ A container that is already attached somewhere is deep-cloned on assignment, so
 two slots never share state.
 This applies whether the source and destination are in the same document
 (`doc["b"] = doc["a"]`) or different ones (`d2["x"] = d1["x"]`).
+The clone is byte-faithful: comments, whitespace, and string / number style on
+the bytes you didn't touch survive the move.
+
+Assigning a whole parsed `Document` as a value lifts its body into a section,
+preserving the comments and layout that were in the source:
+
+```python
+template = tomlrt.loads(template_text)   # a standalone file, no [header]
+doc["tool"]["bumpversion"] = template    # becomes [tool.bumpversion], trivia intact
+```
+
+The document's own file-level preamble / epilogue (comment blocks separated from
+the body by a blank line) belong to no key and are not carried across.
 
 ## Removal and orphaning
 

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -56,6 +56,7 @@ from tomlrt._trivia import (
     NewlineNode,
     Trivia,
     WhitespaceNode,
+    retarget_trivia_newlines,
     trivia_has_comment,
 )
 from tomlrt._typecheck import _validate_key, _validate_mapping
@@ -638,7 +639,9 @@ class Container(dict[str, Any]):
 
         AoT-entry sources clone as a table so trivia survives and the
         head normalises from ``[[..]]`` to ``[..]``. Attached
-        header-bearing sections clone slots; attached implicit sources
+        header-bearing sections clone slots; a whole attached
+        ``Document`` clones its body under a synthesised header (so body
+        comments and inline pad survive); attached implicit sources
         recurse via ``_install_attached_subtree``; detached/private
         sources rehome in place.
         """
@@ -651,9 +654,11 @@ class Container(dict[str, Any]):
                 _layout_ops.clone_aot_entry_as_table(self, key, value)
             elif value._header_ref is not None:
                 _layout_ops.clone_section_as_section(self, key, value)
+            elif isinstance(value, Document):
+                _layout_ops.clone_document_as_section(self, key, value)
             else:
-                # Implicit source / whole Document: tuple-path install
-                # preserves structural children and implicit chains.
+                # Implicit source: tuple-path install preserves structural
+                # children and implicit chains.
                 _install_attached_subtree(self, (key,), value)
             return
         if src_root is not None and src_root._is_private:  # noqa: SLF001
@@ -1514,7 +1519,7 @@ def _install_attached_subtree(
             direct_kvs.append((k, v))
 
     if direct_kvs:
-        _install_dotted_direct_kvs(dst_parent, dst_path, direct_kvs)
+        _install_dotted_direct_kvs(dst_parent, dst_path, direct_kvs, src_table)
 
     for k, v in structural:
         sub_path = (*dst_path, k)
@@ -1530,33 +1535,43 @@ def _install_dotted_direct_kvs(
     dst_parent: Container,
     dst_path: tuple[str, ...],
     direct_kvs: list[tuple[str, object]],
+    src_table: Container,
 ) -> None:
     """Emit each ``(k, v)`` in ``direct_kvs`` as a dotted KV under host.
 
     ``host`` is the nearest header-bearing ancestor at-or-above
     ``dst_parent`` (or the doc / AoT-entry root). Creates implicit
-    intermediates as needed. Values are deep-cloned through
-    ``_to_python`` + ``_synth_value`` so the source CST is not disturbed.
+    intermediates as needed. Each value's CST and leading trivia are
+    deep-cloned from the corresponding source slot so string/number
+    style, inline-array pad, and standalone comments survive — a
+    re-synthesis from the logical value would drop all of those.
     """
+    from tomlrt._build import _decode_value  # noqa: PLC0415
+
+    doc = dst_parent._attached_doc  # noqa: SLF001
     host: Container = dst_parent
     while host._header_ref is None and host._parent is not None:  # noqa: SLF001
         host = host._parent  # noqa: SLF001
     parent_to_host = dst_parent._path[len(host._path) :]  # noqa: SLF001
-    layout_root = dst_parent._layout_root  # noqa: SLF001
     owner = host._owner_aot_entry  # noqa: SLF001
-    for k, v in direct_kvs:
+    for k, _v in direct_kvs:
         leaf_keypath = (*parent_to_host, *dst_path, k)
         leaf_parent = _layout_ops.ensure_implicit_chain(host, leaf_keypath[:-1])
-        py = _to_python(v)
-        cst, decoded = _synth_value(
-            py,
-            layout_root=layout_root,
-            parent=leaf_parent,
-            path=(*host._path, *leaf_keypath),  # noqa: SLF001
-            owner=owner,
+        path = (*host._path, *leaf_keypath)  # noqa: SLF001
+        # A direct (non-structural) key of an attached source is always
+        # backed by a single KVSlot; clone its value + leading so style
+        # and standalone comments survive (re-synthesis would drop them).
+        src_slot = src_table._index[k][0].slot  # noqa: SLF001
+        assert isinstance(src_slot, KVSlot)
+        cst = copy.deepcopy(src_slot.value)
+        _retarget_to_doc(cst, doc)
+        leading = copy.deepcopy(src_slot.leading)
+        retarget_trivia_newlines(leading, doc._newline)  # noqa: SLF001
+        decoded = _decode_value(
+            cst, layout_root=doc, parent=leaf_parent, path=path, owner=owner
         )
         _layout_ops.install_dotted_kv_slot(
-            host, leaf_keypath, cst, leaf_parent=leaf_parent
+            host, leaf_keypath, cst, leaf_parent=leaf_parent, leading=leading
         )
         dict.__setitem__(leaf_parent, k, decoded)
 

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1388,6 +1388,7 @@ def install_dotted_kv_slot(
     value: Value,
     *,
     leaf_parent: Container,
+    leading: Trivia | None = None,
 ) -> None:
     """Insert a single dotted-KV slot hosted by ``host``.
 
@@ -1395,6 +1396,10 @@ def install_dotted_kv_slot(
     ``[host, ..., leaf_parent]``, updates ``_body_tail`` along the
     chain, and maintains ``AoTEntry.entry_slots`` membership. The caller
     owns dict storage at ``leaf_parent``.
+
+    ``leading`` overrides the synthesised separator/indent — used by the
+    trivia-preserving graft to carry a cloned source slot's leading
+    (standalone comments) onto the new slot.
 
     Pre-conditions (checked by caller):
     ``host`` can own the KV scope; the implicit chain already exists;
@@ -1420,7 +1425,9 @@ def install_dotted_kv_slot(
         value=value,
         doc=doc,
         owner=owner,
-        leading=_kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
+        leading=leading
+        if leading is not None
+        else _kv_leading_after(_last_kv(host, lambda s: _is_host_kv(host, s)), doc),
     )
 
     inserted_at_head = _splice_body_slot(
@@ -2260,8 +2267,6 @@ def _install_cloned_section(
     ``parent._path + (key,)``), wires the section container, splices at
     the parent's subtree anchor, and populates child views.
     """
-    from tomlrt._container import Table  # noqa: PLC0415
-
     layout_root = parent._layout_root  # noqa: SLF001
     if layout_root is None:  # pragma: no cover
         msg = "cloned-section install requires parent attached to a document"
@@ -2280,8 +2285,32 @@ def _install_cloned_section(
 
     head = cloned_slots[0]
     assert isinstance(head, StructuralHeaderSlot)
-    cloned_header: StructuralHeaderSlot = head
-    _retarget_header_separator(cloned_header, _build_section_leading(doc))
+    _retarget_header_separator(head, _build_section_leading(doc))
+    return _finish_cloned_section(
+        parent,
+        key,
+        doc=doc,
+        target_path=target_path,
+        cloned_header=head,
+        cloned_slots=cloned_slots,
+    )
+
+
+def _finish_cloned_section(
+    parent: Container,
+    key: str,
+    *,
+    doc: Document,
+    target_path: tuple[str, ...],
+    cloned_header: StructuralHeaderSlot,
+    cloned_slots: list[Slot],
+) -> Table:
+    """Wire a cloned section block under ``parent[key]`` and store it.
+
+    Shared tail of :func:`_install_cloned_section` (clones an existing
+    header) and :func:`clone_document_as_section` (synthesises one).
+    """
+    from tomlrt._container import Table  # noqa: PLC0415
 
     section = Table.section()
     _install_cloned_structural_block(
@@ -2294,7 +2323,6 @@ def _install_cloned_section(
         cloned_slots=cloned_slots,
         anchor=_parent_subtree_tail(parent),
     )
-
     dict.__setitem__(parent, key, section)
     return section
 
@@ -2382,6 +2410,54 @@ def clone_section_as_section(
         msg = "Source section's first owned slot is not a header"
         raise AssertionError(msg)  # noqa: TRY004
     return _install_cloned_section(parent, key, src_slots, src_table._path)  # noqa: SLF001
+
+
+def clone_document_as_section(
+    parent: Container,
+    key: str,
+    src_doc: Document,
+) -> Table:
+    """Install a whole ``Document``'s body under ``parent[key]`` as a section.
+
+    The document is header-less, so a fresh ``[parent.key]`` header is
+    synthesised and the document's entire slot stream is cloned verbatim
+    beneath it (rebasing paths from the document root to the target). This
+    preserves body trivia — standalone comments and inline-array pad —
+    that re-synthesising from logical values would drop. The document's
+    file-level preamble / epilogue belong to no key and are not carried.
+    """
+    doc = parent._attached_doc  # noqa: SLF001
+    target_path = (*parent._path, key)  # noqa: SLF001
+
+    src_slots: list[Slot] = []
+    s = src_doc._head  # noqa: SLF001
+    while s is not None:
+        src_slots.append(s)
+        s = s._next  # noqa: SLF001
+
+    header = _new_section_header(
+        target_path,
+        leading=_build_section_leading(doc),
+        doc=doc,
+        owner_aot_entry=parent._owner_aot_entry,  # noqa: SLF001
+    )
+    cloned_body = _clone_entry_slots(
+        src_slots,
+        new_entry=None,
+        body_owner=parent._owner_aot_entry,  # noqa: SLF001
+        src_prefix=src_doc._path,  # noqa: SLF001
+        target_prefix=target_path,
+        dst_newline=doc._newline,  # noqa: SLF001
+        has_header=False,
+    )
+    return _finish_cloned_section(
+        parent,
+        key,
+        doc=doc,
+        target_path=target_path,
+        cloned_header=header,
+        cloned_slots=[header, *cloned_body],
+    )
 
 
 def clone_aot(

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -879,12 +879,13 @@ def test_cross_doc_table_assign_preserves_comments() -> None:
 
 
 def test_cross_doc_assign_whole_document() -> None:
-    """Assigning a whole ``Document`` as a value snapshots its full content.
+    """Assigning a whole ``Document`` grafts its body as a section.
 
-    Exercises the ``splen == 0`` branch in ``_clone_table_sections``: the
-    source's implicit pre-header entries must survive as dotted KVs under
-    the new host section, and any ``[X]`` / ``[[X]]`` sections must be
-    re-rooted under the destination key.
+    A header-less document gains a synthesised ``[wrap]`` header and its
+    entire slot stream is cloned verbatim beneath it: top-level KVs stay
+    KVs, and ``[s]`` / ``[[a]]`` sections re-root under the destination
+    key. Body trivia is preserved (here, the source's lack of blank
+    lines between sections survives).
     """
     src = td("""
         top = 1
@@ -899,23 +900,25 @@ def test_cross_doc_assign_whole_document() -> None:
     b["wrap"] = a
     out = tomlrt.dumps(b)
     assert out == td("""
-        wrap.top = 1
-        wrap.lit = "x"
-
+        [wrap]
+        top = 1
+        lit = "x"
         [wrap.s]
         x = 1
-
         [[wrap.a]]
         n = 1
         """)
+    assert _reparses(out) == {
+        "wrap": {"top": 1, "lit": "x", "s": {"x": 1}, "a": [{"n": 1}]}
+    }
 
 
 def test_cross_doc_table_assign_dotted_kv_only_source() -> None:
     """Source table backed solely by ancestor dotted KVs (no own header).
 
-    Exercises the ``host is None`` branch in ``_clone_table_sections``:
-    the source's contents live entirely as dotted KVs under an ancestor
-    section, so the cloned block has to synthesise a host section.
+    The source's contents live entirely as dotted KVs under an ancestor
+    section; the graft re-keys them under the destination key, preserving
+    their dotted (header-less) shape.
     """
     src = td("""
         [a]
@@ -934,14 +937,82 @@ def test_cross_doc_table_assign_dotted_kv_only_source() -> None:
     assert _reparses(out) == {"x": {"c": 1, "d": 2}}
 
 
-def test_cross_doc_table_assign_merges_dotted_and_own_section() -> None:
-    """Source has both a pre-header section and an own header at full_path.
+def test_cross_doc_implicit_table_graft_preserves_trivia() -> None:
+    """Grafting an implicit (dotted) table keeps its body trivia and style.
 
-    Exercises the branch where ``host`` is a cloned own-section (rather
-    than a freshly synthesised one) into which extras must be merged.
-    Achievable via the ``Document``-as-value path: the implicit
-    pre-header entries become extras, while a top-level ``[k]`` section
-    in the source clones to the host at the destination's ``[k]``.
+    An implicit table's leaf content lives in dotted keys hosted above
+    it; cloning each source slot's value + leading keeps standalone
+    comments, string style, number format, and inline-array pad that
+    re-synthesising from the logical value would drop. Sub-sections clone
+    too, and the source's header-less (dotted) shape is preserved.
+    """
+    d1 = tomlrt.loads(
+        td("""
+        a.x = 1
+        # why lit
+        a.lit = 'literal'
+        a.hex = 0xFF
+        a.vals = [ "p", "q" ]
+        [a.sub]
+        m = 3
+        """)
+    )
+    d2 = tomlrt.loads("[tool]\n")
+    d2["tool"]["z"] = d1["a"]
+    out = tomlrt.dumps(d2)
+    assert out == td("""
+        [tool]
+        z.x = 1
+        # why lit
+        z.lit = 'literal'
+        z.hex = 0xFF
+        z.vals = [ "p", "q" ]
+
+        [tool.z.sub]
+        m = 3
+        """)
+    assert _reparses(out) == {
+        "tool": {
+            "z": {
+                "x": 1,
+                "lit": "literal",
+                "hex": 255,
+                "vals": ["p", "q"],
+                "sub": {"m": 3},
+            }
+        }
+    }
+    # The graft is an independent snapshot.
+    d1["a"]["x"] = 999
+    assert _reparses(tomlrt.dumps(d2))["tool"]["z"]["x"] == 1
+
+
+def test_cross_doc_implicit_graft_into_implicit_parent() -> None:
+    """Grafting under an implicit destination parent re-hosts at its header.
+
+    The destination ``outer`` is itself header-less, so the dotted KVs
+    are hosted at the nearest header ancestor (the doc root) and keep
+    their leading comment.
+    """
+    d1 = tomlrt.loads("a.x = 1\n# c\na.y = 2\n")
+    d2 = tomlrt.loads("outer.k = 0\n")
+    d2["outer"]["z"] = d1["a"]
+    out = tomlrt.dumps(d2)
+    assert out == td("""
+        outer.k = 0
+        outer.z.x = 1
+        # c
+        outer.z.y = 2
+        """)
+    assert _reparses(out) == {"outer": {"k": 0, "z": {"x": 1, "y": 2}}}
+
+
+def test_cross_doc_table_assign_merges_dotted_and_own_section() -> None:
+    """A whole ``Document`` with both pre-header KVs and an own section.
+
+    The pre-header ``pre = 1`` and the top-level ``[k]`` section both
+    clone under the synthesised destination ``[k]`` header (the source
+    ``[k]`` re-roots to ``[k.k]``), with body trivia preserved.
     """
     src = td("""
         pre = 1
@@ -953,12 +1024,88 @@ def test_cross_doc_table_assign_merges_dotted_and_own_section() -> None:
     b["k"] = a
     out = tomlrt.dumps(b)
     assert out == td("""
-        k.pre = 1
-
+        [k]
+        pre = 1
         [k.k]
         x = 2
         """)
     assert _reparses(out) == {"k": {"pre": 1, "k": {"x": 2}}}
+
+
+def test_cross_doc_document_graft_preserves_comments_and_pad() -> None:
+    """Grafting a parsed standalone template preserves body trivia (#171).
+
+    Standalone (above-key) comments and inline-array bracket pad live
+    only in the source slot stream; cloning the document body verbatim
+    keeps them, where re-synthesising from values would drop them.
+    """
+    template = td("""
+        current = "0.0.0"
+        # Parse versions with an optional .devN suffix.
+        parse = "x"
+        serialize = [
+          "x",
+          "y",
+        ]
+        # When dev is "release", the suffix is omitted.
+        parts.dev.values = [ "0", "release" ]
+        """)
+    section = tomlrt.loads(template)
+    host = tomlrt.loads("[tool]\n")
+    host["tool"]["x"] = section
+    out = tomlrt.dumps(host)
+    assert out == td("""
+        [tool]
+
+        [tool.x]
+        current = "0.0.0"
+        # Parse versions with an optional .devN suffix.
+        parse = "x"
+        serialize = [
+          "x",
+          "y",
+        ]
+        # When dev is "release", the suffix is omitted.
+        parts.dev.values = [ "0", "release" ]
+        """)
+    assert _reparses(out) == {
+        "tool": {
+            "x": {
+                "current": "0.0.0",
+                "parse": "x",
+                "serialize": ["x", "y"],
+                "parts": {"dev": {"values": ["0", "release"]}},
+            }
+        }
+    }
+
+
+def test_cross_doc_assign_document_to_itself_snapshots() -> None:
+    """``doc[k] = doc`` grafts an independent snapshot, not a self-reference.
+
+    TOML cannot express a cycle, so the whole-document graft deep-clones
+    the body; later edits to the original must not touch the snapshot.
+    """
+    doc = tomlrt.loads("top = 1\n[s]\nx = 2\n")
+    doc["a"] = doc
+    doc["top"] = 99
+    doc["s"]["x"] = 77
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        top = 99
+        [s]
+        x = 77
+
+        [a]
+        top = 1
+        [a.s]
+        x = 2
+        """)
+    assert _reparses(out) == {
+        "top": 99,
+        "s": {"x": 77},
+        "a": {"top": 1, "s": {"x": 2}},
+    }
 
 
 def test_self_overlap_assign_replaces_with_child_block() -> None:


### PR DESCRIPTION
Assigning an attached, header-less container into a key re-synthesised it from logical values, dropping standalone comments, inline-array bracket pad, and string / number style (#171).

Two cases now clone the source's slot CST instead:

- a whole parsed Document grafts its body under a synthesised header (clone_document_as_section), sharing the cloned-section install tail with clone_section_as_section via _finish_cloned_section;
- an implicit (dotted, header-less) table clones each leaf KV's source value and leading, keeping its dotted shape.