### PR TITLE
Preserve comma-first layout when editing inline values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An out-of-range index in `arr[i] = value` now raises `IndexError`
+  without corrupting the array; previously an out-of-range negative
+  index could silently overwrite the wrong element.
 - Editing a "comma-first" multi-line array or inline table (comma leading
   each row) now preserves that layout instead of breaking it.
 - Key-path lookups now raise on an empty path (e.g. `""`, `[]`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Editing a "comma-first" multi-line array or inline table (comma leading
+  each row) now preserves that layout instead of breaking it.
 - Key-path lookups now raise on an empty path (e.g. `""`, `[]`,
   `"a..b"`) instead of silently returning the whole container.
 

--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -416,10 +416,15 @@ class Array(list[Any]):
             return
         # int index: just replace the value CST in place.
         i = int(index)
-        cst, dec = self._synth_cst(value)
         items = self._value.items
         if i < 0:
             i += len(items)
+        if i < 0 or i >= len(items):
+            # Reject before synthesising or mutating any CST, matching the
+            # IndexError that ``list.__setitem__`` raises for a bad index.
+            msg = "list assignment index out of range"
+            raise IndexError(msg)
+        cst, dec = self._synth_cst(value)
         items[i].value = cst
         list.__setitem__(self, index, dec)
 

--- a/src/tomlrt/_comma_ops.py
+++ b/src/tomlrt/_comma_ops.py
@@ -38,6 +38,7 @@ from tomlrt._trivia import (
 )
 from tomlrt._values import (
     inter_item_separator,
+    item_breaks_before_comma,
     item_eol_channel,
 )
 
@@ -262,14 +263,35 @@ def flip_to_terminal(item: CommaItem, style: CommaStyle) -> None:
 class CommaStyle:
     """Hold inferred layout policy for inline array/table append paths.
 
-    Carries the inter-item separator, whether the value is multi-line,
-    and whether the terminal item should keep a trailing comma.
+    Carries the inter-item separator, whether the value is multi-line, and
+    whether the terminal item should keep a trailing comma. A non-empty
+    ``pre_comma_break`` marks a *break-before-comma* (comma-first) value:
+    one that parks each row break in the item's own ``trailing`` ahead of
+    its comma rather than downstream in the next item's ``leading``, so
+    ``inter_separator`` is just the post-comma pad.
     """
 
     is_multiline: bool
     inter_separator: Trivia
     trailing_comma: bool
     trailing_post: Trivia
+    pre_comma_break: Trivia
+
+    @property
+    def break_before_comma(self) -> bool:
+        return bool(self.pre_comma_break.pieces)
+
+
+def _pre_comma_break(item: CommaItem) -> Trivia:
+    """The row break a break-before-comma ``item`` parks before its comma.
+
+    Sampled so a new internal item matches the authored newline and the
+    comma-row indent (the trailing whitespace between break and comma).
+    """
+    pieces = item.trailing.pieces
+    nl_text = next(p.text for p in pieces if isinstance(p, NewlineNode))
+    indent = pieces[-1].text if isinstance(pieces[-1], WhitespaceNode) else ""
+    return Trivia([NewlineNode(text=nl_text), WhitespaceNode(indent)])
 
 
 def detect_style(value: ArrayValue | InlineTableValue, *, nl: str) -> CommaStyle:
@@ -278,15 +300,17 @@ def detect_style(value: ArrayValue | InlineTableValue, *, nl: str) -> CommaStyle
     Multi-line shape is read from the value's own trivia
     (:meth:`CommaValue.is_multiline`) — the value is the single source of
     truth, so there is no separate "force multi-line" flag. The inter-item
-    separator is sampled from ``items[1].leading``; a multi-line value that
-    cannot sample one (single item, or a comma-first peer with empty leading)
-    falls back to :func:`_canonical_separator`. ``nl`` is the owning document's
-    newline, used for any break this synthesises when the value carries none.
+    separator is sampled from ``items[1].leading``; a comma-last multi-line
+    value that cannot sample one (single item) falls back to
+    :func:`_canonical_separator`. When item 0 parks its break before its comma
+    the value is comma-first: the post-comma pad is kept and ``pre_comma_break``
+    seeded from that item. ``nl`` is the owning document's newline.
     """
     items = value.items
     is_multiline = value.is_multiline()
     inter_sep = inter_item_separator(items)
-    if is_multiline and not trivia_has_newline(inter_sep):
+    leader = items[0] if items and item_breaks_before_comma(items[0]) else None
+    if is_multiline and leader is None and not trivia_has_newline(inter_sep):
         inter_sep = _canonical_separator(value, nl)
     trailing_comma = items[-1].has_comma if items else is_multiline
     pad_ft, _above_ft = split_above_block(value.final_trivia)
@@ -296,6 +320,7 @@ def detect_style(value: ArrayValue | InlineTableValue, *, nl: str) -> CommaStyle
         inter_separator=inter_sep,
         trailing_comma=trailing_comma,
         trailing_post=trailing_post,
+        pre_comma_break=_pre_comma_break(leader) if leader else Trivia(),
     )
 
 
@@ -388,6 +413,21 @@ def splice_in(
         cv.final_trivia, style.inter_separator
     )
     old_tail = items[-1]
+    if style.break_before_comma:
+        # Comma-first: the former tail keeps its EOL comment but yields its
+        # terminal break (re-homed before the closing bracket) and gains its
+        # own pre-comma break; the new tail needs no trailing break.
+        eol = _take_eol(old_tail).pieces
+        if eol and isinstance(eol[-1], NewlineNode):
+            eol = eol[:-1]
+        old_tail.trailing = Trivia([*eol, *style.pre_comma_break.pieces])
+        old_tail.has_comma = True
+        old_tail.post_comma_trivia = Trivia()
+        if not trivia_has_newline(cv.final_trivia):
+            cv.final_trivia = Trivia([NewlineNode(text=nl), *cv.final_trivia.pieces])
+        items.append(new_item)
+        flip_to_terminal(new_item, style)
+        return
     flip_to_internal(old_tail)
     items.append(new_item)
     flip_to_terminal(new_item, style)
@@ -410,13 +450,21 @@ def splice_insert(
     """Insert ``new_item`` at ``index`` (``0 <= index < len(items)``).
 
     Appending is :func:`splice_in`; this covers interior and head inserts.
-    A head insert migrates the opening-bracket above-block onto the
-    displaced item, keeping item-0 leading empty. The fresh boundary onto
-    ``new_item`` gets just its structural break; the carried boundary onto
-    the displaced item keeps its blank lines while its predecessor changes
-    to ``new_item``.
+    A comma-first item owns its break before its comma, so its neighbours are
+    untouched. Otherwise a head insert migrates the opening-bracket above-block
+    onto the displaced item (keeping item-0 leading empty); an interior insert
+    gives the new item its structural break and shifts the carried boundary so
+    the displaced item keeps its blank lines.
     """
     items = cv.items
+    if style.break_before_comma:
+        new_item.trailing = style.pre_comma_break.copy()
+        new_item.leading = Trivia() if index == 0 else style.inter_separator.copy()
+        items.insert(index, new_item)
+        if index == 0:
+            # Item 0 keeps an empty leading; the displaced item takes the pad.
+            items[1].leading = style.inter_separator.copy()
+        return
     if index == 0:
         cv.header_trivia, items[0].leading = migrate_bracket_above(
             cv.header_trivia, style.inter_separator

--- a/tests/test_edit_golden.py
+++ b/tests/test_edit_golden.py
@@ -2570,11 +2570,9 @@ def test_append_preserves_leading_comment_in_single_item_array() -> None:
 def test_append_preserves_comma_first_boundary_in_array() -> None:
     # A comma-first multiline array parks its row break *before* the
     # comma (in the previous item's trailing), leaving the following
-    # item's leading empty. Appending used to renormalise that
-    # already-broken boundary, injecting a second newline that
-    # stranded the comma on its own line and dropped items to column
-    # zero. The existing ",2" row is now left untouched; only the new
-    # item is laid out (in the default comma-attached style).
+    # item's leading empty. Appending matches that style: the new item
+    # takes its own break-before-comma row at the existing comma-row
+    # indent rather than renormalising to a comma-attached layout.
     src = td("""
         a = [
               1 # comma is on the next line
@@ -2587,16 +2585,16 @@ def test_append_preserves_comma_first_boundary_in_array() -> None:
     assert tomlrt.dumps(doc) == td("""
         a = [
               1 # comma is on the next line
-             ,2,
-              99
+             ,2
+             ,99
             ]
         """)
 
 
 def test_assign_preserves_comma_first_boundary_in_inline_table() -> None:
     # Comma-first inline tables share the row-break logic with arrays
-    # (via _comma_ops), so the existing comma-first entry boundary is
-    # preserved the same way.
+    # (via _comma_ops), so a new entry also takes its own
+    # break-before-comma row matching the existing boundary.
     src = td("""
         t = {
               a = 1 # comma is on the next line
@@ -2609,9 +2607,136 @@ def test_assign_preserves_comma_first_boundary_in_inline_table() -> None:
     assert tomlrt.dumps(doc) == td("""
         t = {
               a = 1 # comma is on the next line
-             ,b = 2,
-              c = 3
+             ,b = 2
+             ,c = 3
             }
+        """)
+
+
+def test_slice_assign_preserves_comma_first_array() -> None:
+    # Replacing one item with two via a slice (del + insert) must keep the
+    # comma-first layout: each new item parks its own row break before its
+    # comma rather than colliding with the predecessor's existing break.
+    src = td("""
+        a = [
+              1
+            , 2
+            , 3
+            ]
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    doc.array("a")[1:2] = [10, 20]
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1
+            , 10
+            , 20
+            , 3
+            ]
+        """)
+
+
+def test_insert_interior_preserves_comma_first_array() -> None:
+    src = td("""
+        a = [
+              1
+            , 2
+            , 3
+            ]
+        """)
+    doc = tomlrt.loads(src)
+    doc.array("a").insert(1, 99)
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1
+            , 99
+            , 2
+            , 3
+            ]
+        """)
+
+
+def test_insert_head_preserves_comma_first_array() -> None:
+    src = td("""
+        a = [
+              1
+            , 2
+            , 3
+            ]
+        """)
+    doc = tomlrt.loads(src)
+    doc.array("a").insert(0, 99)
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              99
+            , 1
+            , 2
+            , 3
+            ]
+        """)
+
+
+def test_append_comma_first_tail_sharing_bracket_row() -> None:
+    # The former tail shared its row with the closing bracket, so the
+    # bracket break lived in the tail rather than final_trivia; appending
+    # must re-home a break before the closing bracket.
+    src = td("""
+        a = [
+              1
+             ,2 ]
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    doc.array("a").append(3)
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1
+             ,2
+             ,3
+         ]
+        """)
+
+
+def test_append_comma_first_tail_with_eol_comment() -> None:
+    # The former tail keeps its EOL comment on its own value row while the
+    # appended item takes the following break-before-comma row.
+    src = td("""
+        a = [
+              1
+             ,2  # tail
+            ]
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    doc.array("a").append(3)
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+              1
+             ,2  # tail
+             ,3
+            ]
+        """)
+
+
+def test_insert_comma_first_with_zero_indent() -> None:
+    # The comma sits at column zero, so the sampled pre-comma break carries
+    # no indent; the new row matches.
+    src = td("""
+        a = [
+        1
+        ,2
+        ]
+        """)
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+    doc.array("a").insert(1, 9)
+    assert tomlrt.dumps(doc) == td("""
+        a = [
+        1
+        ,9
+        ,2
+        ]
         """)
 
 

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -699,6 +699,23 @@ def test_array_setitem_int_negative_index() -> None:
     assert _reparses(out) == {"xs": [1, 2, 33]}
 
 
+def test_array_setitem_int_oob_index_does_not_corrupt_cst() -> None:
+    # Regression: an out-of-range index (negative or positive) must raise
+    # IndexError *without* mutating any item's value CST. The negative case
+    # used to normalise into a valid slot and silently overwrite it before
+    # ``list.__setitem__`` raised, leaving the rendered output disagreeing
+    # with the logical view.
+    for bad in (-4, 3):
+        doc = tomlrt.loads("xs = [1, 2, 3]\n")
+        xs = doc.array("xs")
+        with pytest.raises(IndexError, match="list assignment index out of range"):
+            xs[bad] = 99
+        assert list(xs) == [1, 2, 3]
+        out = tomlrt.dumps(doc)
+        assert out == "xs = [1, 2, 3]\n"
+        assert _reparses(out) == {"xs": [1, 2, 3]}
+
+
 def test_array_setitem_slice_extended_matching_length() -> None:
     doc = tomlrt.loads("xs = [1, 2, 3, 4, 5]\n")
     xs = doc.array("xs")


### PR DESCRIPTION
Mutating a comma-first multi-line array or inline table (the comma leads each row, so the row break sits in an item's trailing before its comma) produced broken output: detect_style only modelled the comma-last shape and synthesised a separator that collided with the existing break.

Detect the comma-first shape from item 0 and place a new item's break in its own trailing, leaving neighbours untouched, so append / insert / slice-assign / inline-table assignment all keep the authored style.