### PR TITLE
Deduplicate slot-splice, comment-view, and section-attach helpers

### DIFF
--- a/src/tomlrt/_array.py
+++ b/src/tomlrt/_array.py
@@ -322,7 +322,6 @@ class Array(list[Any]):
 
     @override
     def insert(self, index: SupportsIndex, value: Any) -> None:
-        cst, decoded = self._synth_cst(value)
         i = int(index)
         n = len(self)
         if i < 0:
@@ -331,6 +330,7 @@ class Array(list[Any]):
         if i == n:
             self.append(value)
             return
+        cst, decoded = self._synth_cst(value)
         style = self._style()
         new_item = _make_item(cst, has_comma=True)
         splice_insert(self._value, new_item, i, style, self._doc_newline)

--- a/src/tomlrt/_comments.py
+++ b/src/tomlrt/_comments.py
@@ -125,6 +125,12 @@ class _SlotKeyedView(MutableMapping[str, _T]):
     def _slot(self, key: str) -> KVSlot | None:
         return _direct_kv_slot(self._c, key)
 
+    def _require_slot(self, key: str, *, missing_msg: str | None = None) -> KVSlot:
+        slot = self._slot(key)
+        if slot is None:
+            raise KeyError(key if missing_msg is None else missing_msg)
+        return slot
+
     def _present(self, slot: KVSlot) -> bool:
         raise NotImplementedError
 
@@ -165,26 +171,23 @@ class EolCommentView(_SlotKeyedView[str]):
 
     @override
     def __getitem__(self, key: str) -> str:
-        slot = self._slot(key)
-        if slot is None or slot.eol.comment is None:
+        slot = self._require_slot(key)
+        if slot.eol.comment is None:
             raise KeyError(key)
         return _decode_comment(slot.eol.comment.text)
 
     @override
     def __setitem__(self, key: str, value: str) -> None:
         _require_attached(self._c)
-        slot = self._slot(key)
-        if slot is None:
-            msg = f"key {key!r} not in container"
-            raise KeyError(msg)
+        slot = self._require_slot(key, missing_msg=f"key {key!r} not in container")
         _validate_comment_str(value, "comment")
         _write_eol_comment(slot.eol, value, self._c._doc_newline)  # noqa: SLF001
 
     @override
     def __delitem__(self, key: str) -> None:
         _require_attached(self._c)
-        slot = self._slot(key)
-        if slot is None or slot.eol.comment is None:
+        slot = self._require_slot(key)
+        if slot.eol.comment is None:
             raise KeyError(key)
         slot.eol.comment = None
         # Also drop the gap-whitespace that preceded the comment so we
@@ -283,18 +286,21 @@ def _validate_comment_entry(c: str, name: str) -> None:
     _validate_comment_text(c)
 
 
-def _validate_block_seq(value: object, name: str) -> tuple[str | None, ...]:
-    """Type-check a leading-block tuple; entries are ``str`` or ``None``."""
+def _validate_comment_entries(
+    value: object, name: str, *, allow_none: bool
+) -> tuple[str | None, ...]:
+    """Type-check a comment iterable, optionally allowing ``None`` entries."""
+    kind = "comment strings or None" if allow_none else "comment strings"
     if isinstance(value, str) or not isinstance(value, Iterable):
-        msg = f"{name} must be an iterable of comment strings or None"
+        msg = f"{name} must be an iterable of {kind}"
         raise TypeError(msg)
     out: list[str | None] = []
     for c in value:
-        if c is None:
+        if c is None and allow_none:
             out.append(None)
             continue
         if not isinstance(c, str):
-            msg = f"{name} entries must be strings or None"
+            msg = f"{name} entries must be strings{' or None' if allow_none else ''}"
             raise TypeError(msg)
         _validate_comment_entry(c, name)
         out.append(c)
@@ -326,27 +332,22 @@ class LeadingCommentView(_SlotKeyedView[tuple[str, ...]]):
 
     @override
     def __getitem__(self, key: str) -> tuple[str, ...]:
-        slot = self._slot(key)
-        if slot is None or not _slot_has_attached_comments(slot):
+        slot = self._require_slot(key)
+        if not _slot_has_attached_comments(slot):
             raise KeyError(key)
         return _extract_leading_comments(slot.leading)
 
     @override
     def __setitem__(self, key: str, value: tuple[str, ...]) -> None:
         _require_attached(self._c)
