### PR TITLE
Widen Container.pop key parameter to satisfy LSP

### DIFF
--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -749,8 +749,9 @@ class Container(dict[str, Any]):
             del self[k]
 
     @override
-    def pop(self, key: str, default: Any = _MISSING) -> Any:
+    def pop(self, key: object, default: Any = _MISSING) -> Any:
         if key in self:
+            assert isinstance(key, str)
             value = dict.__getitem__(self, key)
             del self[key]
             return value

--- a/tests/test_dict_semantics.py
+++ b/tests/test_dict_semantics.py
@@ -208,6 +208,20 @@ def test_pop_default_when_missing() -> None:
     assert doc.pop("missing", sentinel) is sentinel
 
 
+def test_pop_non_str_key_is_treated_as_missing() -> None:
+    doc = tomlrt.loads("a = 1\n")
+    sentinel = object()
+    assert doc.pop(123, sentinel) is sentinel
+    with pytest.raises(KeyError):
+        doc.pop(123)
+    # Unhashable keys raise TypeError, matching ``dict.pop``.
+    with pytest.raises(TypeError):
+        doc.pop([], sentinel)
+    with pytest.raises(TypeError):
+        doc.pop([])
+    assert tomlrt.dumps(doc) == "a = 1\n"
+
+
 def test_popitem_lifo() -> None:
     doc = tomlrt.loads(
         td("""


### PR DESCRIPTION
ty's invalid-method-override check flags Container.pop because typeshed types dict.pop's key as `object` (it only queries the key, never stores it), so narrowing to `str` violates the Liskov Substitution Principle. Widen the parameter to `object` to match the base, keeping the existing membership-then-narrow structure so behaviour stays identical to dict.pop, including the TypeError raised for unhashable keys.