### PR TITLE
Surface overlong-integer ValueError as TOMLParseError

### DIFF
--- a/src/tomlrt/_scanner.py
+++ b/src/tomlrt/_scanner.py
@@ -757,7 +757,11 @@ class _Scanner:
         if len(digits_only) > 1 and digits_only.startswith("0"):
             msg = f"leading zeros are not allowed in {token!r}"
             raise self.error(msg, at=at)
-        value = int(sign + digits_only)
+        try:
+            value = int(sign + digits_only)
+        except ValueError as exc:
+            msg = f"invalid integer {token!r}: {exc}"
+            raise self.error(msg, at=at) from exc
         return IntegerValue(token, value)
 
     def _parse_float_token(self, token: str, *, at: int) -> FloatValue:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -327,6 +327,17 @@ def test_deep_inline_table_nesting_raises_parse_error() -> None:
         tomlrt.loads(payload)
 
 
+def test_overlong_integer_raises_parse_error_not_valueerror() -> None:
+    # CPython caps int<->str conversion at 4300 digits by default; a
+    # longer decimal literal must surface as a TOMLParseError, not the
+    # bare ValueError that ``int()`` raises. The message forwards the
+    # underlying cause rather than presuming it.
+    payload = "x = " + "1" * 4301 + "\n"
+    with pytest.raises(tomlrt.TOMLParseError, match="invalid integer") as exc_info:
+        tomlrt.loads(payload)
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
 def test_inline_table_dotted_key_conflict_reports_inline_position() -> None:
     # The conflict between `x = 1` and `x.y = 2` lives on line 1 inside
     # the inline table; the error must point there, not at the start of


### PR DESCRIPTION
CPython caps int<->str conversion length (4300 digits by default), so parsing an otherwise-valid decimal integer literal longer than that raised a bare ValueError straight out of loads() instead of our positioned TOMLParseError. Wrap the base-10 int() conversion and forward the underlying cause, matching how the date/time paths already handle stdlib ValueErrors. Hex/octal/binary and float conversions are unaffected by the limit and need no change.