-        slot = self._slot(key)
-        if slot is None:
-            msg = f"key {key!r} not in container"
-            raise KeyError(msg)
+        slot = self._require_slot(key, missing_msg=f"key {key!r} not in container")
         comments = _validate_comment_seq(value, "leading_comments")
         _set_attached_block(slot.leading, comments, self._c._doc_newline)  # noqa: SLF001
 
     @override
     def __delitem__(self, key: str) -> None:
         _require_attached(self._c)
-        slot = self._slot(key)
-        if slot is None:
-            raise KeyError(key)
+        slot = self._require_slot(key)
         if not _slot_has_attached_comments(slot):
             raise KeyError(key)
         above, _attached, indent = _split_attached_block(slot.leading)
@@ -376,9 +377,7 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
 
     @override
     def __getitem__(self, key: str) -> tuple[str | None, ...]:
-        slot = self._slot(key)
-        if slot is None:
-            raise KeyError(key)
+        slot = self._require_slot(key)
         block = _read_leading_block(self._c, slot)
         if not block:
             raise KeyError(key)
@@ -387,19 +386,14 @@ class LeadingBlockView(_SlotKeyedView[tuple[str | None, ...]]):
     @override
     def __setitem__(self, key: str, value: tuple[str | None, ...]) -> None:
         _require_attached(self._c)
-        slot = self._slot(key)
-        if slot is None:
-            msg = f"key {key!r} not in container"
-            raise KeyError(msg)
-        block = _validate_block_seq(value, "leading_block")
+        slot = self._require_slot(key, missing_msg=f"key {key!r} not in container")
+        block = _validate_comment_entries(value, "leading_block", allow_none=True)
         _write_leading_block(self._c, slot, block)
 
     @override
     def __delitem__(self, key: str) -> None:
         _require_attached(self._c)
-        slot = self._slot(key)
-        if slot is None:
-            raise KeyError(key)
+        slot = self._require_slot(key)
         if not _read_leading_block(self._c, slot):
             raise KeyError(key)
         _write_leading_block(self._c, slot, ())
@@ -423,9 +417,16 @@ def _header_slot(c: Container) -> StructuralHeaderSlot | None:
     return slot
 
 
-def _header_comment_get(c: Container) -> str | None:
+def _require_header_slot(c: Container, msg: str) -> StructuralHeaderSlot:
+    """Return ``c``'s header slot or raise ``TOMLError`` with ``msg``."""
     h = _header_slot(c)
     if h is None:
+        raise TOMLError(msg)
+    return h
+
+
+def _header_comment_get(c: Container) -> str | None:
+    if (h := _header_slot(c)) is None:
         # No header line means no header comment; mirror the empty
         # state of an explicit section. Setters still raise; silently
         # dropping a write would be a footgun.
@@ -437,10 +438,7 @@ def _header_comment_get(c: Container) -> str | None:
 
 
 def _header_comment_set(c: Container, value: str | None) -> None:
-    h = _header_slot(c)
-    if h is None:
-        msg = "container has no header to attach a comment to"
-        raise TOMLError(msg)
+    h = _require_header_slot(c, "container has no header to attach a comment to")
     eol = h.eol
     if value is None:
         if eol.comment is not None:
@@ -453,51 +451,37 @@ def _header_comment_set(c: Container, value: str | None) -> None:
 
 
 def _header_leading_get(c: Container) -> tuple[str, ...]:
-    h = _header_slot(c)
-    if h is None:
+    if (h := _header_slot(c)) is None:
         # See _header_comment_get: no header line, no comments above it.
         return ()
     return _extract_leading_comments(h.leading)
 
 
 def _header_leading_set(c: Container, value: tuple[str, ...]) -> None:
-    h = _header_slot(c)
-    if h is None:
-        msg = "container has no header to attach leading comments to"
-        raise TOMLError(msg)
+    h = _require_header_slot(c, "container has no header to attach leading comments to")
     comments = _validate_comment_seq(value, "header_leading_comments")
     _set_attached_block(h.leading, comments, c._doc_newline)  # noqa: SLF001
 
 
 def _header_leading_block_get(c: Container) -> tuple[str | None, ...]:
-    h = _header_slot(c)
-    if h is None:
+    if (h := _header_slot(c)) is None:
         # See _header_comment_get: no header line, no block above it.
         return ()
     return _read_leading_block(c, h)
 
 
 def _header_leading_block_set(c: Container, value: tuple[str | None, ...]) -> None:
