### PR TITLE
Fix del/pop/clear on a detached Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `del`, `pop`, and `clear` on a detached `Table.section()` / `Table.inline()`
+  now remove the key instead of raising `AssertionError`.
+
 ## [2.0.0] - 2026-06-22
 
 ### Added

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -733,6 +733,10 @@ class Container(dict[str, Any]):
 
     @override
     def __delitem__(self, key: str) -> None:
+        # Unattached factory mode: dict-only storage until attach.
+        if self._layout_root is None:
+            dict.__delitem__(self, key)
+            return
         if self._inline:
             self._inline_delitem(key)
             return

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -959,9 +959,7 @@ def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> No
     ``_path``; structural mutation through them raises
     ``NotImplementedError`` rather than corrupting the live document.
     """
-    if key not in c:
-        raise KeyError(key)
-    val = dict.__getitem__(c, key)
+    val = dict.__getitem__(c, key)  # raises KeyError if absent
     doc = c._attached_doc  # noqa: SLF001
 
     # Re-materialisation bookkeeping for the public delete API. When the

--- a/tests/test_live_attach.py
+++ b/tests/test_live_attach.py
@@ -41,6 +41,60 @@ def test_inline_factory_can_be_populated_before_assignment() -> None:
     assert dict(t) == {"x": 1, "y": "hello"}
 
 
+def test_detached_section_del_removes_key() -> None:
+    t = Table.section({"a": 1, "b": 2})
+    del t["a"]
+    assert dict(t) == {"b": 2}
+
+
+def test_detached_section_pop_and_clear() -> None:
+    t = Table.section({"a": 1, "b": 2})
+    assert t.pop("a") == 1
+    assert dict(t) == {"b": 2}
+    t.clear()
+    assert dict(t) == {}
+
+
+def test_detached_section_del_missing_key_raises_keyerror() -> None:
+    t = Table.section({"a": 1})
+    with pytest.raises(KeyError):
+        del t["nope"]
+
+
+def test_detached_inline_del_removes_key() -> None:
+    t = Table.inline({"a": 1, "b": 2})
+    del t["a"]
+    assert dict(t) == {"b": 2}
+
+
+def test_detached_inline_nested_del_removes_key() -> None:
+    t = Table.inline({"a": {"b": 1, "c": 2}})
+    del t["a"]["b"]
+    assert dict(t["a"]) == {"c": 2}
+
+
+def test_detached_section_del_then_attach_round_trips() -> None:
+    t = Table.section({"a": 1, "b": 2, "c": 3})
+    del t["b"]
+    doc = tomlrt.loads("")
+    doc["x"] = t
+    assert tomlrt.dumps(doc) == td(
+        """
+        [x]
+        a = 1
+        c = 3
+        """,
+    )
+
+
+def test_detached_inline_del_then_attach_round_trips() -> None:
+    t = Table.inline({"p": 1, "q": 2})
+    del t["p"]
+    doc = tomlrt.loads("")
+    doc["y"] = t
+    assert tomlrt.dumps(doc) == "y = { q = 2 }\n"
+
+
 def test_inline_factory_renders_with_spaced_braces() -> None:
     # Synthesised inline tables use the same spaced ({ k = v }) style
     # as plain dicts assigned through value_to_node. Empty stays {}.


### PR DESCRIPTION
Closes #204.

## Problem

`del`, `pop`, and `clear` on a detached `Table.section()` / `Table.inline()` raised `AssertionError: container is not attached to a document` (and a different internal assert for inline) instead of removing the key. `Table` is a `dict` subclass, so this was surprising — and because it was a bare `assert`, the failure mode changed under `python -O`.

The root cause was an asymmetry: `__setitem__` already had a detached-mode early-out (`if self._layout_root is None: dict.__setitem__(...)`), but `__delitem__` went straight to the layout/inline mutation primitives, which assume an attached document.

## Fix

- `__delitem__` gets a matching detached-mode early-out, so removal behaves like a plain dict. `pop` and `clear` route through `__delitem__`, so they are fixed too.
- Dropped the now-redundant key-presence guard in `delete_key`: the immediately following `dict.__getitem__` raises the same `KeyError`.

## Tests

7 new cases in `tests/test_live_attach.py`: detached section/inline `del`, `pop`, `clear`, missing-key `KeyError`, and attach-after-delete round-trips.

All five checks (pytest, mypy, ty, ruff check, ruff format) pass.