### PR TITLE
Let dumps/dump accept a plain mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dumps` and `dump` now accept a `Mapping`.
+
 ### Changed
 
 - The `indent` argument of `Array(...)`, `Array.set_multiline`, and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,6 +25,9 @@ assert text == text_again
 
 `tomlrt.dumps(doc)` and `doc.render()` are equivalent.
 
+Both `dumps` and `dump` accept a plain mapping, wrapping it in a `Document`
+for you, so `tomlrt.dumps({"a": 1})` works.
+
 ## Reading values
 
 A `Document` behaves like a `dict`; nested tables are `Table` (also a `dict`

--- a/src/tomlrt/_public.py
+++ b/src/tomlrt/_public.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any
 
 from tomlrt._build import build_from_parse
+from tomlrt._container import Document
 from tomlrt._parser import _Parser
 
 if TYPE_CHECKING:
-    from tomlrt._container import Document
+    from collections.abc import Mapping
 
 
 def loads(text: str) -> Document:
@@ -33,17 +34,25 @@ def load(fp: IO[bytes]) -> Document:
     return loads(bytes(data).decode("utf-8"))
 
 
-def dumps(doc: Document) -> str:
-    """Serialize a [`Document`][tomlrt.Document] back to a TOML string."""
+def dumps(data: Mapping[str, Any]) -> str:
+    """Serialize a [`Document`][tomlrt.Document] back to a TOML string.
+
+    A mapping that is not already a [`Document`][tomlrt.Document] is
+    wrapped in one first, so ``tomlrt.dumps({"a": 1})`` works.
+    """
+    doc = data if isinstance(data, Document) else Document(data)
     return doc.render()
 
 
-def dump(doc: Document, fp: IO[bytes]) -> None:
+def dump(data: Mapping[str, Any], fp: IO[bytes]) -> None:
     """Serialize a [`Document`][tomlrt.Document] and write it to a *binary* stream.
 
     The file must be opened in binary mode (``open(path, "wb")``).
+
+    Accepts a plain mapping as well as a [`Document`][tomlrt.Document]
+    (see [`dumps`][tomlrt.dumps]).
     """
-    fp.write(dumps(doc).encode("utf-8"))
+    fp.write(dumps(data).encode("utf-8"))
 
 
 __all__ = ["dump", "dumps", "load", "loads"]

--- a/tests/test_synthesise_and_io.py
+++ b/tests/test_synthesise_and_io.py
@@ -86,6 +86,45 @@ def test_dump_emits_utf8_for_non_ascii() -> None:
     assert out.getvalue() == "name = 'café'\n".encode()
 
 
+def test_dumps_accepts_plain_dict() -> None:
+    out = tomlrt.dumps({"a": 1, "s": {"b": 2}})
+    assert out == td(
+        """
+        a = 1
+
+        [s]
+        b = 2
+        """
+    )
+
+
+def test_dumps_document_is_byte_exact() -> None:
+    src = td(
+        """
+        # preamble
+        a = 1 # eol
+        """
+    )
+    doc = tomlrt.loads(src)
+    assert tomlrt.dumps(doc) == src
+
+
+def test_dumps_accepts_table() -> None:
+    out = tomlrt.dumps(Table.section({"k": "v"}))
+    assert out == 'k = "v"\n'
+
+
+def test_dump_accepts_plain_dict() -> None:
+    out = io.BytesIO()
+    tomlrt.dump({"a": 1}, out)
+    assert out.getvalue() == b"a = 1\n"
+
+
+def test_dumps_rejects_non_mapping() -> None:
+    with pytest.raises(TypeError):
+        tomlrt.dumps([1, 2, 3])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
 # ---------------------------------------------------------------------------
 # String escaping (every branch in _escape_basic_string)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Users were surprised that serializing required constructing a Document by hand. dumps/dump now wrap any non-Document mapping in a Document, so tomlrt.dumps({"a": 1}) just works; passing a Document still round-trips byte-exactly.