-    h = _header_slot(c)
-    if h is None:
-        msg = "container has no header to attach a leading block to"
-        raise TOMLError(msg)
-    block = _validate_block_seq(value, "header_leading_block")
+    h = _require_header_slot(c, "container has no header to attach a leading block to")
+    block = _validate_comment_entries(value, "header_leading_block", allow_none=True)
     _write_leading_block(c, h, block)
 
 
 def _validate_comment_seq(value: object, name: str) -> tuple[str, ...]:
-    if isinstance(value, str) or not isinstance(value, Iterable):
-        msg = f"{name} must be an iterable of comment strings"
-        raise TypeError(msg)
-    out: list[str] = []
-    for c in value:
-        if not isinstance(c, str):
-            msg = f"{name} entries must be strings"
-            raise TypeError(msg)
-        _validate_comment_entry(c, name)
-        out.append(c)
-    return tuple(out)
+    return tuple(
+        c
+        for c in _validate_comment_entries(value, name, allow_none=False)
+        if c is not None
+    )
 
 
 def _line_to_comment(line: Iterable[TriviaPiece]) -> str | None:
@@ -542,6 +526,19 @@ def _write_eol_comment(eol: EolTrivia, text: str, nl: str) -> None:
         eol.newline = NewlineNode(nl)
 
 
+def _render_doc_comment_lines(
+    block: tuple[str | None, ...], nl: str
+) -> list[TriviaPiece]:
+    """Render document-level comment lines, using ``None`` for blanks."""
+    pieces: list[TriviaPiece] = []
+    for entry in block:
+        if entry is None:
+            pieces.append(NewlineNode(nl))
+        else:
+            pieces.extend((CommentNode(_encode_comment(entry)), NewlineNode(nl)))
+    return pieces
+
+
 def _doc_preamble_get(doc: Document) -> tuple[str, ...]:
     lines = split_lines(doc._preamble.pieces)  # noqa: SLF001
     # Drop the trailing blank-line separator before the first slot.
@@ -556,9 +553,7 @@ def _doc_preamble_set(doc: Document, value: tuple[str, ...]) -> None:
     if not comments:
         doc._preamble.pieces = []  # noqa: SLF001
         return
-    pieces: list[TriviaPiece] = []
-    for c in comments:
-        pieces.extend((CommentNode(_encode_comment(c)), NewlineNode(nl)))
+    pieces = _render_doc_comment_lines(comments, nl)
     # Append a blank-line separator before the first slot.
     if doc._head is not None:  # noqa: SLF001
         pieces.append(NewlineNode(nl))
@@ -573,18 +568,12 @@ def _doc_epilogue_get(doc: Document) -> tuple[str | None, ...]:
 
 
 def _doc_epilogue_set(doc: Document, value: tuple[str | None, ...]) -> None:
-    block = _validate_block_seq(value, "epilogue")
+    block = _validate_comment_entries(value, "epilogue", allow_none=True)
     if doc._head is None and block:  # noqa: SLF001
         msg = "cannot set epilogue: document has no structural content"
         raise TOMLError(msg)
     nl = doc._newline  # noqa: SLF001
-    new_pieces: list[TriviaPiece] = []
-    for entry in block:
-        if entry is None:
-            new_pieces.append(NewlineNode(nl))
-        else:
-            new_pieces.extend((CommentNode(_encode_comment(entry)), NewlineNode(nl)))
-    doc._trailing.pieces = new_pieces  # noqa: SLF001
+    doc._trailing.pieces = _render_doc_comment_lines(block, nl)  # noqa: SLF001
 
 
 __all__ = ["EolCommentView", "LeadingBlockView", "LeadingCommentView"]

