### PR TITLE
Derive AoTEntry.path from its header slot

### DIFF
--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -2235,7 +2235,7 @@ def add_aot_entry(
     # the placeholder's in-body position, which could otherwise capture
     # trailing parent KVs on re-parse.
     _consume_first_entry_placeholder(aot, ordinal)
-    entry = AoTEntry(path=path)
+    entry = AoTEntry()
     leading = _build_section_leading(doc) if ordinal == 0 else _aot_separator(aot, doc)
     header = _new_section_header(
         path,
@@ -2406,7 +2406,7 @@ def _install_cloned_aot_entry(
 
     ordinal = len(aot)
     _consume_first_entry_placeholder(aot, ordinal)
-    new_entry = AoTEntry(path=target_path)
+    new_entry = AoTEntry()
 
     cloned_slots = _clone_entry_slots(
         src_slots,
@@ -2721,8 +2721,6 @@ def _rebase_slot_in_place(
 ) -> None:
     """Rebase one slot in place; the reused AoT-entry's path moves with it."""
     _retarget_slot_paths(s, old_prefix, new_prefix, nl)
-    if isinstance(s, StructuralHeaderSlot) and s.entry is not None:
-        s.entry.path = _rebase_path(s.entry.path, old_prefix, new_prefix)
 
 
 def _rehome_view_tree(
@@ -2923,9 +2921,7 @@ def _clone_entry_slots(
             continue
         if id(s.entry) in nested_entry_map:
             continue
-        nested_entry_map[id(s.entry)] = AoTEntry(
-            path=_rebase_path(s.entry.path, src_prefix, target_prefix),
-        )
+        nested_entry_map[id(s.entry)] = AoTEntry()
 
     cloned: list[Slot] = []
     for s in src_slots:

--- a/src/tomlrt/_slots.py
+++ b/src/tomlrt/_slots.py
@@ -37,11 +37,18 @@ class AoTEntry:
     """Identifies one entry of an array-of-tables.
 
     Carried by every physical slot in that entry. ``entry_slots`` is a
-    membership list populated by the slot-builder.
+    membership list populated by the slot-builder, with the entry's
+    ``[[a]]`` header kept first; :attr:`path` is derived from it.
     """
 
-    path: tuple[str, ...]
     entry_slots: list[Slot] = field(default_factory=list)
+
+    @property
+    def path(self) -> tuple[str, ...]:
+        """Decoded path of the entry, taken from its header slot."""
+        header = self.entry_slots[0]
+        assert isinstance(header, StructuralHeaderSlot)
+        return header.path
 
 
 # ---------------------------------------------------------------------------

--- a/src/tomlrt/_validator.py
+++ b/src/tomlrt/_validator.py
@@ -114,7 +114,7 @@ class _Validator:
             self._reset_scope_under(path)
             self._aot_paths.add(path)
             self._track(path)
-            new_entry = AoTEntry(path=path)
+            new_entry = AoTEntry()
             self._active_aot_entries[path] = new_entry
 
         # Intermediate prefixes become implicit tables.


### PR DESCRIPTION
AoTEntry.path duplicated the path already carried by the entry's header slot (entry_slots[0], a StructuralHeaderSlot kept first by the builder). Keeping the copy meant rehome had to rebase entry.path by hand alongside the header's own path, and clone construction had to pass a separately-rebased path.

Derive path from the header instead. Rebasing the header's path now updates the entry's path for free, so _rebase_slot_in_place drops its explicit entry-path write and _clone_entry_slots constructs bare AoTEntry() values. The full suite, the property tests, and the toml-test mutation fuzzer (multiple fresh seeds) stay green.