### PR TITLE
Use tomli unconditionally in slow tests for TOML 1.1 oracle

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -364,7 +364,7 @@ wrong.
   overwrite / sort / array + AoT ops) over each parsed document and
   asserts the model stays self-consistent — valid TOML out, a
   dump→load→dump fixed point, and (the important oracle)
-  `tomllib.loads(dumps(doc))` matching `doc.to_dict()`, which catches a
+  `tomli.loads(dumps(doc))` matching `doc.to_dict()`, which catches a
   mutation that places a slot where a re-parse attributes it to a
   different owner than the logical view says. Draws **fresh random
   seeds** each run and reports the failing seed for reproduction.
@@ -380,7 +380,9 @@ wrong.
 - `tests/_helpers.py` — shared test helpers: `td(""" … """)` for writing
   TOML fixtures as indented triple-quoted literals (prefer it over walls
   of `\n`-escaped strings in new tests), and `reparses(src)` for the
-  re-parse sanity check via stdlib `tomllib`.
+  re-parse sanity check via `tomli` (used unconditionally because, as of
+  writing, stdlib `tomllib` is TOML 1.0 only whereas `tomli` 2.4+ accepts
+  TOML 1.1 syntax).
 
 When adding behaviour, add a focused unit test in the relevant file
 **and** consider whether the property tests should grow.

--- a/tests/test_fuzz_mutation.py
+++ b/tests/test_fuzz_mutation.py
@@ -11,10 +11,10 @@ seeded random edit programs (set / delete / overwrite / sort across
 containers, plus append / insert / pop / sort / reverse across arrays
 and arrays-of-tables) and asserts the model stayed self-consistent:
 
-* the rendered output is valid TOML (``tomllib`` accepts it);
+* the rendered output is valid TOML (``tomli`` accepts it);
 * dump -> load -> dump is a fixed point (byte-exact idempotence);
 * the rendered output reads back as the in-memory logical model
-  (``tomllib.loads(dumps(doc))`` matches ``doc.to_dict()``).
+  (``tomli.loads(dumps(doc))`` matches ``doc.to_dict()``).
 
 The last oracle is the important one: it is sensitive to a mutation
 that places a slot where a re-parse attributes it to a different owner
@@ -40,20 +40,15 @@ from __future__ import annotations
 import math
 import random
 import secrets
-import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
+import tomli
 
 import tomlrt
 from tomlrt import AoT, Array
 from tomlrt._container import Container
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:  # pragma: no cover -- 3.10 backport
-    import tomli as tomllib
 
 pytestmark = pytest.mark.slow
 
@@ -214,9 +209,9 @@ def _mutate_aot(node: AoT, rng: random.Random) -> None:
 def test_mutation_keeps_model_consistent(path: Path) -> None:
     src = path.read_text(encoding="utf-8")
     try:
-        tomllib.loads(src)
-    except tomllib.TOMLDecodeError:
-        pytest.skip("corpus entry not valid under stdlib tomllib")
+        tomli.loads(src)
+    except tomli.TOMLDecodeError:
+        pytest.skip("corpus entry not valid under tomli")
 
     for _ in range(_PROGRAMS):
         # A fresh random seed every run, so the fuzzer explores new
@@ -231,12 +226,12 @@ def test_mutation_keeps_model_consistent(path: Path) -> None:
         out = tomlrt.dumps(doc)
         ctx = f"{path.relative_to(_VALID_ROOT).as_posix()} seed={seed}"
         # Valid TOML and a fixed point of dump -> load -> dump.
-        tomllib.loads(out)
+        tomli.loads(out)
         assert tomlrt.dumps(tomlrt.loads(out)) == out, f"non-idempotent: {ctx}\n{out!r}"
         # The rendered output reflects the in-memory logical model. Skip
         # when the model holds a non-representable empty array-of-tables.
         if not _has_empty_aot(doc):