--- a/src/tomlrt/_container.py
+++ b/src/tomlrt/_container.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from tomlrt._slots import AoTEntry, Slot, SlotRef
-    from tomlrt._trivia import TriviaPiece
+    from tomlrt._trivia import EolTrivia, TriviaPiece
     from tomlrt._values import (
         CommaItem,
         CommaValue,
@@ -478,6 +478,26 @@ class Container(dict[str, Any]):
             out[k] = _to_python(v)
         return out
 
+    def _synth_local_value(self, key: str, value: object) -> tuple[Value, object]:
+        """Synthesise ``value`` for direct storage under ``key`` on ``self``."""
+        return _synth_value(
+            value,
+            layout_root=self._layout_root,
+            parent=self,
+            path=(*self._path, key),
+            owner=self._owner_aot_entry,
+        )
+
+    def _require_promotable_entry(self, key: str, *, action: str) -> object:
+        """Return ``self[key]`` after the shared promotion pre-checks."""
+        if self._inline:
+            msg = f"{action} is not supported on inline tables"
+            raise TOMLError(msg)
+        if key not in self:
+            msg = f"key {key!r} not in table"
+            raise KeyError(msg)
+        return dict.__getitem__(self, key)
+
     # ------------------------------------------------------------------
     # Mutation
     # ------------------------------------------------------------------
@@ -556,13 +576,7 @@ class Container(dict[str, Any]):
     def _insert_new(self, key: str, value: Any) -> None:
         """Bind ``key`` for the first time at the document tail."""
         if is_scalar(value) or _is_synth_inline(value):
-            cst, decoded = _synth_value(
-                value,
-                layout_root=self._layout_root,
-                parent=self,
-                path=(*self._path, key),
-                owner=self._owner_aot_entry,
-            )
+            cst, decoded = self._synth_local_value(key, value)
             _layout_ops.append_direct_kv(self, key, cst)
             dict.__setitem__(self, key, decoded)
             return
@@ -696,13 +710,7 @@ class Container(dict[str, Any]):
             msg = "structural overwrite of header-bound binding is not supported"
             raise NotImplementedError(msg)
         old = dict.__getitem__(self, key)
-        cst, decoded = _synth_value(
-            value,
-            layout_root=self._layout_root,
-            parent=self,
-            path=(*self._path, key),
-            owner=self._owner_aot_entry,
-        )
+        cst, decoded = self._synth_local_value(key, value)
         slot.value = cst
         dict.__setitem__(self, key, decoded)
         # Detach the displaced view so it can be reattached live.
@@ -873,13 +881,7 @@ class Container(dict[str, Any]):
         # ``__setitem__`` has already rejected ``AoT`` / section values
         # for inline hosts. Non-coerceable types (``set``, custom
         # classes, …) reach ``_synth_value`` for the canonical TypeError.
-        cst, decoded = _synth_value(
-            value,
-            layout_root=self._layout_root,
-            parent=self,
-            path=(*self._path, key),
-            owner=self._owner_aot_entry,
-        )
+        cst, decoded = self._synth_local_value(key, value)
         if key in self and isinstance(dict.__getitem__(self, key), Container):
             # Stay on the CST side when replacing a dotted-prefix
             # navigator; dict-level delete would prune the parent chain.
@@ -940,23 +942,9 @@ class Container(dict[str, Any]):
         if (is_section or is_aot) and len(parts) > 1 and self._layout_root is not None:
             # Walk existing prefix; whatever's left is created with
             # implicit intermediates plus the final explicit binding.
-            cur: Container = self
-            i = 0
-            while i < len(parts) - 1:
-                p = parts[i]
-                if p not in cur:
-                    break
-                nxt = dict.__getitem__(cur, p)
-                if isinstance(nxt, AoT):
-                    msg = (
-                        f"cannot install through array-of-tables at {p!r}: "
-                        "no addressable target inside an AoT"
-                    )
-                    raise TOMLError(msg)
-                if not isinstance(nxt, Container) or nxt._inline:  # noqa: SLF001
-                    break
-                cur = nxt
-                i += 1
+            cur, i = _walk_existing_sections(
+                self, parts, limit=len(parts) - 1, stop_on_non_section=True
+            )
             # Drop conflicting inline-tail keys before installing the
             # section, or a stale inline value would shadow it.
             if (
@@ -996,33 +984,9 @@ class Container(dict[str, Any]):
         value or inline table that would have to be traversed.
         """
         parts = validate_path(key)
-        cur: Container = self
-        i = 0
-        while i < len(parts):
-            p = parts[i]
-            if p not in cur:
-                break
-            nxt = dict.__getitem__(cur, p)
-            if isinstance(nxt, AoT):
-                msg = (
-                    f"cannot ensure_table through array-of-tables at {p!r}: "
-                    "no addressable target inside an AoT"
-                )
-                raise TOMLError(msg)
-            if not isinstance(nxt, Container):
-                msg = (
-                    f"existing value at {p!r} is not section-backed "
-                    "(is an inline table or non-table value)"
-                )
-                raise TOMLError(msg)
-            if nxt._inline and i < len(parts) - 1:  # noqa: SLF001
-                msg = (
-                    f"existing value at {p!r} is not section-backed "
-                    "(is an inline table or non-table value)"
-                )
-                raise TOMLError(msg)
-            cur = nxt
-            i += 1
+        cur, i = _walk_existing_sections(
+            self, parts, limit=len(parts), stop_on_non_section=False
+        )
         if i == len(parts):
             assert isinstance(cur, Table)
             return cur
@@ -1050,13 +1014,7 @@ class Container(dict[str, Any]):
         ``KeyError`` if the key is missing, or ``TypeError`` if it
         doesn't refer to an inline-style table.
         """
-        if self._inline:
-            msg = "inline-table promotion is not supported on inline tables"
-            raise TOMLError(msg)
-        if key not in self:
-            msg = f"key {key!r} not in table"
-            raise KeyError(msg)
-        cur = dict.__getitem__(self, key)
+        cur = self._require_promotable_entry(key, action="inline-table promotion")
         if not (_is_inline_table(cur)):
             msg = f"{key!r} is not an inline table"
             raise TypeError(msg)
@@ -1067,9 +1025,7 @@ class Container(dict[str, Any]):
             )
             raise TOMLError(msg)
         # Transfer the existing KV slot's leading + eol to the header.
-        old_slot = _direct_kv_slot(self, key)
-        saved_leading = old_slot.leading if old_slot is not None else None
-        saved_eol = old_slot.eol if old_slot is not None else None
+        saved_leading, saved_eol = _direct_kv_trivia(self, key)
         snapshot = cur.to_dict()
         _layout_ops.delete_key(self, key)
         self[key] = Table.section(snapshot)
@@ -1101,13 +1057,7 @@ class Container(dict[str, Any]):
         ``TOMLError`` for an empty array or an array with
         non-inline-table elements.
         """
-        if self._inline:
-            msg = "array-of-tables promotion is not supported on inline tables"
-            raise TOMLError(msg)
-        if key not in self:
-            msg = f"key {key!r} not in table"
-            raise KeyError(msg)
-        cur = dict.__getitem__(self, key)
+        cur = self._require_promotable_entry(key, action="array-of-tables promotion")
         if not isinstance(cur, Array):
             msg = f"{key!r} is not an array"
             raise TypeError(msg)
@@ -1132,9 +1082,7 @@ class Container(dict[str, Any]):
                     raise TOMLError(msg)
         snapshot = cur.to_list()
         # Carry the original KV slot's leading/eol onto the promoted AoT.
-        old_slot = _direct_kv_slot(self, key)
-        saved_leading = old_slot.leading if old_slot is not None else None
-        saved_eol = old_slot.eol if old_slot is not None else None
+        saved_leading, saved_eol = _direct_kv_trivia(self, key)
         _layout_ops.delete_key(self, key)
         self[key] = AoT(snapshot)
         result = dict.__getitem__(self, key)
@@ -1181,6 +1129,49 @@ def _reorder_dict_storage(c: Container, new_key_order: list[str]) -> None:
     dict.clear(c)
     for k, v in values:
         dict.__setitem__(c, k, v)
+
+
+def _direct_kv_trivia(c: Container, key: str) -> tuple[Trivia | None, EolTrivia | None]:
+    """Return the direct-KV slot's leading/EOL trivia for ``key``, if any."""
+    slot = _direct_kv_slot(c, key)
+    if slot is None:
+        return None, None
+    return slot.leading, slot.eol
+
+
+def _walk_existing_sections(
+    start: Container,
+    parts: Sequence[str],
+    *,
+    limit: int,
+    stop_on_non_section: bool,
+) -> tuple[Container, int]:
+    """Walk the existing section-backed prefix of ``parts`` under ``start``."""
+    cur: Container = start
+    i = 0
+    while i < limit:
+        p = parts[i]
+        if p not in cur:
+            break
+        nxt = dict.__getitem__(cur, p)
+        if isinstance(nxt, AoT):
+            action = "install" if stop_on_non_section else "ensure_table"
+            msg = (
+                f"cannot {action} through array-of-tables at {p!r}: "
+                "no addressable target inside an AoT"
+            )
+            raise TOMLError(msg)
+        if not isinstance(nxt, Container) or (nxt._inline and i < len(parts) - 1):  # noqa: SLF001
+            if stop_on_non_section:
+                break
+            msg = (
+                f"existing value at {p!r} is not section-backed "
+                "(is an inline table or non-table value)"
+            )
+            raise TOMLError(msg)
+        cur = nxt
+        i += 1
+    return cur, i
 
 
 def _populate_unattached(t: Container, mapping: Mapping[str, Any]) -> None:

--- a/src/tomlrt/_layout_ops.py
+++ b/src/tomlrt/_layout_ops.py
@@ -488,12 +488,16 @@ def _default_eol(doc: Document) -> EolTrivia:
     )
 
 
