### PR TITLE
Derive KVSlot.key instead of caching it

### DIFF
--- a/src/tomlrt/_build.py
+++ b/src/tomlrt/_build.py
@@ -191,11 +191,12 @@ def _apply_kv(slot: KVSlot, *, host: Container) -> None:
     threaded from the most recent header; decoded value attachment
     cascades through ``host._layout_root``.
     """
-    decoded = slot.key
+    parts = slot.key_parts
     # Logical chain for dotted-KV intermediates: host -> ... -> leaf parent.
     leaf_chain: list[Container] = [host]
     cur = host
-    for step in decoded[:-1]:
+    for part in parts[:-1]:
+        step = part.value
         sub = cur.get(step)
         if sub is None:
             child_path = (*cur._path, step)  # noqa: SLF001
@@ -209,7 +210,7 @@ def _apply_kv(slot: KVSlot, *, host: Container) -> None:
             cur = sub
         leaf_chain.append(cur)
     target = leaf_chain[-1]
-    name = decoded[-1]
+    name = parts[-1].value
     assert name not in target, (
         f"duplicate key {name!r} reached builder under {target._path}; "  # noqa: SLF001
         "validator drift"

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -1458,7 +1458,6 @@ def _new_kv_slot(
         value=value,
         eol=_default_eol(doc),
         owner_aot_entry=owner,
-        key=key,
     )
 
 
@@ -2834,7 +2833,6 @@ def _rebase_implicit_slot_in_place(
         new_key = (*new_prefix, *within)[len(host_path) :]
         head_n = len(new_key) - len(within)
         s.host_path = host_path
-        s.key = new_key
         s.key_parts = (
             make_keyparts(new_key[:head_n])
             + s.key_parts[len(s.key_parts) - len(within) :]

--- a/src/tomlrt/_parser.py
+++ b/src/tomlrt/_parser.py
@@ -176,7 +176,6 @@ class _Parser:
             value=value,
             eol=eol,
             owner_aot_entry=owner,
-            key=key_path,
         )
         if owner is not None:
             owner.entry_slots.append(slot)

--- a/src/tomlrt/_slots.py
+++ b/src/tomlrt/_slots.py
@@ -114,12 +114,10 @@ class KVSlot(Slot):
     value: Value = field(kw_only=True)
     eol: EolTrivia = field(kw_only=True)
 
-    key: tuple[str, ...] = field(kw_only=True)
-    """Decoded dotted-key path.
-
-    Set by every construction site so ``_build._apply_kv`` can avoid
-    re-walking ``key_parts``.
-    """
+    @property
+    def key(self) -> tuple[str, ...]:
+        """Decoded dotted-key path, derived from ``key_parts``."""
+        return tuple(p.value for p in self.key_parts)
 
     def render_key(self) -> str:
         return render_dotted(self.key_parts, self.key_seps)
@@ -209,7 +207,7 @@ class SlotRef:
         slot = self.slot
         c_path = self.container._path  # noqa: SLF001
         if isinstance(slot, KVSlot):
-            return slot.key[len(c_path) - len(slot.host_path)]
+            return slot.key_parts[len(c_path) - len(slot.host_path)].value
         assert isinstance(slot, StructuralHeaderSlot)
         if slot.path == c_path:
             return None


### PR DESCRIPTION
KVSlot.key was a stored decoded copy of key_parts, kept in sync by hand at every construction and rebase site (a four-field update alongside host_path / key_parts / key_seps). It is exactly
tuple(p.value for p in key_parts), so make it a property and drop the stored field, removing the sync burden and one source of potential drift.

The two hot readers no longer materialise the tuple: SlotRef.local_key indexes key_parts[i].value directly, and _build._apply_kv walks key_parts rather than the derived key. This leaves the key property with no hot caller, so parse and mutation benchmarks are unchanged within noise (a worst-case 20k x 8-part dotted-key parse is at parity).