-            assert _leaves_match(tomllib.loads(out), doc.to_dict()), (
+            assert _leaves_match(tomli.loads(out), doc.to_dict()), (
                 f"render/model mismatch: {ctx}\n{out!r}\n"
-                f"logical={doc.to_dict()!r}\nreparsed={tomllib.loads(out)!r}"
+                f"logical={doc.to_dict()!r}\nreparsed={tomli.loads(out)!r}"
             )

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import math
 import string
-import sys
 from typing import Any
 
 import pytest
+import tomli
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
@@ -16,11 +16,6 @@ from _helpers import td
 from tomlrt import Document
 
 pytestmark = pytest.mark.slow
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 
 def _deep_equal(a: object, b: object) -> bool:
@@ -65,7 +60,20 @@ _STRINGS = _BASIC_STR_CHARS.map(_quoted)
 _INTS = st.integers(min_value=-(2**31), max_value=2**31 - 1).map(str)
 _BOOLS = st.sampled_from(["true", "false"])
 _FLOATS = st.sampled_from(["0.0", "1.5", "-3.25", "1e10", "-2.5e-3", "inf", "-inf"])
-_SCALARS = st.one_of(_STRINGS, _INTS, _BOOLS, _FLOATS)
+
+# TOML 1.1 scalar literals that `tomli` (>=2.4) accepts but the stdlib
+# `tomllib` does not yet: the `\xHH` / `\e` basic-string escapes and the
+# seconds-optional date-time / time forms. Including them here threads
+# 1.1 syntax through every `_document()`-based round-trip + oracle test.
+_TOML11_STRINGS = st.sampled_from(
+    [r'"\xe9"', r'"tail \xE9"', r'"esc\e end"', r'"\x00\x7f"']
+)
+_TOML11_DATETIMES = st.sampled_from(
+    ["07:32", "1979-05-27T07:32", "1979-05-27 07:32Z", "1979-05-27 07:32-07:00"]
+)
+_TOML11_SCALARS = st.one_of(_TOML11_STRINGS, _TOML11_DATETIMES)
+
+_SCALARS = st.one_of(_STRINGS, _INTS, _BOOLS, _FLOATS, _TOML11_SCALARS)
 
 
 @st.composite
@@ -145,13 +153,13 @@ def _document(draw: st.DrawFn) -> str:
 
 def _python_scalar(literal: str) -> Any:
     """Decode a TOML scalar literal (as our generator emits it) to Python."""
-    return tomllib.loads(f"_x = {literal}")["_x"]
+    return tomli.loads(f"_x = {literal}")["_x"]
 
 
 @st.composite
 def _document_with_overrides(draw: st.DrawFn) -> tuple[str, dict[str, Any]]:
     src = draw(_document())
-    parsed = tomllib.loads(src)
+    parsed = tomli.loads(src)
     top_keys = [k for k, v in parsed.items() if not isinstance(v, (dict, list))]
     overrides: dict[str, Any] = {}
     for k in top_keys:
@@ -171,14 +179,14 @@ def test_document_invariants(case: tuple[str, dict[str, Any]]) -> None:
 
     For each generated source, asserts:
     * byte-exact round-trip (parse + dumps == src);
-    * semantic equivalence to stdlib `tomllib`;
+    * semantic equivalence to `tomli`;
     * mutating top-level scalar slots reflects in to_dict() and
       survives a dump/parse cycle.
     """
     src, overrides = case
     doc = tomlrt.loads(src)
     assert tomlrt.dumps(doc) == src
-    expected = tomllib.loads(src)
+    expected = tomli.loads(src)
     assert _deep_equal(doc.to_dict(), expected)
     for k, v in overrides.items():
         doc[k] = v
@@ -217,6 +225,19 @@ _EDGE_CASES = [
     "[a.b.c]\nv = 1\n",
     "a.b.c = 1\n",
     f"strs = {list(string.ascii_letters[:5])}\n".replace("'", '"'),
+    # TOML 1.1: inline-table trailing commas, multi-line inline tables,
+    # and the new \xHH / \e escapes and seconds-optional times.
+    "obj = { a = 1, b = 2, }\n",
+    td("""
+        obj = {
+            a = 1,
+            b = 2,
+        }
+        """),
+    'a = "hi \\xe9 \\e there"\n',
+    "t = 07:32\n",
+    "ldt = 1979-05-27T07:32\n",
+    "odt = 1979-05-27 07:32Z\n",
 ]
 
 
@@ -358,7 +379,7 @@ def test_eol_comment_set_then_clear(text: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Edge-case + tomllib semantic cross-check on the fixed corpus.
+# Edge-case + tomli semantic cross-check on the fixed corpus.
 # ---------------------------------------------------------------------------
 
 
@@ -366,7 +387,7 @@ def test_eol_comment_set_then_clear(text: str) -> None:
 @settings(max_examples=len(_EDGE_CASES), database=None)
 def test_edge_cases_match_tomllib(src: str) -> None:
     ours = tomlrt.loads(src).to_dict()
-    theirs = tomllib.loads(src)
+    theirs = tomli.loads(src)
     assert _deep_equal(ours, theirs)
 
 
@@ -594,6 +615,6 @@ def test_aot_reorder_preserves_nested_blocks(src: str, how: str) -> None:
         aot.reverse()
     out = tomlrt.dumps(doc)
     # The rendered output must reflect the reordered logical model...
-    assert _deep_equal(tomllib.loads(out), doc.to_dict())
+    assert _deep_equal(tomli.loads(out), doc.to_dict())
     # ...and stay valid + idempotent.
     assert tomlrt.dumps(tomlrt.loads(out)) == out


### PR DESCRIPTION
The hypothesis and mutation-fuzzer property tests cross-check tomlrt against a stdlib `tomllib` oracle when available, falling back to `tomli` only on 3.10. Stdlib `tomllib` is TOML 1.0 only, so any example exercising 1.1 syntax could not be validated against it, capping the coverage those property tests could reach.

Switch both slow suites to `tomli` unconditionally (it accepts 1.1) and thread 1.1 constructs through the generators now that the oracle understands them: the `\xHH` / `\e` escapes and seconds-optional date-times in the scalar strategy, plus inline-table trailing commas, multi-line inline tables, and the new escapes/times in the edge-case corpus.