-def insert_after(anchor: Slot, new_slot: Slot, doc: Document) -> None:
-    """Splice ``new_slot`` immediately after ``anchor`` in ``doc``."""
-    nxt = anchor._next  # noqa: SLF001
-    new_slot._prev = anchor  # noqa: SLF001
+def _insert_between(
+    prev: Slot | None, new_slot: Slot, nxt: Slot | None, doc: Document
+) -> None:
+    """Splice ``new_slot`` between ``prev`` and ``nxt`` in ``doc``."""
+    new_slot._prev = prev  # noqa: SLF001
     new_slot._next = nxt  # noqa: SLF001
-    anchor._next = new_slot  # noqa: SLF001
+    if prev is not None:
+        prev._next = new_slot  # noqa: SLF001
+    else:
+        doc._head = new_slot  # noqa: SLF001
     if nxt is not None:
         nxt._prev = new_slot  # noqa: SLF001
     else:
@@ -501,17 +505,14 @@ def insert_after(anchor: Slot, new_slot: Slot, doc: Document) -> None:
     _record_new_slot(doc, new_slot)
 
 
+def insert_after(anchor: Slot, new_slot: Slot, doc: Document) -> None:
+    """Splice ``new_slot`` immediately after ``anchor`` in ``doc``."""
+    _insert_between(anchor, new_slot, anchor._next, doc)  # noqa: SLF001
+
+
 def insert_before(anchor: Slot, new_slot: Slot, doc: Document) -> None:
     """Splice ``new_slot`` immediately before ``anchor`` in ``doc``."""
