### PR TITLE
Render an empty array-of-tables as key = []

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- An empty array-of-tables now renders as an empty array (`key = []`) instead of
+  being omitted, so a dumped document matches its dict view.
+
 ## [1.8.1] - 2026-06-14
 
 ### Fixed

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -142,10 +142,12 @@ doc.sort()
 
 ## Empty arrays-of-tables
 
-TOML has no syntax for an array-of-tables with zero entries, so an empty `AoT`
-does not appear in `dumps` output — the key is silently absent.
-The in-memory `AoT` remains usable: append entries to it and they will reappear
-in the next dump.
+An array-of-tables with zero entries has no `[[key]]` syntax, so an empty `AoT`
+renders as an empty array — `key = []` — preserving the same semantic shape as
+the dict view (`{"key": []}`). Appending the first entry replaces that
+placeholder with the usual `[[key]]` header. Note that re-parsing such output
+reads `key = []` back as an empty inline `Array` rather than an `AoT`; the dict
+view (`to_dict()`) is identical, but the in-memory type differs.
 
 ## Inline-array layout
 

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -43,7 +43,7 @@ from tomlrt._trivia import (
     WhitespaceNode,
     line_has_comment,
 )
-from tomlrt._values import InlineTableValue, make_keyparts
+from tomlrt._values import ArrayValue, InlineTableValue, make_keyparts
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -1149,6 +1149,9 @@ def _collect_subtree(
             _collect_subtree(child, containers_out, aots_out, add_slot)
     elif isinstance(val, AoT):
         aots_out.append(val)
+        placeholder = _empty_aot_placeholder_ref(val)
+        if placeholder is not None:
+            add_slot(placeholder.slot)
         for entry in val:
             _collect_subtree(entry, containers_out, aots_out, add_slot)
 
@@ -2053,9 +2056,11 @@ def _build_section_leading(doc: Document) -> Trivia:
 def attach_empty_aot(parent: Container, key: str, source_aot: AoT) -> AoT:
     """Bind an empty AoT under ``parent[key]``.
 
-    No physical slots are created; subsequent ``aot.add(...)`` calls
-    will materialise the first ``[[path]]`` header. The ``source_aot``
-    is rehomed in place (identity preserved).
+    The AoT has no entries, so its physical presence is a single
+    ``key = []`` placeholder KVSlot (an empty inline array) filed in
+    ``parent``'s body. The first ``aot.add(...)`` consumes that
+    placeholder and materialises the first ``[[path]]`` header in its
+    stead. The ``source_aot`` is rehomed in place (identity preserved).
     """
     if len(source_aot) > 0:  # pragma: no cover
         msg = "non-empty AoT live-attach has its own routing"
@@ -2064,7 +2069,87 @@ def attach_empty_aot(parent: Container, key: str, source_aot: AoT) -> AoT:
     source_aot._layout_root = parent._layout_root  # noqa: SLF001
     source_aot._path = (*parent._path, key)  # noqa: SLF001
     source_aot._parent = parent  # noqa: SLF001
+    _materialise_empty_aot(source_aot)
     return source_aot
+
+
+def _materialise_empty_aot(aot: AoT) -> None:
+    """Splice a ``key = []`` placeholder for a now-empty attached AoT.
+
+    The placeholder is a normal direct KV (empty ``ArrayValue``) under
+    the AoT's parent, so it lands in the parent's body region rather
+    than at a header position a re-parse would misattribute. Dict
+    storage at ``parent[key]`` is left as the AoT — only the physical
+    slot is created.
+    """
+    parent = aot._parent  # noqa: SLF001
+    assert parent is not None
+    assert len(aot) == 0
+    key = aot._path[-1]  # noqa: SLF001
+    append_direct_kv(parent, key, ArrayValue())
+
+
+def _empty_aot_placeholder_ref(aot: AoT) -> SlotRef | None:
+    """Return the ``key = []`` placeholder ref backing an empty AoT, if any.
+
+    Derived from the parent's ``_index[key]``: an empty AoT's only
+    physical presence is one ``KVSlot`` whose value is an empty
+    ``ArrayValue``. Returns ``None`` when the AoT is non-empty or carries
+    no placeholder yet (e.g. a fresh AoT mid-clone, before its first
+    entry or placeholder lands).
+    """
+    if len(aot) != 0:
+        return None
+    parent = aot._parent  # noqa: SLF001
+    assert parent is not None
+    key = aot._path[-1]  # noqa: SLF001
+    bucket = parent._index.get(key)  # noqa: SLF001
+    if not bucket:
+        return None
+    ref = bucket[0]
+    slot = ref.slot
+    if not (isinstance(slot, KVSlot) and isinstance(slot.value, ArrayValue)):
+        return None  # pragma: no cover -- key invariant: one value per key
+    return ref
+
+
+def _remove_empty_aot_placeholder(aot: AoT, ref: SlotRef) -> None:
+    """Unlink an empty AoT's placeholder slot and scrub its refs.
+
+    Mirrors the focused leaf-delete sequence in `delete_key`: scrub
+    every ref via slot back-pointers, recompute body tails on the
+    parent chain, drop any ``entry_slots`` membership, then unlink.
+    """
+    parent = aot._parent  # noqa: SLF001
+    assert parent is not None
+    doc = aot._attached_doc  # noqa: SLF001
+    slot = ref.slot
+    owned_ids = {id(slot)}
+    _scrub_owned_slots_via_backptrs([slot])
+    min_depth = len(slot.host_path) if isinstance(slot, KVSlot) else 0
+    _invalidate_body_tail_chain(parent, owned_ids, min_depth=min_depth, recompute=True)
+    owner = slot.owner_aot_entry
+    if owner is not None:
+        with contextlib.suppress(ValueError):
+            owner.entry_slots.remove(slot)
+    unlink_slot(slot, doc)
+
+
+def _consume_first_entry_placeholder(aot: AoT, ordinal: int) -> None:
+    """Drop the ``key = []`` placeholder before the AoT's first entry lands.
+
+    No-op past entry 0 or when the AoT carries no placeholder (the
+    fresh-AoT clone path). The first ``[[path]]`` header takes the AoT's
+    structural position (after the parent body), not the placeholder's
+    in-body position, which a re-parse could otherwise misattribute.
+    Runs before the append anchor is computed and before any synthetic
+    parent header is demoted.
+    """
+    if ordinal != 0:
+        return
+    placeholder = _empty_aot_placeholder_ref(aot)
+    if placeholder is not None:
+        _remove_empty_aot_placeholder(aot, placeholder)
 
 
 def _aot_separator(aot: AoT, doc: Document) -> Trivia:
@@ -2105,6 +2190,12 @@ def add_aot_entry(
     assert path
 
     ordinal = len(aot)
+    # Consume the ``key = []`` placeholder before computing the append
+    # anchor or demoting the parent header: the first ``[[path]]`` header
+    # takes the AoT's structural position (after the parent body), not
+    # the placeholder's in-body position, which could otherwise capture
+    # trailing parent KVs on re-parse.
+    _consume_first_entry_placeholder(aot, ordinal)
     entry = AoTEntry(path=path)
     leading = _build_section_leading(doc) if ordinal == 0 else _aot_separator(aot, doc)
     header = _new_section_header(
@@ -2275,6 +2366,7 @@ def _install_cloned_aot_entry(
     assert target_path
 
     ordinal = len(aot)
+    _consume_first_entry_placeholder(aot, ordinal)
     new_entry = AoTEntry(path=target_path)
 
     cloned_slots = _clone_entry_slots(
@@ -2740,6 +2832,8 @@ def clone_aot(
             dst_path=target_path,
             preserve_source_separator=True,
         )
+    if len(new_aot) == 0:
+        _materialise_empty_aot(new_aot)
     return new_aot
 
 
@@ -3283,6 +3377,9 @@ def remove_aot_entries(aot: AoT, indices: Iterable[int]) -> list[Table]:
     def _collect_nested_aot_slots(c: Container, sink: list[Slot]) -> None:
         for v in c.values():
             if isinstance(v, AoT):
+                placeholder = _empty_aot_placeholder_ref(v)
+                if placeholder is not None:
+                    sink.append(placeholder.slot)
                 for nested_entry_table in v:
                     ne = nested_entry_table._owner_aot_entry  # noqa: SLF001
                     if ne is not None:
@@ -3354,6 +3451,10 @@ def remove_aot_entries(aot: AoT, indices: Iterable[int]) -> list[Table]:
     last_key = aot._path[-1]  # noqa: SLF001
     if len(aot) == 0 and not parent._index.get(last_key):  # noqa: SLF001
         parent._index.pop(last_key, None)  # noqa: SLF001
+        # An empty AoT still lives in dict storage; a ``key = []``
+        # placeholder gives it a physical presence so the document keeps
+        # the same semantic shape as the dict view.
+        _materialise_empty_aot(aot)
 
     return popped_entries
 

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -2639,7 +2639,10 @@ def test_assign_empty_aot_returns_appendable_view() -> None:
     doc = tomlrt.loads("")
     doc["servers"] = AoT()
     aot = doc["servers"]
-    assert tomlrt.dumps(doc) == ""
+    # An empty AoT renders as an empty array, preserving the dict-view
+    # shape (``{"servers": []}``); appending the first entry replaces it
+    # with the ``[[servers]]`` header.
+    assert tomlrt.dumps(doc) == "servers = []\n"
     aot.append({"host": "localhost"})
     rendered = tomlrt.dumps(doc)
     assert rendered == td("""
@@ -3822,12 +3825,10 @@ def test_leading_comments_view_does_not_bleed_eol_comment() -> None:
 
 
 def test_aot_clear_renders_empty_but_keeps_key() -> None:
-    """Clearing an AoT empties it like a regular Python list value:
-    the key stays on the host (so ``in`` / ``len`` / ``keys`` keep
-    behaving like a dict), but render skips it because empty AoTs
-    have no syntax in TOML. A subsequent re-parse will not see the
-    key — that's an acceptable mutation-time cost; held references
-    keep working as plain (now-empty) lists."""
+    """Clearing an AoT empties it like a regular Python list value: the
+    key stays on the host and renders as an empty array (``a = []``), so
+    the document keeps the same semantic shape as the dict view. A
+    re-parse reads ``a`` as an empty inline array rather than an AoT."""
     doc = tomlrt.loads(
         td("""
         [[a]]
@@ -3839,7 +3840,7 @@ def test_aot_clear_renders_empty_but_keeps_key() -> None:
     doc["a"].clear()
     assert "a" in doc
     assert len(doc["a"]) == 0
-    assert tomlrt.dumps(doc) == ""
+    assert tomlrt.dumps(doc) == "a = []\n"
 
 
 def test_aot_pop_last_renders_empty_but_keeps_key() -> None:
@@ -3852,7 +3853,108 @@ def test_aot_pop_last_renders_empty_but_keeps_key() -> None:
     )
     doc["a"].pop()
     assert "a" in doc
-    assert tomlrt.dumps(doc) == "x=0\n"
+    assert tomlrt.dumps(doc) == "x=0\na = []\n"
+
+
+def test_aot_empty_placeholder_lands_in_parent_body_not_after_sibling() -> None:
+    """When the AoT's only header sat after a sibling sub-section, the
+    ``key = []`` placeholder must move into the parent's *body* region.
+    Replacing the header in place would put it after ``[t.b]``, where a
+    re-parse would read it as ``t.b.a`` rather than ``t.a``."""
+    doc = tomlrt.loads(
+        td("""
+        [t]
+        [t.b]
+        x = 1
+        [[t.a]]
+        n = 1
+        """)
+    )
+    doc["t"]["a"].pop()
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        [t]
+        a = []
+        [t.b]
+        x = 1
+        """)
+    assert tomlrt.loads(out)["t"]["a"] == []
+
+
+def test_aot_first_add_after_placeholder_does_not_capture_sibling() -> None:
+    """Adding the first entry must anchor the ``[[t.a]]`` header at the
+    AoT's structural position (after the parent body), not in place of
+    the placeholder — otherwise a trailing sibling KV would be captured
+    into the new entry on re-parse."""
+    doc = tomlrt.loads("[t]\n")
+    doc["t"]["a"] = AoT()
+    doc["t"]["x"] = 1
+    assert tomlrt.dumps(doc) == td("""
+        [t]
+        a = []
+        x = 1
+        """)
+    doc["t"]["a"].add({"n": 5})
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        [t]
+        x = 1
+
+        [[t.a]]
+        n = 5
+        """)
+    assert tomlrt.loads(out)["t"] == {"x": 1, "a": [{"n": 5}]}
+
+
+def test_delete_empty_aot_key_removes_placeholder() -> None:
+    doc = tomlrt.loads(
+        td("""
+        [[a]]
+        n = 1
+        """)
+    )
+    doc["a"].clear()
+    assert tomlrt.dumps(doc) == "a = []\n"
+    del doc["a"]
+    assert "a" not in doc
+    assert tomlrt.dumps(doc) == ""
+
+
+def test_nested_empty_aot_renders_as_empty_array() -> None:
+    doc = tomlrt.loads(
+        td("""
+        [[a]]
+        n = 1
+        """)
+    )
+    doc["a"][0]["sub"] = AoT()
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        [[a]]
+        n = 1
+        sub = []
+        """)
+    assert tomlrt.loads(out)["a"][0]["sub"] == []
+
+
+def test_assign_empty_live_aot_clones_as_empty_array() -> None:
+    """Assigning a live (attached) empty AoT to another key routes
+    through the AoT clone path; with no entries to clone, the
+    destination still renders as an empty ``key = []`` array."""
+    doc = tomlrt.loads(
+        td("""
+        [[a]]
+        n = 1
+        """)
+    )
+    doc["a"].clear()
+    doc["b"] = doc["a"]
+    out = tomlrt.dumps(doc)
+    assert out == td("""
+        a = []
+        b = []
+        """)
+    assert tomlrt.loads(out).to_dict() == {"a": [], "b": []}
 
 
 def test_replace_section_preserves_blank_before_next_section() -> None:

--- a/tests/test_fuzz_mutation.py
+++ b/tests/test_fuzz_mutation.py
@@ -107,16 +107,6 @@ def _leaves_match(rendered: object, logical: object) -> bool:
     return fa.keys() == fb.keys() and all(_deep_eq(fa[k], fb[k]) for k in fa)
 
 
-def _has_empty_aot(value: object) -> bool:
-    if isinstance(value, AoT):
-        return len(value) == 0 or any(_has_empty_aot(e) for e in value)
-    if isinstance(value, Array):
-        return any(_has_empty_aot(e) for e in value)
-    if isinstance(value, Container):
-        return any(_has_empty_aot(value[k]) for k in value)
-    return False
-
-
 def _rand_value(rng: random.Random) -> Any:
     return rng.choice(
         [1, 3.5, "str", True, -7, "x y", "", [1, 2], {"a": 1}, [{"q": 1}]]
@@ -228,10 +218,10 @@ def test_mutation_keeps_model_consistent(path: Path) -> None:
         # Valid TOML and a fixed point of dump -> load -> dump.
         tomli.loads(out)
         assert tomlrt.dumps(tomlrt.loads(out)) == out, f"non-idempotent: {ctx}\n{out!r}"
-        # The rendered output reflects the in-memory logical model. Skip
-        # when the model holds a non-representable empty array-of-tables.
-        if not _has_empty_aot(doc):
-            assert _leaves_match(tomli.loads(out), doc.to_dict()), (
-                f"render/model mismatch: {ctx}\n{out!r}\n"
-                f"logical={doc.to_dict()!r}\nreparsed={tomli.loads(out)!r}"
-            )
+        # The rendered output reflects the in-memory logical model. An
+        # empty array-of-tables renders as ``key = []``, so the
+        # render/model oracle holds even when the model holds one.
+        assert _leaves_match(tomli.loads(out), doc.to_dict()), (
+            f"render/model mismatch: {ctx}\n{out!r}\n"
+            f"logical={doc.to_dict()!r}\nreparsed={tomli.loads(out)!r}"
+        )

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -562,12 +562,12 @@ def test_api_mutation_program(ops: list[tuple[Any, ...]]) -> None:
         # Internal consistency: dumps must succeed at every step and
         # be a fixed point of dumps -> loads -> dumps.
         #
-        # NB: a stronger ``tomllib.loads(out) == doc.to_dict()`` oracle
-        # is *not* valid here — synthesis can build logically-valid but
-        # non-representable states (e.g. an empty ``AoT``, which has no
-        # TOML syntax and renders as nothing), so the rendered bytes and
-        # the logical model legitimately diverge. The reorder property
-        # below seeds from parsed source, where that oracle does hold.
+        # NB: only the idempotence oracle is asserted here. Synthesis can
+        # build states whose rendered form re-parses to a different *type*
+        # than the logical model even though the dict view matches — e.g.
+        # an empty ``AoT`` renders as ``key = []`` and re-parses as an
+        # empty ``Array``. The reorder property below seeds from parsed
+        # source, where the stronger ``loads(out) == to_dict()`` holds.
         out = tomlrt.dumps(doc)
         assert tomlrt.dumps(tomlrt.loads(out)) == out
 

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -1202,8 +1202,8 @@ def test_aot_clear_removes_all_entries_and_owned_subsections() -> None:
     aot.clear()
     assert len(aot) == 0
     out = tomlrt.dumps(doc)
-    assert out == ""
-    assert _reparses(out) == {}
+    assert out == "pkg = []\n"
+    assert _reparses(out) == {"pkg": []}
 
 
 def test_aot_delitem_index_pops_one() -> None:
@@ -1403,8 +1403,8 @@ def test_aot_imul_zero_clears() -> None:
     aot = doc.aot("t")
     aot *= 0
     out = tomlrt.dumps(doc)
-    assert out == ""
-    assert "t" not in tomlrt.loads(out)
+    assert out == "t = []\n"
+    assert tomlrt.loads(out)["t"] == []
 
 
 def test_aot_imul_detached_replicates_entries() -> None:


### PR DESCRIPTION
An empty AoT (zero entries) previously had no physical slots and so rendered as nothing, even though the dict view still held {key: []}. The rendered document therefore diverged semantically from the model, and the mutation fuzzer had to skip its render/model oracle whenever an empty AoT was present.

Materialise an empty AoT as a key = [] placeholder KVSlot (an empty inline array) in the parent body. The first entry add consumes the placeholder and materialises the [[key]] header in its structural position; popping/clearing the last entry re-materialises the placeholder. Re-parsing such output reads the key back as an empty inline Array rather than an AoT — to_dict() is identical, only the in-memory type differs.

The placeholder is routed through append_direct_kv so it lands in the parent body region (before child-section headers), avoiding the misattribution a re-parse would make if a dotted KV sat after a sibling section header. All entry-add paths (add_aot_entry and the clone installers) consume the placeholder via a shared helper, and the subtree/nested-AoT slot collectors now find it so delete and clear scrub it correctly.