-    p = anchor._prev  # noqa: SLF001
-    new_slot._prev = p  # noqa: SLF001
-    new_slot._next = anchor  # noqa: SLF001
-    anchor._prev = new_slot  # noqa: SLF001
-    if p is not None:
-        p._next = new_slot  # noqa: SLF001
-    else:
-        doc._head = new_slot  # noqa: SLF001
-    _record_new_slot(doc, new_slot)
+    _insert_between(anchor._prev, new_slot, anchor, doc)  # noqa: SLF001
 
 
 def insert_before_head(new_slot: Slot, doc: Document) -> None:
@@ -523,15 +524,7 @@ def insert_before_head(new_slot: Slot, doc: Document) -> None:
     :attr:`Document.preamble` or parsed from a comment-only source)
     should follow up with :func:`_promote_trailing_to_preamble`.
     """
-    head = doc._head  # noqa: SLF001
-    new_slot._prev = None  # noqa: SLF001
-    new_slot._next = head  # noqa: SLF001
-    if head is not None:
-        head._prev = new_slot  # noqa: SLF001
-    else:
-        doc._tail = new_slot  # noqa: SLF001
-    doc._head = new_slot  # noqa: SLF001
-    _record_new_slot(doc, new_slot)
+    _insert_between(None, new_slot, doc._head, doc)  # noqa: SLF001
 
 
 def _promote_trailing_to_preamble(doc: Document) -> None:
@@ -844,6 +837,22 @@ def _replace_primary_in_place(
         insert_after(primary._prev, new_slot, doc)  # noqa: SLF001
 
 
+def _new_owned_section_header(
+    c: Container, *, leading: Trivia, doc: Document
+) -> StructuralHeaderSlot:
+    return _new_section_header(
+        c._path,  # noqa: SLF001
+        leading=leading,
+        doc=doc,
+        owner_aot_entry=c._owner_aot_entry,  # noqa: SLF001
+    )
+
+
+def _extend_entry_slots(owner: AoTEntry | None, *slots: Slot) -> None:
+    if owner is not None:
+        owner.entry_slots.extend(slots)
+
+
 def _materialise_empty_section_header(
     c: Container,
     primary: StructuralHeaderSlot,
@@ -862,18 +871,12 @@ def _materialise_empty_section_header(
     parent = c._parent  # noqa: SLF001
     assert parent is not None
     owner = c._owner_aot_entry  # noqa: SLF001
-    header = _new_section_header(
-        c._path,  # noqa: SLF001
-        leading=_build_section_leading(doc),
-        doc=doc,
-        owner_aot_entry=owner,
-    )
+    header = _new_owned_section_header(c, leading=_build_section_leading(doc), doc=doc)
     own_ref = SlotRef(slot=header, container=c)
     c._refs.append(own_ref)  # noqa: SLF001
     c._header_ref = own_ref  # noqa: SLF001
     _replace_primary_in_place(header, primary, doc)
-    if owner is not None:
-        owner.entry_slots.append(header)
+    _extend_entry_slots(owner, header)
     _file_header_binding_chain(parent, header)
     c._body_tail = header  # noqa: SLF001
 
@@ -936,8 +939,7 @@ def _materialise_empty_inline_table(
     c._value = val  # noqa: SLF001
     c._body_tail = None  # noqa: SLF001
 
-    if owner is not None:
-        owner.entry_slots.append(kv)
+    _extend_entry_slots(owner, kv)
 
 
 def delete_key(c: Container, key: str, *, materialise_empty: bool = False) -> None:
@@ -1560,10 +1562,9 @@ def install_dotted_kv_slot(
             # ``_body_tail`` is still empty).
             anc._body_tail = new_slot  # noqa: SLF001
 
-    if owner is not None:
-        # ``entry_slots`` is membership + header-first order only (doc
-        # order is derived on demand), so a plain append is enough.
-        owner.entry_slots.append(new_slot)
+    # ``entry_slots`` is membership + header-first order only (doc
+    # order is derived on demand), so a plain append is enough.
+    _extend_entry_slots(owner, new_slot)
 
 
 def _synthesise_header_then_insert_kv(c: Container, key: str, value: Value) -> None:
@@ -1600,12 +1601,7 @@ def _synthesise_header_then_insert_kv(c: Container, key: str, value: Value) -> N
     adopted_leading = anchor_slot.leading
     original_pred = anchor_slot._prev  # noqa: SLF001
     new_descendant_leading = _build_section_leading(doc)
-    header_slot = _new_section_header(
-        c._path,  # noqa: SLF001
-        leading=adopted_leading,
-        doc=doc,
-        owner_aot_entry=owner,
-    )
+    header_slot = _new_owned_section_header(c, leading=adopted_leading, doc=doc)
     insert_before(anchor_slot, header_slot, doc)
     recorder = doc._displaced_recorder  # noqa: SLF001
     if recorder is not None:
@@ -1637,9 +1633,7 @@ def _synthesise_header_then_insert_kv(c: Container, key: str, value: Value) -> N
     # Add the synthesised header + KV to the entry's membership list
     # (order within ``entry_slots`` is not doc-significant; the entry's
     # own ``[[a]]`` header stays first because it was appended first).
-    if owner is not None:
-        owner.entry_slots.append(header_slot)
-        owner.entry_slots.append(new_kv)
+    _extend_entry_slots(owner, header_slot, new_kv)
 
 
 def _synthesise_header_then_insert_kv_at_doc_tail(
@@ -1654,11 +1648,8 @@ def _synthesise_header_then_insert_kv_at_doc_tail(
     doc = c._attached_doc  # noqa: SLF001
     owner = c._owner_aot_entry  # noqa: SLF001
 
-    header_slot = _new_section_header(
-        c._path,  # noqa: SLF001
-        leading=_build_section_leading(doc),
-        doc=doc,
-        owner_aot_entry=owner,
+    header_slot = _new_owned_section_header(
+        c, leading=_build_section_leading(doc), doc=doc
     )
     # When ``c`` lives inside an AoT entry, the synthesised header
     # MUST sit physically inside that entry's slot region (before the
@@ -1683,12 +1674,12 @@ def _synthesise_header_then_insert_kv_at_doc_tail(
     if isinstance(header_slot._prev, StructuralHeaderSlot):  # noqa: SLF001
         header_slot.leading = Trivia()
 
-    ancestors = _ancestor_chain(c)
     # When ``c`` lives inside an AoT entry, the synthesised header sits
     # mid-doc-stream (between this entry's last slot and the next
     # sibling ``[[arr]]`` entry). Each ancestor's ``_refs`` is
     # doc-stream-ordered, so insert the binding ref after the entry's
     # last owned ref rather than appending.
+    ancestors = _ancestor_chain(c)
     entry_slot_set: set[Slot] | None = None
     if owner is not None and owner.entry_slots:
         entry_slot_set = set(owner.entry_slots)
@@ -1716,9 +1707,7 @@ def _synthesise_header_then_insert_kv_at_doc_tail(
         header_ref_index=len(c._refs),  # noqa: SLF001
     )
 
-    if owner is not None:
-        owner.entry_slots.append(header_slot)
-        owner.entry_slots.append(new_kv)
+    _extend_entry_slots(owner, header_slot, new_kv)
 
 
 def _append_kv_in_aot_entry(c: Container, key: str, value: Value) -> None:
@@ -2534,6 +2523,17 @@ def _gather_subtree_slots(src_table: Container) -> list[Slot]:
     return _owned_slots_from(src_table, src_table._header_ref.slot)  # noqa: SLF001
 
 
+def _gather_headered_subtree_slots(
+    src_table: Container,
+) -> tuple[StructuralHeaderSlot, list[Slot]]:
+    src_slots = _gather_subtree_slots(src_table)
+    head = src_slots[0]
+    if not isinstance(head, StructuralHeaderSlot):  # pragma: no cover
+        msg = "source section's first owned slot is not a header"
+        raise AssertionError(msg)  # noqa: TRY004
+    return head, src_slots
+
+
 def clone_table_as_aot_entry(
     aot: AoT,
     src_table: Container,
@@ -2544,11 +2544,8 @@ def clone_table_as_aot_entry(
     ``[k]`` to ``[[aot._path]]`` and rebasing paths to ``aot._path``.
     Preserves per-slot leading / EOL / lexeme bytes.
     """
-    src_slots = _gather_subtree_slots(src_table)
-    if not isinstance(src_slots[0], StructuralHeaderSlot):  # pragma: no cover
-        msg = "source section's first owned slot is not a header"
-        raise AssertionError(msg)  # noqa: TRY004
-    if src_slots[0].kind != "table":  # pragma: no cover
+    head, src_slots = _gather_headered_subtree_slots(src_table)
+    if head.kind != "table":  # pragma: no cover
         msg = "clone_table_as_aot_entry: source must be a standard section"
         raise RuntimeError(msg)
     return _install_cloned_aot_entry(
@@ -2571,10 +2568,7 @@ def clone_section_as_section(
     ``[k]`` section. Preserves per-slot trivia and nested sub-sections
     while rebasing paths under ``parent._path + (key,)``.
     """
-    src_slots = _gather_subtree_slots(src_table)
-    if not isinstance(src_slots[0], StructuralHeaderSlot):  # pragma: no cover
-        msg = "source section's first owned slot is not a header"
-        raise AssertionError(msg)  # noqa: TRY004
+    _, src_slots = _gather_headered_subtree_slots(src_table)
     return _install_cloned_section(parent, key, src_slots, src_table._path)  # noqa: SLF001
 
 
@@ -2654,7 +2648,7 @@ def adopt_private_section(
     norm_entry = value._owner_aot_entry  # noqa: SLF001
 
     assert value._header_ref is not None  # noqa: SLF001
-    slots = _gather_subtree_slots(value)
+    _, slots = _gather_headered_subtree_slots(value)
     for s in slots:
         _retarget_slot_paths(s, old_prefix, new_prefix, doc._newline)  # noqa: SLF001
         if norm_entry is not None and s.owner_aot_entry is norm_entry:
@@ -3129,7 +3123,7 @@ def attach_section_at(
         doc=doc,
         path=full_path,
         parent=deepest_parent,
-        owner=None,
+        owner=owner,
         header=header,
     )
 
@@ -3139,11 +3133,9 @@ def attach_section_at(
     # sibling of an implicit ``parent``) under the new header on re-parse.
     anchor = _parent_subtree_tail(_nearest_header_host(parent))
     _splice_block_after([header], anchor, doc)
-    if owner is not None:
-        # Own the new header on the AoT entry so a later delete of the
-        # entry takes the promoted section with it.
-        owner.entry_slots.append(header)
-        section._owner_aot_entry = owner  # noqa: SLF001
+    # Own the new header on the AoT entry so a later delete of the
+    # entry takes the promoted section with it.
+    _extend_entry_slots(owner, header)
 
     # File the binding ref under the deepest implicit parent and
     # propagate ancestor-prefix bindings up to the doc root.


### PR DESCRIPTION
Unify near-duplicate logic across four files, reviewed and verified behavior-preserving (full pytest incl. slow/fuzz suite, mypy --strict, ty check, ruff all clean):

- _layout_ops.py: collapse insert_after/insert_before/insert_before_head into a shared _insert_between primitive; factor out _new_owned_section_header, _extend_entry_slots, and _gather_headered_subtree_slots for repeated section-header construction, AoT-entry slot filing, and headered-subtree gathering.
- _comments.py: unify repeated slot-lookup/error handling behind _require_slot / _require_header_slot, comment/block validation behind _validate_comment_entries, and preamble/epilogue rendering behind _render_doc_comment_lines.
- _container.py: factor out Container._synth_local_value, _require_promotable_entry, _direct_kv_trivia, and _walk_existing_sections (shared by install/ensure_table, whose loops shared the same invariants and error text).
- _array.py: delay CST synthesis in insert() until the non-append case, avoiding a redundant _synth_cst call on the append fast-path.